### PR TITLE
Prevent `.buttons` being part of a user selection.

### DIFF
--- a/bulma/base/helpers.sass
+++ b/bulma/base/helpers.sass
@@ -20,8 +20,4 @@
   margin: 0 !important
 
 .is-unselectable
-  -webkit-touch-callout: none
-  -webkit-user-select: none
-  -moz-user-select: none
-  -ms-user-select: none
-  user-select: none
+  +unselectable

--- a/bulma/elements/buttons.sass
+++ b/bulma/elements/buttons.sass
@@ -15,6 +15,7 @@
 
 .button
   +control
+  +unselectable
   padding: 3px 10px
   text-align: center
   white-space: nowrap

--- a/bulma/utilities/mixins.sass
+++ b/bulma/utilities/mixins.sass
@@ -55,6 +55,13 @@
   text-indent: -290486px
   width: $width
 
+=unselectable
+  -webkit-touch-callout: none
+  -webkit-user-select: none
+  -moz-user-select: none
+  -ms-user-select: none
+  user-select: none
+
 $tablet: 769px
 $desktop: 980px
 


### PR DESCRIPTION
It is possible to select the text of a button, especially with a double click, this is ugly IMO.
![eww](https://cloud.githubusercontent.com/assets/1196098/12704975/caa76948-c85e-11e5-9de1-b021fc8590d3.gif)
