### PR TITLE
Add new feature: Breadcrumb component

### DIFF
--- a/docs/_includes/subnav-components.html
+++ b/docs/_includes/subnav-components.html
@@ -1,6 +1,9 @@
 <nav class="nav has-shadow">
   <div class="container">
     <div class="nav-left">
+      <a class="nav-item is-tab {% if page.doc-subtab == 'breadcrumb' %}is-active{% endif %}" href="{{ site.url }}/documentation/components/breadcrumb/">
+        Breadcrumb
+      </a>
       <a class="nav-item is-tab {% if page.doc-subtab == 'card' %}is-active{% endif %}" href="{{ site.url }}/documentation/components/card/">
         Card
       </a>

--- a/docs/_layouts/documentation.html
+++ b/docs/_layouts/documentation.html
@@ -43,7 +43,7 @@ route: documentation
             <a href="{{ site.url }}/documentation/elements/box/">Elements</a>
           </li>
           <li {% if page.doc-tab == 'components' %}class="is-active"{% endif %}>
-            <a href="{{ site.url }}/documentation/components/card/">Components</a>
+            <a href="{{ site.url }}/documentation/components/breadcrumb/">Components</a>
           </li>
           <li {% if page.doc-tab == 'layout' %}class="is-active"{% endif %}>
             <a href="{{ site.url }}/documentation/layout/container/">Layout</a>

--- a/docs/documentation/components/breadcrumb.html
+++ b/docs/documentation/components/breadcrumb.html
@@ -14,29 +14,21 @@ doc-subtab: breadcrumb
         <hr>
 
         <div class="content">
-            <p>The <strong>breadcrumb</strong> component consists of two elements:</p>
-            <ul>
-                <li>
-                    <code>breadcrumb</code>: the main container
-                    <ul>
-                        <li>
-                            <code>breadcrumb-item</code>: a repeatable list item
-                        </li>
-                    </ul>
-                </li>
-            </ul>
-            <p>The breadcrumb dividers are created automatically in the <code>::before</code> pseudo-element's content of <code>breadcrumb-item</code> elements</p>
-            <p>You can inform the current page using the <code>is-active</code> modifier in a <code>breadcrumb-item</code> element. It will disable the navigation of this item.</p>
+            <p>The <strong>breadcrumb</strong> component only requires a <code>.breadcrumb</code> container and a <code>ul</code> list.</p>
+            <p>The dividers are automatically created in the content of the <code>::before</code> pseudo-element of <code>li</code> tags.</p>
+            <p>You can inform the current page using the <code>is-active</code> modifier in a <code>li</code> tag. It will disable the navigation of inner links.</p>
         </div>
 
         <hr>
 
 {% capture breadcrumb_example %}
 <nav class="breadcrumb">
-    <a class="breadcrumb-item">Bulma</a>
-    <a class="breadcrumb-item">Documentation</a>
-    <a class="breadcrumb-item">Components</a>
-    <span class="breadcrumb-item is-active">Breadcrumb</span>
+    <ul>
+        <li><a>Bulma</a></li>
+        <li><a>Documentation</a></li>
+        <li><a>Components</a></li>
+        <li class="is-active"><a>Breadcrumb</a></li>
+    </ul>
 </nav>
 {% endcapture %}
 <div class="example">
@@ -50,15 +42,34 @@ doc-subtab: breadcrumb
 
 <h3 class="title">Alignment</h3>
 <div class="content">
-    <p>To align the breadcrumb items to the right, use the <code>is-right</code> modifier on the <code>.breadcrumb</code> container.</p>
+    <p>For alternative alignments, use the <code>is-centered</code> and <code>is-right</code> modifiers on the <code>.breadcrumb</code> container.</p>
 </div>
+
+{% capture breadcrumb_centered_example %}
+<nav class="breadcrumb is-centered">
+    <ul>
+        <li><a>Bulma</a></li>
+        <li><a>Documentation</a></li>
+        <li><a>Components</a></li>
+        <li class="is-active"><a>Breadcrumb</a></li>
+    </ul>
+</nav>
+{% endcapture %}
+<div class="example">
+{{breadcrumb_centered_example}}
+</div>
+{% highlight html %}
+{{breadcrumb_centered_example}}
+{% endhighlight %}
 
 {% capture breadcrumb_right_example %}
 <nav class="breadcrumb is-right">
