### PR TITLE
Fixes #227 - prevent $colors names from being minified

### DIFF
--- a/sass/utilities/variables.sass
+++ b/sass/utilities/variables.sass
@@ -146,6 +146,6 @@ $size-large: $size-4 !default
 ////////////////////////////////////////////////
 // 4. Lists and maps
 
-$colors: (white: ($white, $black), black: ($black, $white), light: ($light, $light-invert), dark: ($dark, $dark-invert), primary: ($primary, $primary-invert), info: ($info, $info-invert), success: ($success, $success-invert), warning: ($warning, $warning-invert), danger: ($danger, $danger-invert)) !default
+$colors: ('white': ($white, $black), 'black': ($black, $white), light: ($light, $light-invert), dark: ($dark, $dark-invert), primary: ($primary, $primary-invert), info: ($info, $info-invert), success: ($success, $success-invert), warning: ($warning, $warning-invert), danger: ($danger, $danger-invert)) !default
 
 $sizes: $size-1 $size-2 $size-3 $size-4 $size-5 $size-6 !default


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

### Proposed solution
By setting `white` and `black` as strings in the $colors map in variables.scss, external minifiers/compilers don't class them as literal colours and change them to `#fff` and `#000`.

This allows usage of, e.g. `.button.is-white` as expected, instead of the `.button.is-#fff` that is built.
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

### Tradeoffs
N/A
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->


### Testing Done
<!-- How have you confirmed this feature works? -->
#### Before:
![before-devtools](https://cloud.githubusercontent.com/assets/4254570/24426933/2d697672-1401-11e7-9079-0d63e4f98c77.png)
![before-minified](https://cloud.githubusercontent.com/assets/4254570/24427002/62a2890a-1401-11e7-8e9a-1fa4cdd3f792.png)

#### After:
![after-devtools](https://cloud.githubusercontent.com/assets/4254570/24427079/a03e74ea-1401-11e7-9a7c-18728ef8dc44.png)
![after-minified](https://cloud.githubusercontent.com/assets/4254570/24427078/a02a0104-1401-11e7-9f8c-7e3a0dc47f98.png)

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Run `npm install` to install all Bulma dependencies -->
<!-- 3. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 4. If your PR fixes an issue, reference that issue -->
<!-- 5. If your PR has lots of commits, **rebase** first -->
<!-- 6. Your PR should only affect `.sass` and documentation files -->
