### PR TITLE
Fix example wrapper in components section

### DIFF
--- a/docs/documentation/components/tabs.html
+++ b/docs/documentation/components/tabs.html
@@ -338,7 +338,7 @@ doc-subtab: tabs
 {{tabs_centered_boxed_example}}
 {% endhighlight %}
 
-{% capture toggle_fullwidth_example %}
+{% capture tabs_toggle_fullwidth_example %}
 <div class="tabs is-toggle is-fullwidth">
   <ul>
     <li class="is-active">


### PR DESCRIPTION
Fix the name of the example section.

BTW, `npm run deploy` changes the CSS file, but I didn't do any changes to styles, so I did not commit them.