### PR TITLE
fix select element with is-expanded class

### DIFF
--- a/sass/elements/form.sass
+++ b/sass/elements/form.sass
@@ -200,6 +200,8 @@ $input-radius:              $radius !default
         select
           border-radius: 0 $input-radius $input-radius 0
       &.is-expanded
+        select
+          width: 100%
         flex-grow: 1
         flex-shrink: 0
     .select select


### PR DESCRIPTION
to fill the full width of its parent span

### Pull Request

Fixes #458

Changes proposed:

* [x] Fix
