### PR TITLE
Obeys align modifiers on .message-header

### DIFF
--- a/sass/components/message.sass
+++ b/sass/components/message.sass
@@ -19,6 +19,13 @@
       .message-body
         border-color: $color
         color: desaturate(darken($color, $darken-percentage), $desaturate-percentage)
+        
+  &.has-text-centered .message-header
+    justify-content: center
+  &.has-text-left .message-header
+    justify-content: flex-start
+  &.has-text-right .message-header
+    justify-content: flex-end
 
 .message-header
   align-items: center


### PR DESCRIPTION
### Proposed solution
I was going to write an issue but then I noticed it was so stupidly easy to fix I decided to push the PR directly, hoping it's not so easy it went wrong.
The issue is simple: adding the "general" alignment modifiers `.has-text-***` to a `.message` only affects its body, leaving the header on its place because it's aligned through flex, not plain text alignment.

### Tradeoffs
None? I see there could be an issue with the spacing in the header, but that's explicit from using one of the modifiers, so it's not really a trade-off but a new usage option.

### Testing Done
Using my DevTools on a simple message box:
![screenshot_009](https://cloud.githubusercontent.com/assets/532299/24835260/47c2da9c-1cd3-11e7-9bb4-b9bd29154dbd.png)
