### PR TITLE
Bug select arrow ie

### DIFF
--- a/bulma/elements/controls.sass
+++ b/bulma/elements/controls.sass
@@ -160,6 +160,8 @@
     padding-right: 36px
     &:hover
       border-color: $control-hover-border
+  &::ms-expand
+    display: none
   &:after
     +arrow($link)
     margin-top: -6px

--- a/bulma/elements/controls.sass
+++ b/bulma/elements/controls.sass
@@ -160,8 +160,8 @@
     padding-right: 36px
     &:hover
       border-color: $control-hover-border
-  &::ms-expand
-    display: none
+    &::ms-expand
+      display: none
   &:after
     +arrow($link)
     margin-top: -6px


### PR DESCRIPTION
This should now have the correct indentation level to apply to `<select>` as intended, and hide the dropdown arrows in IE10+