### PR TITLE
Fixes #560: Adds how-to README for docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .ruby-version
 test.sass
 npm-debug.log
+/docs/_config.local.yml
 
 # Folders
 .idea/

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 .ruby-version
 test.sass
 npm-debug.log
-/docs/_config.local.yml
 
 # Folders
 .idea/

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ Bulma uses [autoprefixer](https://github.com/postcss/autoprefixer) to make (most
 * Opera
 * Safari
 
+## Documentation
+
+The documentation resides in the [docs](docs) directory, and is built with the Ruby-based [Jekyll](https://jekyllrb.com/) tool.
+
+Browse the [online documentation here.](http://bulma.io/documentation/overview/start/)
+
 ## Related projects
 
 * Bulma with Attribute Modules: https://github.com/j5bot/bulma-attribute-selectors

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,9 +11,9 @@ Then to view the documentation in your local checkout:
 
 1. Before you begin, cd into `docs/` directory, and `cp _config.yml _config.local.yml`. Then edit `_config.local.yml` and change the `url:` value to `http://localhost:4000`. This local config file will be ignored by git. 
 1. In a separate shell session, `cd` to the `docs/` directory, and do:
-
-```jekyll serve --incremental --config _config.local.yml```
-
+```
+jekyll serve --incremental --config _config.local.yml
+```
 This will start an HTTP server at `http://localhost:4000/` that serves the docs built in the `_site` directory; and anytime the docs are rebuilt by you, it will serve the docs site on the fly.
 2. In your main shell session where you develop, if you change anything in `docs/` the jekyll server will rebuild those on the fly. But if you change anything about the Bulma SASS or CSS, you need to do `npm run start-docs` to build the docs' CSS before you will see it in the browser. The process running `jekyll serve` will pick up the new CSS automatically.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,14 @@
+## Building the documentation
+
+The documentation HTML is produced with the Ruby-based `jekyll` tool.
+
+1. Make sure Ruby 2.x is installed.
+2. `gem install jekyll`
+
+## Viewing the documentation locally
+
+Then to view the documentation in your local checkout:
+
+1. In a separate shell session, `cd` to the `docs/` directory, and do `jekyll serve _site`. This will start an HTTP server at http://localhost:4000/ that serves the docs built in the `_site` directory; and anytime the docs are rebuilt by you, it will serve the docs site on the fly.
+2. In your main shell session where you develop, if you change anything in `docs/` the jekyll server will rebuild those on the fly. But if you change anything about the Bulma SASS or CSS, you need to do `npm run deploy` to build Bulma and the docs' CSS before you will see it in the browser.
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,11 @@ The documentation HTML is produced with the Ruby-based `jekyll` tool.
 
 Then to view the documentation in your local checkout:
 
-1. In a separate shell session, `cd` to the `docs/` directory, and do `jekyll serve _site`. This will start an HTTP server at http://localhost:4000/ that serves the docs built in the `_site` directory; and anytime the docs are rebuilt by you, it will serve the docs site on the fly.
-2. In your main shell session where you develop, if you change anything in `docs/` the jekyll server will rebuild those on the fly. But if you change anything about the Bulma SASS or CSS, you need to do `npm run deploy` to build Bulma and the docs' CSS before you will see it in the browser.
+1. Before you begin, cd into `docs/` directory, and `cp _config.yml _config.local.yml`. Then edit `_config.local.yml` and change the `url:` value to `http://localhost:4000`. This local config file will be ignored by git. 
+1. In a separate shell session, `cd` to the `docs/` directory, and do:
+
+```jekyll serve --incremental --config _config.local.yml```
+
+This will start an HTTP server at `http://localhost:4000/` that serves the docs built in the `_site` directory; and anytime the docs are rebuilt by you, it will serve the docs site on the fly.
+2. In your main shell session where you develop, if you change anything in `docs/` the jekyll server will rebuild those on the fly. But if you change anything about the Bulma SASS or CSS, you need to do `npm run start-docs` to build the docs' CSS before you will see it in the browser. The process running `jekyll serve` will pick up the new CSS automatically.
 


### PR DESCRIPTION

### Proposed solution
Adds how-to README.md. to docs/ directory, and mentions/links to it on main README.md.


### Tradeoffs
None.

### Testing Done
Tested by viewing on github in my forked repo.

