### PR TITLE
Fixes Issue 508 - background-color definition to match implementation

### DIFF
--- a/docs/documentation/overview/variables.html
+++ b/docs/documentation/overview/variables.html
@@ -40,7 +40,7 @@ doc-subtab: variables
         <li>
           <strong>Generated variables</strong> where variables are <strong>calculated</strong> from the values set in the previous file. For example, you can have:
           <ul>
-            <li><code>$background: $white-ter</code>: the main background color</li>
+            <li><code>$body-background: $white-ter</code>: the main background color</li>
             <li><code>$link: $primary</code>: the links use the primary color</li>
             <li><code>$family-primary: $family-sans-serif</code>: the primary font family is the sans-serif one</li>
           </ul>

--- a/docs/documentation/overview/variables.html
+++ b/docs/documentation/overview/variables.html
@@ -40,7 +40,7 @@ doc-subtab: variables
         <li>
           <strong>Generated variables</strong> where variables are <strong>calculated</strong> from the values set in the previous file. For example, you can have:
           <ul>
-            <li><code>$body-background: $white-ter</code>: the main background color</li>
+            <li><code>$body-background: $white</code>: the main background color</li>
             <li><code>$link: $primary</code>: the links use the primary color</li>
             <li><code>$family-primary: $family-sans-serif</code>: the primary font family is the sans-serif one</li>
           </ul>


### PR DESCRIPTION
This short fix updated the documentation to match the implementation of `$body-background` to set the `<html>` `background-color` property.

https://github.com/jgthms/bulma/blob/master/sass/base/generic.sass#L5

References [Issue 508](https://github.com/jgthms/bulma/issues/508)

