### PR TITLE
Fixes #460 - modal component horizontally not centered in IE

### DIFF
--- a/sass/components/modal.sass
+++ b/sass/components/modal.sass
@@ -11,7 +11,7 @@
   width: 100%
   // Responsiveness
   +tablet
-    margin: 0 auto
+    margin: 0
     max-height: calc(100vh - 40px)
     width: 640px
 


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->
In modal component, modal horizontally not centered in IE 11 and IE lower version.
<code>modal-content</code> is child of absolute position div, there is a bug for <code>margin: 0 auto;</code> in IE, when it is child of parent which have absolute position.

<code>margin: 0;</code> will make modal horizontally centered in IE and it will not break anything.
### Tradeoffs
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->
Removing auto in margin will make modal horizontally centered in IE and it will not break anything.

### Testing Done
<!-- How have you confirmed this feature works? -->
Browsing local version of docs/_site.
<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Run `npm install` to install all Bulma dependencies -->
<!-- 3. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 4. If your PR fixes an issue, reference that issue -->
<!-- 5. If your PR has lots of commits, **rebase** first -->
<!-- 6. Your PR should only affect `.sass` and documentation files -->
