### PR TITLE
Prevent Chrome to suggest translation from Latin

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="{% if page.route %}route-{{page.route}}{% elsif page.layout %}route-{{page.layout}}{% endif %}">
+<html lang="en" class="{% if page.route %}route-{{page.route}}{% elsif page.layout %}route-{{page.layout}}{% endif %}">
   {% include head.html %}
   <body class="layout-{{ page.layout }}{% if page.doc-tab %} page-{{ page.doc-tab}}{% endif %}">
     {{ content }}


### PR DESCRIPTION
Add `lang` attribute to `html` tag