### PR TITLE
fixed typo (expect => except) in mixins.html

### DIFF
--- a/docs/documentation/overview/mixins.html
+++ b/docs/documentation/overview/mixins.html
@@ -20,7 +20,7 @@ doc-subtab: mixins
 </tr>
 <tr>
   <td><code>=block</code></td>
-  <td>Defines a margin-bottom of 1.5rem, expect when the element is the last child. Used for almost all block elements.</td>
+  <td>Defines a margin-bottom of 1.5rem, except when the element is the last child. Used for almost all block elements.</td>
 </tr>
 <tr>
   <td><code>=clearfix</code></td>


### PR DESCRIPTION
Fixed a typo in the mixins documentation.