### PR TITLE
Include Bulma's initial variables

### DIFF
--- a/docs/documentation/overview/start.html
+++ b/docs/documentation/overview/start.html
@@ -88,6 +88,9 @@ npm install bulma
         <p class="title is-5">
           <strong>Set</strong> your variables:<br>
 {% highlight sass %}
+// Import Bulma's initial variables
+@import "bulma/sass/utilities/variables.sass"
+
 // Override initial variables here
 // You can add new ones or update existing ones:
 
@@ -112,7 +115,10 @@ $family-primary: $family-serif // Use the new serif family
         <p class="title is-5">
           <strong>Import</strong> Bulma <em>after</em> having set your variables:<br>
 {% highlight sass %}
-// Override variables here
+// Import Bulma's initial variables
+@import "bulma/sass/utilities/variables.sass"
+
+// Override initial variables here
 // You can add new ones or update existing ones:
 
 $blue: #72d0eb // Update blue


### PR DESCRIPTION
Bulma's `$orange` could not be referenced without first importing the variables.
