### PR TITLE
Document `is-grouped` alignment

### DIFF
--- a/docs/documentation/elements/form.html
+++ b/docs/documentation/elements/form.html
@@ -837,6 +837,9 @@ doc-subtab: form
       <p>
         If you want to <strong>group</strong> controls together, use the <code>is-grouped</code> modifier on the <code>control</code> container.
         <br>
+        Use the <code>is-grouped-centered</code> or the <code>is-grouped-right</code> modifers to alter the <strong>alignment</strong>.
+      </p>
+      <p>
         Add the <code>is-expanded</code> modifier on the control element you want to <strong>fill up the remaining space</strong>.
       </p>
     </div>


### PR DESCRIPTION
`is-grouped` can be aligned like `has-addons` using modifiers, but it's not documented.
 This PR fixes that.