-    <a class="breadcrumb-item">Bulma</a>
-    <a class="breadcrumb-item">Documentation</a>
-    <a class="breadcrumb-item">Components</a>
-    <span class="breadcrumb-item is-active">Breadcrumb</span>
+    <ul>
+        <li><a>Bulma</a></li>
+        <li><a>Documentation</a></li>
+        <li><a>Components</a></li>
+        <li class="is-active"><a>Breadcrumb</a></li>
+    </ul>
 </nav>
 {% endcapture %}
 <div class="example">
@@ -77,10 +88,12 @@ doc-subtab: breadcrumb
 
 {% capture breadcrumb_icons_example %}
 <nav class="breadcrumb">
-    <a class="breadcrumb-item"><span class="icon is-small"><i class="fa fa-home"></i></span><span>Bulma</span></a>
-    <a class="breadcrumb-item"><span class="icon is-small"><i class="fa fa-file-text"></i></span><span>Documentation</span></a>
-    <a class="breadcrumb-item"><span class="icon is-small"><i class="fa fa-puzzle-piece"></i></span><span>Components</span></a>
-    <span class="breadcrumb-item is-active">Breadcrumb</span>
+    <ul>
+        <li><a><span class="icon is-small"><i class="fa fa-home"></i></span><span>Bulma</span></a></li>
+        <li><a><span class="icon is-small"><i class="fa fa-book"></i></span><span>Documentation</span></a></li>
+        <li><a><span class="icon is-small"><i class="fa fa-puzzle-piece"></i></span><span>Components</span></a></li>
+        <li class="is-active"><a><span class="icon is-small"><i class="fa fa-thumbs-up"></i></span><span>Breadcrumb</span></a></li>
+    </ul>
 </nav>
 {% endcapture %}
 <div class="example">
@@ -98,10 +111,12 @@ doc-subtab: breadcrumb
 </div>
 {% capture breadcrumb_small_example %}
 <nav class="breadcrumb is-small">
-    <a class="breadcrumb-item">Bulma</a>
-    <a class="breadcrumb-item">Documentation</a>
-    <a class="breadcrumb-item">Components</a>
-    <span class="breadcrumb-item is-active">Breadcrumb</span>
+    <ul>
+        <li><a>Bulma</a></li>
+        <li><a>Documentation</a></li>
+        <li><a>Components</a></li>
+        <li class="is-active"><a>Breadcrumb</a></li>
+    </ul>
 </nav>
 {% endcapture %}
 <div class="example">
@@ -113,10 +128,12 @@ doc-subtab: breadcrumb
 
 {% capture breadcrumb_medium_example %}
 <nav class="breadcrumb is-medium">
-    <a class="breadcrumb-item">Bulma</a>
-    <a class="breadcrumb-item">Documentation</a>
-    <a class="breadcrumb-item">Components</a>
-    <span class="breadcrumb-item is-active">Breadcrumb</span>
+    <ul>
+        <li><a>Bulma</a></li>
+        <li><a>Documentation</a></li>
+        <li><a>Components</a></li>
+        <li class="is-active"><a>Breadcrumb</a></li>
+    </ul>
 </nav>
 {% endcapture %}
 <div class="example">
@@ -128,10 +145,12 @@ doc-subtab: breadcrumb
 
 {% capture breadcrumb_large_example %}
 <nav class="breadcrumb is-large">
-    <a class="breadcrumb-item">Bulma</a>
-    <a class="breadcrumb-item">Documentation</a>
-    <a class="breadcrumb-item">Components</a>
-    <span class="breadcrumb-item is-active">Breadcrumb</span>
+    <ul>
+        <li><a>Bulma</a></li>
+        <li><a>Documentation</a></li>
+        <li><a>Components</a></li>
+        <li class="is-active"><a>Breadcrumb</a></li>
+    </ul>
 </nav>
 {% endcapture %}
 <div class="example">
@@ -149,10 +168,12 @@ doc-subtab: breadcrumb
 </div>
 {% capture breadcrumb_arrow_example %}
 <nav class="breadcrumb has-arrow-separator">
