### PR TITLE
Custom table mixin

### DIFF
--- a/sass/utilities/mixins.sass
+++ b/sass/utilities/mixins.sass
@@ -163,6 +163,11 @@
     &:#{$placeholder}-placeholder
       @content
 
+=custom-table($table-size, $td-widths)
+  @for $i from 1 through $table-size
+    tr td:nth-child(#{$i})
+      width: nth($td-widths, $i)
+
 =unselectable
   -webkit-touch-callout: none
   -webkit-user-select: none


### PR DESCRIPTION
### Proposed solution

Simple mixin to set custom widths for a table cell.

Examples:

Responsive table

```
.classname
  +custom-table(4, 10% 50% 20% 20%)
```
Fixed width table

```
.classname
  +custom-table(5, 100px 80px 200px 150px 50px)
```
It's possible to have different units mixed( em, rem, px , percentage...), but not recommended obviously.

I made this because of a project that i am working , it seens rather complicated to do it over and over again without a mixin,
