### PR TITLE
Remove the section "Documentation website"

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,6 @@ Bulma keeps track of the upcoming fixes and features on Trello: [Bulma roadmap](
 
 It's more a tasklist than a roadmap, but it will give you an overview of where things are going!
 
-## Documentation website
-
-This repository is **only** for the Bulma source files.
-The [website](http://bulma.io) (which includes the [documentation](http://bulma.io/documentation/overview/start/)) is in another repo: [https://github.com/jgthms/bulma-website](https://github.com/jgthms/bulma-website)
-
-If you encounter a typo or a lack of documentation, submit an issue [there](https://github.com/jgthms/bulma-website/issues).
-
 ## Browser Support
 
 Bulma uses [autoprefixer](https://github.com/postcss/autoprefixer) to make (most) Flexbox features compatible with earlier browser versions. According to [Can I use](http://caniuse.com/#feat=flexbox), Bulma is compatible with:


### PR DESCRIPTION
The section "Documentation website" is obsolete. I think we can remove this part of the readme.