-    <a class="breadcrumb-item">Bulma</a>
-    <a class="breadcrumb-item">Documentation</a>
-    <a class="breadcrumb-item">Components</a>
-    <span class="breadcrumb-item is-active">Breadcrumb</span>
+    <ul>
+        <li><a>Bulma</a></li>
+        <li><a>Documentation</a></li>
+        <li><a>Components</a></li>
+        <li class="is-active"><a>Breadcrumb</a></li>
+    </ul>
 </nav>
 {% endcapture %}
 <div class="example">
@@ -164,10 +185,12 @@ doc-subtab: breadcrumb
 
 {% capture breadcrumb_bullet_example %}
 <nav class="breadcrumb has-bullet-separator">
-    <a class="breadcrumb-item">Bulma</a>
-    <a class="breadcrumb-item">Documentation</a>
-    <a class="breadcrumb-item">Components</a>
-    <span class="breadcrumb-item is-active">Breadcrumb</span>
+    <ul>
+        <li><a>Bulma</a></li>
+        <li><a>Documentation</a></li>
+        <li><a>Components</a></li>
+        <li class="is-active"><a>Breadcrumb</a></li>
+    </ul>
 </nav>
 {% endcapture %}
 <div class="example">
@@ -179,10 +202,12 @@ doc-subtab: breadcrumb
 
 {% capture breadcrumb_dot_example %}
 <nav class="breadcrumb has-dot-separator">
-    <a class="breadcrumb-item">Bulma</a>
-    <a class="breadcrumb-item">Documentation</a>
-    <a class="breadcrumb-item">Components</a>
-    <span class="breadcrumb-item is-active">Breadcrumb</span>
+    <ul>
+        <li><a>Bulma</a></li>
+        <li><a>Documentation</a></li>
+        <li><a>Components</a></li>
+        <li class="is-active"><a>Breadcrumb</a></li>
+    </ul>
 </nav>
 {% endcapture %}
 <div class="example">
@@ -194,10 +219,12 @@ doc-subtab: breadcrumb
 
 {% capture breadcrumb_succeeds_example %}
 <nav class="breadcrumb has-succeeds-separator">
-    <a class="breadcrumb-item">Bulma</a>
-    <a class="breadcrumb-item">Documentation</a>
-    <a class="breadcrumb-item">Components</a>
-    <span class="breadcrumb-item is-active">Breadcrumb</span>
+    <ul>
+        <li><a>Bulma</a></li>
+        <li><a>Documentation</a></li>
+        <li><a>Components</a></li>
+        <li class="is-active"><a>Breadcrumb</a></li>
+    </ul>
 </nav>
 {% endcapture %}
 <div class="example">

