### PR TITLE
Incorrect pull request, please close it for me :(

### DIFF
--- a/sass/components/nav.sass
+++ b/sass/components/nav.sass
@@ -65,6 +65,7 @@ a.nav-item
   +overflow-touch
   align-items: stretch
   display: flex
+  flex-basis: 0
   flex-grow: 1
   flex-shrink: 0
   max-width: 100%


### PR DESCRIPTION
### Proposed solution

I found .nav-center does not centered like `v0.4.0`.

![2017-04-21 6 33 10](https://cloud.githubusercontent.com/assets/11359892/25255834/980b3fc2-265f-11e7-8c39-2d35beeec96b.png)

### Tradeoffs

Probably no.

### Testing Done

I add `flex-basis: 0` back to `nav.sass`. It now looks like:

![2017-04-21 6 49 18](https://cloud.githubusercontent.com/assets/11359892/25255874/ce05fa86-265f-11e7-947d-e90d4cff6390.png)
