### PR TITLE
Fixes 524: Error in documentation for Content

### DIFF
--- a/docs/documentation/elements/content.html
+++ b/docs/documentation/elements/content.html
@@ -21,7 +21,7 @@ doc-subtab: content
         <li><code>&lt;p&gt;</code> paragraphs</li>
         <li><code>&lt;ul&gt;</code> <code>&lt;ol&gt;</code> <code>&lt;dl&gt;</code> lists</li>
         <li><code>&lt;h1&gt;</code> to <code>&lt;h6&gt;</code> headings</li>
-        <li><code>&lt;blockquotes&gt;</code> quotes</li>
+        <li><code>&lt;blockquote&gt;</code> quotes</li>
         <li><code>&lt;em&gt;</code> and <code>&lt;strong&gt;</code></li>
         <li><code>&lt;table&gt;</code> <code>&lt;tr&gt;</code> <code>&lt;th&gt;</code> <code>&lt;td&gt;</code> tables</li>
       </ul>


### PR DESCRIPTION
Fixes issue in Bulma  [0.3.11] docs.
On page  : http://bulma.io/documentation/elements/content/

There is a typo on the blockquote tag. It's written `blockquotes`. It should be `blockquote`.