--- a/docs/documentation/components/breadcrumb.html
+++ b/docs/documentation/components/breadcrumb.html
@@ -1,0 +1,212 @@
+---
+layout: documentation
+doc-tab: components
+doc-subtab: breadcrumb
+---
+
+{% include subnav-components.html %}
+
+<section class="section">
+    <div class="container">
+        <h1 class="title">Breadcrumb</h1>
+        <h2 class="subtitle">A simple breadcrumb component to improve your navigation experience</h2>
+
+        <hr>
+
+        <div class="content">
+            <p>The <strong>breadcrumb</strong> component consists of two elements:</p>
+            <ul>
+                <li>
+                    <code>breadcrumb</code>: the main container
+                    <ul>
+                        <li>
+                            <code>breadcrumb-item</code>: a repeatable list item
+                        </li>
+                    </ul>
+                </li>
+            </ul>
+            <p>The breadcrumb dividers are created automatically in the <code>::before</code> pseudo-element's content of <code>breadcrumb-item</code> elements</p>
+            <p>You can inform the current page using the <code>is-active</code> modifier in a <code>breadcrumb-item</code> element. It will disable the navigation of this item.</p>
+        </div>
+
+        <hr>
+
+{% capture breadcrumb_example %}
+<nav class="breadcrumb">
+    <a class="breadcrumb-item">Bulma</a>
+    <a class="breadcrumb-item">Documentation</a>
+    <a class="breadcrumb-item">Components</a>
+    <span class="breadcrumb-item is-active">Breadcrumb</span>
+</nav>
+{% endcapture %}
+<div class="example">
+{{breadcrumb_example}}
+</div>
+{% highlight html %}
+{{breadcrumb_example}}
+{% endhighlight %}
+
+<hr>
+
+<h3 class="title">Alignment</h3>
+<div class="content">
+    <p>To align the breadcrumb items to the right, use the <code>is-right</code> modifier on the <code>.breadcrumb</code> container.</p>
+</div>
+
+{% capture breadcrumb_right_example %}
+<nav class="breadcrumb is-right">
+    <a class="breadcrumb-item">Bulma</a>
+    <a class="breadcrumb-item">Documentation</a>
+    <a class="breadcrumb-item">Components</a>
+    <span class="breadcrumb-item is-active">Breadcrumb</span>
+</nav>
+{% endcapture %}
+<div class="example">
+{{breadcrumb_right_example}}
+</div>
+{% highlight html %}
+{{breadcrumb_right_example}}
+{% endhighlight %}
+
+<hr>
+
+<h3 class="title">Icons</h3>
+<div class="content">
+    <p>You can use any of the <a href="http://fortawesome.github.io/Font-Awesome/">Font Awesome</a> <strong>icons</strong>.</p>
+</div>
+
+{% capture breadcrumb_icons_example %}
+<nav class="breadcrumb">
+    <a class="breadcrumb-item"><span class="icon is-small"><i class="fa fa-home"></i></span><span>Bulma</span></a>
+    <a class="breadcrumb-item"><span class="icon is-small"><i class="fa fa-file-text"></i></span><span>Documentation</span></a>
+    <a class="breadcrumb-item"><span class="icon is-small"><i class="fa fa-puzzle-piece"></i></span><span>Components</span></a>
+    <span class="breadcrumb-item is-active">Breadcrumb</span>
+</nav>
+{% endcapture %}
+<div class="example">
+{{breadcrumb_icons_example}}
+</div>
+{% highlight html %}
+{{breadcrumb_icons_example}}
+{% endhighlight %}
+
+<hr>
+
+<h3 class="title">Sizes</h3>
+<div class="content">
+    <p>You can choose between <strong>3 additional sizes</strong>: <code>is-small</code> <code>is-medium</code> and <code>is-large</code>.</p>
+</div>
+{% capture breadcrumb_small_example %}
+<nav class="breadcrumb is-small">
+    <a class="breadcrumb-item">Bulma</a>
+    <a class="breadcrumb-item">Documentation</a>
+    <a class="breadcrumb-item">Components</a>
+    <span class="breadcrumb-item is-active">Breadcrumb</span>
+</nav>
+{% endcapture %}
+<div class="example">
+{{breadcrumb_small_example}}
+</div>
+{% highlight html %}
+{{breadcrumb_small_example}}
+{% endhighlight %}
+
+{% capture breadcrumb_medium_example %}
+<nav class="breadcrumb is-medium">
+    <a class="breadcrumb-item">Bulma</a>
+    <a class="breadcrumb-item">Documentation</a>
+    <a class="breadcrumb-item">Components</a>
+    <span class="breadcrumb-item is-active">Breadcrumb</span>
+</nav>
+{% endcapture %}
+<div class="example">
+{{breadcrumb_medium_example}}
+</div>
+{% highlight html %}
+{{breadcrumb_medium_example}}
+{% endhighlight %}
+
+{% capture breadcrumb_large_example %}
+<nav class="breadcrumb is-large">
+    <a class="breadcrumb-item">Bulma</a>
+    <a class="breadcrumb-item">Documentation</a>
+    <a class="breadcrumb-item">Components</a>
+    <span class="breadcrumb-item is-active">Breadcrumb</span>
+</nav>
+{% endcapture %}
+<div class="example">
+{{breadcrumb_large_example}}
+</div>
+{% highlight html %}
+{{breadcrumb_large_example}}
+{% endhighlight %}
+
+<hr>
+
+<h3 class="title">Alternative separators</h3>
+<div class="content">
+    <p>You can choose between <strong>4 additional separators</strong>: <code>has-arrow-separator</code> <code>has-bullet-separator</code> <code>has-dot-separator</code> and <code>has-succeeds-separator</code>.</p>
+</div>
+{% capture breadcrumb_arrow_example %}
+<nav class="breadcrumb has-arrow-separator">
+    <a class="breadcrumb-item">Bulma</a>
+    <a class="breadcrumb-item">Documentation</a>
+    <a class="breadcrumb-item">Components</a>
+    <span class="breadcrumb-item is-active">Breadcrumb</span>
+</nav>
+{% endcapture %}
+<div class="example">
+{{breadcrumb_arrow_example}}
+</div>
+{% highlight html %}
+{{breadcrumb_arrow_example}}
+{% endhighlight %}
+
+{% capture breadcrumb_bullet_example %}
+<nav class="breadcrumb has-bullet-separator">
+    <a class="breadcrumb-item">Bulma</a>
+    <a class="breadcrumb-item">Documentation</a>
+    <a class="breadcrumb-item">Components</a>
+    <span class="breadcrumb-item is-active">Breadcrumb</span>
+</nav>
+{% endcapture %}
+<div class="example">
+{{breadcrumb_bullet_example}}
+</div>
+{% highlight html %}
+{{breadcrumb_bullet_example}}
+{% endhighlight %}
+
+{% capture breadcrumb_dot_example %}
+<nav class="breadcrumb has-dot-separator">
+    <a class="breadcrumb-item">Bulma</a>
+    <a class="breadcrumb-item">Documentation</a>
+    <a class="breadcrumb-item">Components</a>
+    <span class="breadcrumb-item is-active">Breadcrumb</span>
+</nav>
+{% endcapture %}
+<div class="example">
+{{breadcrumb_dot_example}}
+</div>
+{% highlight html %}
+{{breadcrumb_dot_example}}
+{% endhighlight %}
+
+{% capture breadcrumb_succeeds_example %}
+<nav class="breadcrumb has-succeeds-separator">
+    <a class="breadcrumb-item">Bulma</a>
+    <a class="breadcrumb-item">Documentation</a>
+    <a class="breadcrumb-item">Components</a>
+    <span class="breadcrumb-item is-active">Breadcrumb</span>
+</nav>
+{% endcapture %}
+<div class="example">
+{{breadcrumb_succeeds_example}}
+</div>
+{% highlight html %}
+{{breadcrumb_succeeds_example}}
+{% endhighlight %}
+
+
+    </div>
+</section>

