### PR TITLE
Improve customizability of variables when importing bulma

### DIFF
--- a/bulma/config/variables.sass
+++ b/bulma/config/variables.sass
@@ -1,43 +1,43 @@
 // Colors
 
-$grey-darker: #222324
-$grey-dark: #69707a
-$grey: #aeb1b5
-$grey-light: #d3d6db
-$grey-lighter: #f5f7fa
+$grey-darker: #222324 !default
+$grey-dark: #69707a !default
+$grey: #aeb1b5 !default
+$grey-light: #d3d6db !default
+$grey-lighter: #f5f7fa !default
 
-$blue: #42afe3
-$green: #97cd76
-$orange: #f68b39
-$purple: #847bb9
-$red: #ed6c63
-$turquoise: #1fc8db
-$yellow: #fce473
+$blue: #42afe3 !default
+$green: #97cd76 !default
+$orange: #f68b39 !default
+$purple: #847bb9 !default
+$red: #ed6c63 !default
+$turquoise: #1fc8db !default
+$yellow: #fce473 !default
 
-$primary: $turquoise
+$primary: $turquoise !default
 
 // Typography
 
-$family-sans-serif: "Helvetica Neue", "Helvetica", "Arial", sans-serif
-$family-monospace: "Source Code Pro", "Monaco", "Inconsolata", monospace
+$family-sans-serif: "Helvetica Neue", "Helvetica", "Arial", sans-serif !default
+$family-monospace: "Source Code Pro", "Monaco", "Inconsolata", monospace !default
 
-$size-1: 48px
-$size-2: 40px
-$size-3: 28px
-$size-4: 24px
-$size-5: 18px
-$size-6: 14px
+$size-1: 48px !default
+$size-2: 40px !default
+$size-3: 28px !default
+$size-4: 24px !default
+$size-5: 18px !default
+$size-6: 14px !default
 
-$size-7: 11px
+$size-7: 11px !default
 
 // Dimensions
 
-$column-gap: 20px
+$column-gap: 20px !default
 
-$header-height: 50px
+$header-height: 50px !default
 
 // Miscellaneous
 
-$easing: ease-out
-$radius: 3px
-$speed: 86ms
+$easing: ease-out !default
+$radius: 3px !default
+$speed: 86ms !default


### PR DESCRIPTION
When importing bulma, it's not possible to set variables (located in `bulma/config/variables.sass`) without modifying bulma's original source code.

This branch allows to set any variables from `bulma/config/variables.sass` before importing `bulma.sass` by using the `!default` flag for those variables in question.