### PR TITLE
Fixed link to documentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Bulma is in early but active development! Try it out now:
 npm install bulma
 ```
 
-Feel free to raise an issue or submit a pull request. In the meantime, check the [documentation](http://bulma.io/documentation/overview/).
+Feel free to raise an issue or submit a pull request. In the meantime, check the [documentation](http://bulma.io/documentation/overview/start).
 
 ## Copyright and license
 


### PR DESCRIPTION
documentation link was pointing to http://bulma.io/documentation/overview/ which gave a 404 error instead of http://bulma.io/documentation/overview/start which I guess was changed to be the new overview page at some point.