--- a/sass/components/_all.sass
+++ b/sass/components/_all.sass
@@ -1,5 +1,6 @@
 @charset "utf-8"
 
+@import "breadcrumb.sass"
 @import "card.sass"
 @import "level.sass"
 @import "media.sass"
@@ -10,4 +11,3 @@
 @import "pagination.sass"
 @import "panel.sass"
 @import "tabs.sass"
-@import "breadcrumb.sass"

--- a/sass/components/_all.sass
+++ b/sass/components/_all.sass
@@ -10,3 +10,4 @@
 @import "pagination.sass"
 @import "panel.sass"
 @import "tabs.sass"
+@import "breadcrumb.sass"

--- a/sass/components/breadcrumb.sass
+++ b/sass/components/breadcrumb.sass
@@ -3,7 +3,6 @@
   +unselectable
   align-items: stretch
   display: flex
-  flex-wrap: wrap
   font-size: $size-normal
   overflow: hidden
   overflow-x: auto

--- a/sass/components/breadcrumb.sass
+++ b/sass/components/breadcrumb.sass
@@ -1,0 +1,68 @@
+.breadcrumb-item
+  align-items: center
+  display: flex
+  flex-grow: 0
+  flex-shrink: 0
+  line-height: 1.5
+  padding: 0.5em (0.75em/2)
+  white-space: nowrap
+  color: $text-light
+
+  a
+    color: $text-light
+    &:hover
+      color: $link-hover
+
+  .icon
+    &:first-child
+      margin-right: 0.5em
+    &:last-child
+      margin-left: 0.5em
+
+  // Pseudo-classes
+  &:hover
+    color: $link-hover
+  & + .breadcrumb-item:before
+    color: $text
+    content: '\0002f'
+    padding-right: 0.75em
+
+  // Modifiers
+  &.is-active, .is-active
+    color: $text-strong
+    cursor: default
+    pointer-events: none
+
+
+.breadcrumb
+  align-items: center
+  display: flex
+  flex-grow: 0
+  flex-shrink: 1
+  flex-wrap: wrap
+  font-size: $size-normal
+  list-style: none
+
+  // Sizes
+  &.is-small
+    font-size: $size-small
+  &.is-medium
+    font-size: $size-medium
+  &.is-large
+    font-size: $size-large
+
+  // Modifiers
+  &.has-arrow-separator
+    .breadcrumb-item + .breadcrumb-item:before
+      content: '\02192'
+  &.has-bullet-separator
+    .breadcrumb-item + .breadcrumb-item:before
+      content: '\02022'
+  &.has-dot-separator
+    .breadcrumb-item + .breadcrumb-item:before
+      content: '\000b7'
+  &.has-succeeds-separator
+    .breadcrumb-item + .breadcrumb-item:before
+      content: '\0227B'
+  &.is-right
+    justify-content: flex-end

