### PR TITLE
Padding not right

### DIFF
--- a/sass/elements/form.sass
+++ b/sass/elements/form.sass
@@ -120,7 +120,7 @@ $input-radius:              $radius !default
     display: block
     font-size: 1em
     outline: none
-    padding-right: 2.5em
+    padding-right: 2.5em !important
     &:hover
       border-color: $input-hover-border
     &::ms-expand


### PR DESCRIPTION
If I try to build bulma with react-create-app build the select field doesn't look properly.
Somewhere it overrides the padding-right to 0.625em and then it looks gross. 