### PR TITLE
Remove incorrect/unclear documentation

### DIFF
--- a/docs/documentation/overview/start.html
+++ b/docs/documentation/overview/start.html
@@ -98,9 +98,6 @@ npm install bulma
         <p class="title is-5">
           <strong>Set</strong> your variables:<br>
 {% highlight sass %}
-// Import Bulma's initial variables
-@import "bulma/sass/utilities/variables.sass"
-
 // Override initial variables here
 // You can add new ones or update existing ones:
 
@@ -127,9 +124,6 @@ $family-primary: $family-serif // Use the new serif family
         <p class="title is-5">
           <strong>Import</strong> Bulma <em>after</em> having set your variables:<br>
 {% highlight sass %}
-// Import Bulma's initial variables
-@import "bulma/sass/utilities/variables.sass"
-
 // Override initial variables here
 // You can add new ones or update existing ones:
 


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

### Proposed solution
Documentation currently suggests importing `variables.sass` to override default colors and then import all of Bulma. This strategy doesn't work as the initial setting of `$colors` will not be overwritten on the second import.

This commit simply removes that suggestion from the documentation.
