### PR TITLE
[fix] Remove explicit font-size for ".select select"

### DIFF
--- a/sass/elements/form.sass
+++ b/sass/elements/form.sass
@@ -118,7 +118,6 @@ $input-radius:              $radius !default
     +input
     cursor: pointer
     display: block
-    font-size: 1em
     outline: none
     padding-right: 2.5em
     &:hover


### PR DESCRIPTION
This was overwriting the font size inherited from =control and therefore causing inconsistencies, see screenshots.

Before:
![Before](https://i.imgur.com/BaPviwI.png)

After:
![After](https://i.imgur.com/fUmZp3w.png)

Changes proposed:

* [ ] Add
* [x] Fix
* [ ] Remove
* [ ] Update
