### PR TITLE
Fixes #469 | fixing group buttons overlap on safari

### DIFF
--- a/css/bulma.css
+++ b/css/bulma.css
@@ -2209,6 +2209,7 @@ a.box:active {
 
 .control.is-grouped > .control {
   flex-basis: 0;
+  flex-basis: auto;
   flex-shrink: 0;
 }
 

--- a/docs/css/bulma-docs.css
+++ b/docs/css/bulma-docs.css
@@ -2273,7 +2273,9 @@ a.box:active {
 
 .control.is-grouped > .control {
   -ms-flex-preferred-size: 0;
+  -ms-flex-preferred-size: auto;
       flex-basis: 0;
+      flex-basis: auto;
   -ms-flex-negative: 0;
       flex-shrink: 0;
 }

--- a/sass/elements/form.sass
+++ b/sass/elements/form.sass
@@ -273,6 +273,7 @@ $input-radius:              $radius !default
     justify-content: flex-start
     & > .control
       flex-basis: 0
+      flex-basis: auto
       flex-shrink: 0
       &:not(:last-child)
         margin-bottom: 0


### PR DESCRIPTION
Issue: #469 

Issue on both Bulma css and docs. Issue caused on Safari, IE11, and IOS where grouped buttons will overlap each other caused by a flex-basis of 0, changed to flex-basis auto with the initial fallback for partially supported auto property. Reference: https://github.com/jgthms/bulma/issues/469

- Added in 0 fallback for partially supported “auto” property