### PR TITLE
Remove arrows from select element in IE

### DIFF
--- a/bulma/elements/controls.sass
+++ b/bulma/elements/controls.sass
@@ -160,6 +160,8 @@
     padding-right: 36px
     &:hover
       border-color: $control-hover-border
+  &::ms-expand
+    display: none
   &:after
     +arrow($link)
     margin-top: -6px


### PR DESCRIPTION
IE handles the arrows in select elements with a pseudoclass.

More info here:

http://stackoverflow.com/questions/20163079/remove-select-arrow-on-ie