### PR TITLE
fix modal display bug in IE11

### DIFF
--- a/sass/components/modal.sass
+++ b/sass/components/modal.sass
@@ -10,7 +10,6 @@
   width: 100%
   // Responsiveness
   +tablet
-    margin: 0 auto
     max-height: calc(100vh - 40px)
     width: 640px
 


### PR DESCRIPTION
Fixes #252 

`margin: 0 auto` in a flex item causes display bug in IE11
See: #252
http://codepen.io/anon/pen/AXkyQY
