### PR TITLE
Fixes #640 - Fix help text in .has-addons

### DIFF
--- a/sass/elements/form.sass
+++ b/sass/elements/form.sass
@@ -156,6 +156,7 @@ $input-radius:              $radius !default
   display: block
   font-size: $size-small
   margin-top: 0.25rem
+  order: 1
   @each $name, $pair in $colors
     $color: nth($pair, 1)
     &.is-#{$name}
@@ -172,6 +173,7 @@ $input-radius:              $radius !default
   // Modifiers
   &.has-addons
     display: flex
+    flex-wrap: wrap
     justify-content: flex-start
     .control
       margin-right: -1px
@@ -204,6 +206,9 @@ $input-radius:              $radius !default
       &.is-expanded
         flex-grow: 1
         flex-shrink: 0
+    &::after
+      width: 100%
+      content: ''
     &.has-addons-centered
       justify-content: center
     &.has-addons-right


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

### Proposed solution
`flex-wrap: wrap` on `.has-addons`, with `width: 100%` and `content: ''` in an after pseudo-selector. Any selector such as `.help` with `order: 1` (in commit) will be put on the next line.

### Tradeoffs
N/A

With this solution, no extra HTML is required to fix this and after testing I have found that no styling is affected as that only selectors with `order` set to 1 or greater are moved.

### Testing Done
**Before:**
![before](https://cloud.githubusercontent.com/assets/9816125/24920351/824fbd1c-1eac-11e7-84b7-32c16d16aca9.png)

**After:**
![after](https://cloud.githubusercontent.com/assets/9816125/24920366/8bbb9614-1eac-11e7-967c-4e796ae0e1ab.png)

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Run `npm install` to install all Bulma dependencies -->
<!-- 3. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 4. If your PR fixes an issue, reference that issue -->
<!-- 5. If your PR has lots of commits, **rebase** first -->
<!-- 6. Your PR should only affect `.sass` and documentation files -->
