### PR TITLE
Documentation: fix placeholder parameters in media object example

### DIFF
--- a/docs/documentation/components/media-object.html
+++ b/docs/documentation/components/media-object.html
@@ -21,7 +21,7 @@ doc-subtab: media-object
       <article class="media">
         <figure class="media-left structure-item" title="media-left">
           <p class="image is-64x64">
-            <img src="http://placehold.it/128x128">
+            <img src="http://placehold.it/64x64">
           </p>
         </figure>
         <div class="media-content structure-item is-structure-right" title="media-content">
@@ -57,7 +57,7 @@ doc-subtab: media-object
       <article class="media">
         <figure class="media-left">
           <p class="image is-64x64">
-            <img src="http://placehold.it/128x128">
+            <img src="http://placehold.it/64x64">
           </p>
         </figure>
         <div class="media-content">
@@ -92,7 +92,7 @@ doc-subtab: media-object
 <article class="media">
   <figure class="media-left">
     <p class="image is-64x64">
-      <img src="http://placehold.it/128x128">
+      <img src="http://placehold.it/64x64">
     </p>
   </figure>
   <div class="media-content">
@@ -131,7 +131,7 @@ doc-subtab: media-object
       <article class="media">
         <figure class="media-left">
           <p class="image is-64x64">
-            <img src="http://placehold.it/128x128">
+            <img src="http://placehold.it/64x64">
           </p>
         </figure>
         <div class="media-content">
@@ -160,7 +160,7 @@ doc-subtab: media-object
 <article class="media">
   <figure class="media-left">
     <p class="image is-64x64">
-      <img src="http://placehold.it/128x128">
+      <img src="http://placehold.it/64x64">
     </p>
   </figure>
   <div class="media-content">
@@ -195,7 +195,7 @@ doc-subtab: media-object
       <article class="media">
         <figure class="media-left">
           <p class="image is-64x64">
-            <img src="http://placehold.it/128x128">
+            <img src="http://placehold.it/64x64">
           </p>
         </figure>
         <div class="media-content">
@@ -212,7 +212,7 @@ doc-subtab: media-object
           <article class="media">
             <figure class="media-left">
               <p class="image is-48x48">
-                <img src="http://placehold.it/96x96">
+                <img src="http://placehold.it/48x48">
               </p>
             </figure>
             <div class="media-content">
@@ -239,7 +239,7 @@ doc-subtab: media-object
           <article class="media">
             <figure class="media-left">
               <p class="image is-48x48">
-                <img src="http://placehold.it/96x96">
+                <img src="http://placehold.it/48x48">
               </p>
             </figure>
             <div class="media-content">
@@ -259,7 +259,7 @@ doc-subtab: media-object
       <article class="media">
         <figure class="media-left">
           <p class="image is-64x64">
-            <img src="http://placehold.it/128x128">
+            <img src="http://placehold.it/64x64">
           </p>
         </figure>
         <div class="media-content">
@@ -276,7 +276,7 @@ doc-subtab: media-object
 <article class="media">
   <figure class="media-left">
     <p class="image is-64x64">
-      <img src="http://placehold.it/128x128">
+      <img src="http://placehold.it/64x64">
     </p>
   </figure>
   <div class="media-content">
@@ -293,7 +293,7 @@ doc-subtab: media-object
     <article class="media">
       <figure class="media-left">
         <p class="image is-48x48">
-          <img src="http://placehold.it/96x96">
+          <img src="http://placehold.it/48x48">
         </p>
       </figure>
       <div class="media-content">
@@ -320,7 +320,7 @@ doc-subtab: media-object
     <article class="media">
       <figure class="media-left">
         <p class="image is-48x48">
-          <img src="http://placehold.it/96x96">
+          <img src="http://placehold.it/48x48">
         </p>
       </figure>
       <div class="media-content">
@@ -340,7 +340,7 @@ doc-subtab: media-object
 <article class="media">
   <figure class="media-left">
     <p class="image is-64x64">
-      <img src="http://placehold.it/128x128">
+      <img src="http://placehold.it/64x64">
     </p>
   </figure>
   <div class="media-content">


### PR DESCRIPTION
### Pull Request

Changes proposed:

* [x] Fix: In the media object example of the documentation, the size of the placeholder didn't match the wrapper size.
