### PR TITLE
Fix inconsistency in modal docs

### DIFF
--- a/docs/documentation/components/modal.html
+++ b/docs/documentation/components/modal.html
@@ -105,7 +105,7 @@ doc-subtab: modal
       <!-- Content ... -->
     </section>
     <footer class="modal-card-foot">
-      <a class="button is-primary">Save changes</a>
+      <a class="button is-success">Save changes</a>
       <a class="button">Cancel</a>
     </footer>
   </div>


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->

### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->
In modal **docs**, under `Modal card`, highlighted code shows :

```css
<figure class="highlight">
...
<a class="button is-primary">Save changes</a>
...
</figure>
```

the `is-primary` modifier class is not consistent with the actual modal example :

```css
<div id="modal-ter" class="modal">
...
<a class="button is-success">Save changes</a>
...
</div>
```
#### Result

This PR fixes the issue.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Run `npm install` to install all Bulma dependencies -->
<!-- 3. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 4. If your PR fixes an issue, reference that issue -->
<!-- 5. If your PR has lots of commits, **rebase** first -->
<!-- 6. Run `npm run deploy` before submitting your PR -->
