### PR TITLE
Proposed solution to issue #46

### DIFF
--- a/sass/components/nav.sass
+++ b/sass/components/nav.sass
@@ -119,3 +119,14 @@ a.nav-item
   // Modifiers
   &.has-shadow
     box-shadow: 0 2px 3px rgba($black, 0.1)
+  &.is-fixed
+    position: fixed
+    width: 100%
+    &-top
+      top: 0
+      & + .container
+        margin-top: $nav-height
+    &-bottom
+      bottom: 0
+      & + .container
+        margin-bottom: $nav-height


### PR DESCRIPTION
### Proposed solution
Added `.is-fixed-top` and `.is-fixed-bottom` to get navbar fixed to top or bottom.

Fixes #46 

### Tradeoffs
This way, `.container` needs a margin top or bottom equals to `$nav-height`, because using `position: fixed;` rule gets content overlapped on top or bottom respectively.

### Testing Done
**Before: Fixed on top. Content gets overlapped (same with `.is-fixed-bottom`)**
![without-adjust](https://cloud.githubusercontent.com/assets/8890124/25064910/44eb8fbc-21d3-11e7-841b-4c489c2b660d.png)
**After: Fixed on top. Content gets a margin equals to `$nav-height`**
![with-adjust](https://cloud.githubusercontent.com/assets/8890124/25064920/74465b2a-21d3-11e7-93d1-cd315452b522.png)
