### PR TITLE
Fixes #637, variables import in docs.

### DIFF
--- a/docs/documentation/overview/start.html
+++ b/docs/documentation/overview/start.html
@@ -98,8 +98,8 @@ npm install bulma
         <p class="title is-5">
           <strong>Set</strong> your variables:<br>
 {% highlight sass %}
-// Import Bulma's initial variables
-@import "bulma/sass/utilities/variables.sass"
+// Import Bulma's initial variables and utilities:
+@import "bulma/sass/utilities/_all"
 
 // Override initial variables here
 // You can add new ones or update existing ones:


### PR DESCRIPTION
As discussed in issue #637. When copy & pasting the example from the docs an error occurs, this fixes that.
