### PR TITLE
Allow the overriding of $button-shadow-inset

### DIFF
--- a/sass/elements/button.sass
+++ b/sass/elements/button.sass
@@ -11,7 +11,7 @@ $button-focus-border: $link-focus-border !default
 $button-active: $link-active !default
 $button-active-border: $link-active-border !default
 
-$button-shadow-inset: inset 0 1px 2px rgba($black, 0.2)
+$button-shadow-inset: inset 0 1px 2px rgba($black, 0.2) !default
 
 @function buttonIconSpacing($button-font-size, $icon-width)
   // The button font-size value with no unit


### PR DESCRIPTION
### Proposed solution
Upon testing the framework, I didn't like how the inset shadow on a button looked when it is active. I noticed there was a variable that controls the shadow (`$button-shadow-inset`), but since it doesn't have `!default` at the end, there's no way to change it without customizing the framework files (apart from hacking some quick CSS). Although it isn't a big deal, adding `!default` to `$button-shadow-inset` allows the user to customize the inner shadow easily.