### PR TITLE
Add print media type to +tablet mixin media query

### DIFF
--- a/sass/utilities/mixins.sass
+++ b/sass/utilities/mixins.sass
@@ -179,7 +179,7 @@
     @content
 
 =tablet
-  @media screen and (min-width: $tablet)
+  @media screen and (min-width: $tablet), print
     @content
 
 =tablet-only


### PR DESCRIPTION
Remake of #398, fixes #363.
>  It adds the print media type to the tablet mixin, so that horizontal layout is used for printing. (No min-width condition as it's not very useful for paper pages)