--- a/sass/components/breadcrumb.sass
+++ b/sass/components/breadcrumb.sass
@@ -1,48 +1,50 @@
-.breadcrumb-item
-  align-items: center
+.breadcrumb
+  +block
+  +unselectable
+  align-items: stretch
   display: flex
-  flex-grow: 0
-  flex-shrink: 0
-  line-height: 1.5
-  padding: 0.5em (0.75em/2)
+  flex-wrap: wrap
+  font-size: $size-normal
+  overflow: hidden
+  overflow-x: auto
   white-space: nowrap
-  color: $text-light
-
   a
+    align-items: center
     color: $text-light
+    display: flex
+    justify-content: center
+    padding: 0.5em 0.75em
     &:hover
       color: $link-hover
-
+  li
+    align-items: center
+    display: flex
+    &.is-active
+      a
+        color: $text-strong
+        cursor: default
+        pointer-events: none
+    & + li:before
+      color: $text
+      content: '\0002f'
+  ul, ol
+    align-items: center
+    display: flex
+    flex-grow: 1
+    flex-shrink: 0
+    justify-content: flex-start
   .icon
     &:first-child
       margin-right: 0.5em
     &:last-child
       margin-left: 0.5em
-
-  // Pseudo-classes
-  &:hover
-    color: $link-hover
-  & + .breadcrumb-item:before
-    color: $text
-    content: '\0002f'
-    padding-right: 0.75em
-
-  // Modifiers
-  &.is-active, .is-active
-    color: $text-strong
-    cursor: default
-    pointer-events: none
-
-
-.breadcrumb
-  align-items: center
-  display: flex
-  flex-grow: 0
-  flex-shrink: 1
-  flex-wrap: wrap
-  font-size: $size-normal
-  list-style: none
-
+  // Alignment
+  &.is-centered
+    ol, ul
+      justify-content: center
+  &.is-right
+    ol, ul
+      justify-content: flex-end
   // Sizes
   &.is-small
     font-size: $size-small
@@ -50,19 +52,16 @@
     font-size: $size-medium
   &.is-large
     font-size: $size-large
-
-  // Modifiers
+  // Styles
   &.has-arrow-separator
-    .breadcrumb-item + .breadcrumb-item:before
+    li + li:before
       content: '\02192'
   &.has-bullet-separator
-    .breadcrumb-item + .breadcrumb-item:before
+    li + li:before
       content: '\02022'
   &.has-dot-separator
-    .breadcrumb-item + .breadcrumb-item:before
+    li + li:before
       content: '\000b7'
   &.has-succeeds-separator
-    .breadcrumb-item + .breadcrumb-item:before
+    li + li:before
       content: '\0227B'
-  &.is-right
-    justify-content: flex-end


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->
Add a breadcrumb component, as requested in https://github.com/jgthms/bulma/issues/298
It was based on bootstrap v4's breadcrumb and includes automatically created separators in the ::before pseudo-elements.
I also created modifiers for alternatives separators, which is originally a forward slash "/".

### Tradeoffs
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->
The component wraps for big breadcrumbs on mobile. I haven't found a better way to solve it.

### Testing Done
<!-- How have you confirmed this feature works? -->
<img width="659" alt="screen shot 2017-04-02 at 10 11 14 pm" src="https://cloud.githubusercontent.com/assets/2145589/24593070/dd313f8e-17f5-11e7-9735-8e8f1cf44d4b.png">
I tested this solution on google chrome for mac os. I also made tests using lists instead of nav elements and it works well.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Run `npm install` to install all Bulma dependencies -->
<!-- 3. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 4. If your PR fixes an issue, reference that issue -->
<!-- 5. If your PR has lots of commits, **rebase** first -->
<!-- 6. Your PR should only affect `.sass` and documentation files -->
