### PR TITLE
New Features:  Switch for Checkbox & Timeline

### DIFF
--- a/sass/components/_all.sass
+++ b/sass/components/_all.sass
@@ -10,3 +10,4 @@
 @import "pagination.sass"
 @import "panel.sass"
 @import "tabs.sass"
+@import "timeline.sass"

--- a/sass/components/timeline.sass
+++ b/sass/components/timeline.sass
@@ -1,0 +1,65 @@
+.timeline
+  border-left: 2px solid $grey
+  position: relative
+
+  .time-item
+    padding-bottom: 1px
+    position: relative
+    flex-grow: 0
+    flex-shrink: 0
+    &:after
+      background-color: #ffffff
+      border-color: $grey
+      border-radius: 20px
+      border-style: solid
+      border-width: 2px
+      bottom: 0
+      content: ''
+      height: 30px
+      left: 0
+      margin-left: -16px
+      position: absolute
+      top: 0px
+      width: 30px
+    &:before
+      content: " "
+      position: absolute
+      background: rgb(228, 228, 228)
+      top: 10px
+      width: 10px
+      height: 10px
+      z-index: 2
+      left: -6px
+      border-radius: 100%
+    &.is-danger
+      &:after
+        border-color: $danger
+        background-color: $danger
+      &:before
+        background-color: $danger
+    &.is-success
+      &:after
+        border-color: $success
+        background-color: $success
+      &:before
+        background-color: $success
+    &.is-info
+      &:after
+        border-color: $info
+        background-color: $info
+      &:before
+        background-color: $info
+
+
+    .item-content
+      margin-bottom: 15px
+      margin-left: 30px
+      .title
+        font-size: $size-6
+        font-weight: $weight-semibold
+        margin-bottom: 3px
+        color: $grey-light
+      .details
+        font-size: $size-6
+        font-weight: $weight-normal
+        color: $grey

--- a/sass/elements/form.sass
+++ b/sass/elements/form.sass
@@ -298,3 +298,53 @@ $input-radius:              $radius !default
       position: absolute !important
       right: 0.75em
       top: 0.75em
+
+
+input[type="checkbox"]
+  &.switch
+    display: none
+    + label
+      position: relative
+      display: inline-block
+      cursor: pointer
+      font-weight: 500
+      text-align: left
+      margin: 0px
+      padding: 0px 44px
+      &:before, &:after
+        content: ""
+        position: absolute
+        margin: 0
+        outline: 0
+        top: 50%
+        transform: translate( 0, -50% )
+        transition: all .3s ease
+      &:before
+        left: 1px
+        width: 34px
+        height: 14px
+        background-color: rgba( $grey, 0.5 )
+        border-radius: 8px
+      &:after
+        left: 0
+        width: 20px
+        height: 20px
+        background-color: $grey
+        border-radius: 50%
+        box-shadow: 0 3px 1px -2px rgba(0,0,0,.14), 0 2px 2px 0 rgba(0,0,0,.098), 0 1px 5px 0 rgba(0,0,0,.084)
+  &:checked
+    + label
+      &:after
+        transform: translate( 80%, -50% )
+  @each $name, $pair in $colors
+    $color: nth($pair, 1)
+    $color-invert: nth($pair, 2)
+    &.is-#{$name}
+      display: none
+      &:checked
+        + label
+          &:before
+            background-color: rgba( $color, 0.5 )
+          &:after
+            background-color: $color
+            transform: translate( 80%, -50% )

--- a/sass/elements/form.sass
+++ b/sass/elements/form.sass
@@ -300,10 +300,10 @@ $input-radius:              $radius !default
       top: 0.75em
 
 
-input[type="checkbox"]
-  &.switch
+.switch
+  input[type="checkbox"]
     display: none
-    + label
+    + span
       position: relative
       display: inline-block
       cursor: pointer
@@ -332,19 +332,19 @@ input[type="checkbox"]
         background-color: $grey
         border-radius: 50%
         box-shadow: 0 3px 1px -2px rgba(0,0,0,.14), 0 2px 2px 0 rgba(0,0,0,.098), 0 1px 5px 0 rgba(0,0,0,.084)
-  &:checked
-    + label
-      &:after
-        transform: translate( 80%, -50% )
-  @each $name, $pair in $colors
-    $color: nth($pair, 1)
-    $color-invert: nth($pair, 2)
-    &.is-#{$name}
-      display: none
-      &:checked
-        + label
-          &:before
-            background-color: rgba( $color, 0.5 )
-          &:after
-            background-color: $color
-            transform: translate( 80%, -50% )
+    &:checked
+      + span
+        &:after
+          transform: translate( 80%, -50% )
+    @each $name, $pair in $colors
+      $color: nth($pair, 1)
+      $color-invert: nth($pair, 2)
+      &.is-#{$name}
+        display: none
+        &:checked
+          + label
+            &:before
+              background-color: rgba( $color, 0.5 )
+            &:after
+              background-color: $color
+              transform: translate( 80%, -50% )

--- a/sass/elements/form.sass
+++ b/sass/elements/form.sass
@@ -342,7 +342,7 @@ $input-radius:              $radius !default
       &.is-#{$name}
         display: none
         &:checked
-          + label
+          + span
             &:before
               background-color: rgba( $color, 0.5 )
             &:after

--- a/sass/elements/form.sass
+++ b/sass/elements/form.sass
@@ -318,7 +318,7 @@ input[type="checkbox"]
         outline: 0
         top: 50%
         transform: translate( 0, -50% )
-        transition: all .3s ease
+        transition: all $speed $easing
       &:before
         left: 1px
         width: 34px


### PR DESCRIPTION
Add sass rules to display checkboxes as switches just by adding “switch” class. [issue #538 ](https://github.com/jgthms/bulma/issues/538)
<img width="800" alt="screen shot 2017-03-03 at 10 37 57" src="https://cloud.githubusercontent.com/assets/24766179/23545939/bfddaa0e-fffd-11e6-8e7e-35723c7737ad.png">

HTML code:
```
<label class="switch">
    <input type="checkbox">
    <span>Label</span>
</label>
```


Add Timeline component : [issue #422](https://github.com/jgthms/bulma/issues/422)
![Image of Timeline](http://oi66.tinypic.com/x1ni92.jpg)