### PR TITLE
Fix modal example (remove "modal-container" class)

### DIFF
--- a/docs/documentation/components/modal.html
+++ b/docs/documentation/components/modal.html
@@ -39,10 +39,8 @@ doc-subtab: modal
 {% highlight html %}
 <div class="modal">
   <div class="modal-background"></div>
-  <div class="modal-container">
-    <div class="modal-content">
-      <!-- Any other Bulma elements you want -->
-    </div>
+  <div class="modal-content">
+    <!-- Any other Bulma elements you want -->
   </div>
   <button class="modal-close"></button>
 </div>


### PR DESCRIPTION
The `modal-container` generates an error and does not exist in bulma. See https://github.com/jgthms/bulma-website/pull/38