### PR TITLE
Fixes #466 | level-item remove justify-content center in mobile

### DIFF
--- a/sass/components/level.sass
+++ b/sass/components/level.sass
@@ -10,6 +10,7 @@
     margin-bottom: 0
   // Responsiveness
   +mobile
+    justify-content: flex-start
     &:not(:last-child)
       margin-bottom: 0.75rem
 


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->

### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
Fixes #466 

replace `justify-content: center` in view mobile for `justify-content: flex-start`