### PR TITLE
Add wrap option for panel block

### DIFF
--- a/sass/components/panel.sass
+++ b/sass/components/panel.sass
@@ -53,6 +53,8 @@
     flex-grow: 1
     flex-shrink: 1
     width: 100%
+  &.has-wrap
+    flex-wrap: wrap;
   &.is-active
     border-left-color: $link
     color: $link-active


### PR DESCRIPTION
### Pull Request

Fixes #

Changes proposed: Add wrap option for panel.block style

* [x] Add
* [ ] Fix
* [ ] Remove
* [ ] Update


I'm proposing this change to allow the panel element block to be usable without a container. 

## What is all about?
It's a simple class that allows the panel.block element to wrap its content if needed.

## Example

Simple example where the wrap is useful: Tag cloud inside a panel.block

```
<div class="panel-block has-wrap">
<span class="tag">Tag1</span>
<span class="tag">Tag2</span>
<span class="tag">Tag3</span>
....
<span class="tag">Tag 20</span>
</div>
```

With the `.has-wrap` the content will not overflow the parent block.