### PR TITLE
Add .editorconfig to maintain code style consistency

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = crlf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .DS_Store
 node_modules
 npm-debug.log
+.idea/


### PR DESCRIPTION
Added an [.editorconfig](http://editorconfig.org/) file to the project root, to help contributors maintain code style consistency between different editors and IDEs.

Also added the `.idea/` to `.gitignore`. This is a folder that many JetBrains IDEs (WebStorm, PhpStorm, etc.) create to store various config files. I think these are fairly common IDEs nowadays, it might be useful for those who use them.