### PR TITLE
Remove unused class from the level documentation page

### DIFF
--- a/docs/documentation/components/level.html
+++ b/docs/documentation/components/level.html
@@ -36,7 +36,7 @@ doc-subtab: level
       <nav class="level structure-item is-structure-container" title="level">
         <div class="level-left structure-item" title="level-left">
           <div class="level-item">
-            <p class="subtitle is-5">
+            <p class="subtitle">
               <strong>123</strong> posts
             </p>
           </div>
@@ -75,7 +75,7 @@ doc-subtab: level
       <nav class="level">
         <div class="level-left">
           <div class="level-item">
-            <p class="subtitle is-5">
+            <p class="subtitle">
               <strong>123</strong> posts
             </p>
           </div>
@@ -116,7 +116,7 @@ doc-subtab: level
   <!-- Left side -->
   <div class="level-left">
     <div class="level-item">
-      <p class="subtitle is-5">
+      <p class="subtitle">
         <strong>123</strong> posts
       </p>
     </div>


### PR DESCRIPTION
Changes proposed:

* [ ] Add
* [X] Fix
* [ ] Remove
* [ ] Update

The class is-5 is normally used with the grid systems. It is useless for the level and can be
removed without changes to the elements css rules.