### PR TITLE
Converted left, right to start, end

### DIFF
--- a/css/bulma.css
+++ b/css/bulma.css
@@ -280,7 +280,7 @@ table {
 
 table th,
 table td {
-  text-align: left;
+  text-align: start;
   vertical-align: top;
 }
 
@@ -613,11 +613,11 @@ table th {
 }
 
 .is-left {
-  text-align: left;
+  text-align: start;
 }
 
 .is-right {
-  text-align: right;
+  text-align: end;
 }
 
 .is-block {
@@ -762,7 +762,8 @@ table th {
   cursor: pointer;
   display: inline-block;
   line-height: 16px;
-  padding-left: 18px;
+  -webkit-padding-start: 18px;
+  padding-start: 18px;
   position: relative;
   vertical-align: top;
 }
@@ -870,7 +871,8 @@ table th {
 }
 
 .radio + .radio {
-  margin-left: 10px;
+  -webkit-margin-start: 10px;
+  margin-start: 10px;
 }
 
 .radio input {
@@ -974,7 +976,7 @@ table th {
 
 .control {
   position: relative;
-  text-align: left;
+  text-align: start;
 }
 
 .control.is-loading:after {
@@ -1004,7 +1006,8 @@ table th {
 }
 
 .control.is-withicon .input, .control.is-withicon .textarea {
-  padding-left: 32px;
+  -webkit-padding-start: 32px;
+  padding-start: 32px;
 }
 
 .control.is-withicon .input:focus + .fa, .control.is-withicon .textarea:focus + .fa {
@@ -1019,7 +1022,8 @@ table th {
 .control.is-horizontal > .input:not(:last-child),
 .control.is-horizontal > .textarea:not(:last-child),
 .control.is-horizontal > .select:not(:last-child) {
-  margin-right: 10px;
+  -webkit-margin-end: 10px;
+  margin-end: 10px;
 }
 
 .control.is-horizontal > .input, .control.is-horizontal > .textarea {
@@ -1034,7 +1038,8 @@ table th {
 .control.is-grouped .button,
 .control.is-grouped .select {
   border-radius: 0;
-  margin-right: -1px;
+  -webkit-margin-end: -1px;
+  margin-end: -1px;
 }
 
 .control.is-grouped .input:hover, .control.is-grouped .textarea:hover,
@@ -1488,7 +1493,8 @@ table th {
 
 .button.is-loading:after {
   left: 50%;
-  margin-left: -8px;
+  -webkit-margin-start: -8px;
+  margin-start: -8px;
   margin-top: -8px;
   position: absolute;
   top: 50%;
@@ -1971,7 +1977,8 @@ table th {
   display: block;
   height: 1px;
   left: 50%;
-  margin-left: -7px;
+  -webkit-margin-start: -7px;
+  margin-start: -7px;
   position: absolute;
   top: 50%;
   transition: none 86ms ease-out;
@@ -2000,7 +2007,8 @@ table th {
 }
 
 .hamburger.is-active span:nth-child(1), .is-active.header-toggle span:nth-child(1) {
-  margin-left: -5px;
+  -webkit-margin-start: -5px;
+  margin-start: -5px;
   transform: rotate(45deg);
   transform-origin: left top;
 }
@@ -2010,7 +2018,8 @@ table th {
 }
 
 .hamburger.is-active span:nth-child(3), .is-active.header-toggle span:nth-child(3) {
-  margin-left: -5px;
+  -webkit-margin-start: -5px;
+  margin-start: -5px;
   transform: rotate(-45deg);
   transform-origin: left bottom;
 }
@@ -2119,8 +2128,10 @@ table th {
 }
 
 .tag:not(.is-large) .delete {
-  margin-left: 4px;
-  margin-right: -6px;
+  -webkit-margin-start: 4px;
+  margin-start: 4px;
+  -webkit-margin-end: -6px;
+  margin-end: -6px;
 }
 
 .tag.is-large {
@@ -2132,8 +2143,10 @@ table th {
 }
 
 .tag.is-large .delete {
-  margin-left: 4px;
-  margin-right: -8px;
+  -webkit-margin-start: 4px;
+  margin-start: 4px;
+  -webkit-margin-end: -8px;
+  margin-end: -8px;
 }
 
 .tag.is-dark {
@@ -2177,7 +2190,8 @@ table th {
     flex: 1;
   }
   .column + .column {
-    margin-left: 20px;
+    -webkit-margin-start: 20px;
+    margin-start: 20px;
   }
   .column.is-double {
     flex: 2;
@@ -2275,7 +2289,8 @@ table th {
     width: 33.3333%;
   }
   .columns.is-grid > .column + .column {
-    margin-left: 0;
+    -webkit-margin-start: 0;
+    margin-start: 0;
   }
 }
 
@@ -2321,7 +2336,8 @@ table th {
 
 .navbar-left .navbar-item:not(:last-child),
 .navbar-right .navbar-item:not(:last-child) {
-  margin-right: 10px;
+  -webkit-margin-end: 10px;
+  margin-end: 10px;
 }
 
 @media screen and (max-width: 768px) {
@@ -2469,7 +2485,7 @@ table th {
 
 .table th {
   color: #222324;
-  text-align: left;
+  text-align: start;
 }
 
 .table tr:hover {
@@ -2578,7 +2594,8 @@ table th {
 }
 
 .tabs li + li {
-  margin-left: 20px;
+  -webkit-margin-start: 20px;
+  margin-start: 20px;
 }
 
 .tabs li.is-active a {
@@ -2596,7 +2613,8 @@ table th {
 }
 
 .tabs.is-centered li + li {
-  margin-left: 0;
+  -webkit-margin-start: 0;
+  margin-start: 0;
 }
 
 .tabs.is-centered ul {
@@ -2620,7 +2638,8 @@ table th {
 }
 
 .tabs.is-boxed li + li {
-  margin-left: 5px;
+  -webkit-margin-start: 5px;
+  margin-start: 5px;
 }
 
 .tabs.is-boxed li.is-active a {
@@ -2648,7 +2667,8 @@ table th {
 }
 
 .tabs.is-toggle li + li {
-  margin-left: -1px;
+  -webkit-margin-start: -1px;
+  margin-start: -1px;
 }
 
 .tabs.is-toggle li:first-child a {
@@ -2675,7 +2695,8 @@ table th {
     flex: 1;
   }
   .tabs.is-fullwidth li + li {
-    margin-left: 0;
+    -webkit-margin-start: 0;
+    margin-start: 0;
   }
   .tabs.is-fullwidth ul {
     justify-content: center;
@@ -2699,7 +2720,8 @@ table th {
 
 @media screen and (min-width: 769px) {
   .media-image {
-    margin-right: 10px;
+    -webkit-margin-end: 10px;
+    margin-end: 10px;
     width: 60px;
   }
 }
@@ -2725,7 +2747,8 @@ table th {
 
 @media screen and (min-width: 769px) {
   .media-number {
-    margin-right: 10px;
+    -webkit-margin-end: 10px;
+    margin-end: 10px;
   }
 }
 
@@ -2737,7 +2760,8 @@ table th {
 
 @media screen and (min-width: 769px) {
   .media-left {
-    margin-right: 20px;
+    -webkit-margin-end: 20px;
+    margin-end: 20px;
   }
 }
 
@@ -2749,13 +2773,14 @@ table th {
 
 @media screen and (min-width: 769px) {
   .media-right {
-    margin-left: 20px;
+    -webkit-margin-start: 20px;
+    margin-start: 20px;
   }
 }
 
 .media-content {
   flex: 1;
-  text-align: left;
+  text-align: start;
 }
 
 .media-content .textarea {
@@ -2764,7 +2789,7 @@ table th {
 
 .media {
   align-items: flex-start;
-  text-align: left;
+  text-align: start;
 }
 
 .media .content:not(:last-child) {
@@ -2779,7 +2804,8 @@ table th {
 
 .media .media .media-image {
   margin-bottom: 0;
-  margin-right: 10px;
+  -webkit-margin-end: 10px;
+  margin-end: 10px;
   width: 40px;
 }
 
@@ -2829,7 +2855,8 @@ table th {
     display: flex;
   }
   .media.is-large .media-number {
-    margin-right: 20px;
+    -webkit-margin-end: 20px;
+    margin-end: 20px;
   }
 }
 
@@ -2907,7 +2934,8 @@ table th {
   border-radius: 3px;
   display: block;
   padding: 8px;
-  padding-left: 32px;
+  -webkit-padding-start: 32px;
+  padding-start: 32px;
 }
 
 .menu-block .checkbox input, .menu-block .menu-checkbox input {
@@ -3059,7 +3087,8 @@ a.menu-block:hover {
 
 @media screen and (min-width: 980px) {
   .header-left .header-item:first-child {
-    padding-left: 0;
+    -webkit-padding-start: 0;
+    padding-start: 0;
   }
 }
 
@@ -3083,7 +3112,7 @@ a.menu-block:hover {
 
 @media screen and (min-width: 980px) {
   .header-right .header-item:last-child {
-    padding-right: 0;
+    padding-end: 0;
   }
 }
 
@@ -3218,7 +3247,8 @@ a.menu-block:hover {
     justify-content: center;
   }
   .hero-buttons .button:not(:last-child) {
-    margin-right: 20px;
+    -webkit-margin-end: 20px;
+    margin-end: 20px;
   }
 }
 
@@ -3815,11 +3845,11 @@ a.menu-block:hover {
 }
 
 .hero.is-left {
-  text-align: left;
+  text-align: start;
 }
 
 .hero.is-right {
-  text-align: right;
+  text-align: end;
 }
 
 .section {


### PR DESCRIPTION
Converted left, right in padding, margin and text-align to start and end respectively.
This adds support for direction independent layout i.e. support for right-to-left languages.

Just add `direction: rtl;` to the `body`.