### PR TITLE
Add max width to .select, .select select

### DIFF
--- a/sass/elements/form.sass
+++ b/sass/elements/form.sass
@@ -98,9 +98,9 @@ $input-radius:              $radius !default
 .select
   display: inline-block
   height: 2.25em
+  max-width: 100%
   position: relative
   vertical-align: top
-  max-width: 100%
   &:after
     +arrow($input-arrow)
     margin-top: -0.375em
@@ -112,9 +112,9 @@ $input-radius:              $radius !default
     cursor: pointer
     display: block
     font-size: 1em
+    max-width: 100%
     outline: none
     padding-right: 2.5em
-    max-width: 100%
     &:hover
       border-color: $input-hover-border
     &::-ms-expand

--- a/sass/elements/form.sass
+++ b/sass/elements/form.sass
@@ -100,6 +100,7 @@ $input-radius:              $radius !default
   height: 2.25em
   position: relative
   vertical-align: top
+  max-width: 100%
   &:after
     +arrow($input-arrow)
     margin-top: -0.375em
@@ -113,6 +114,7 @@ $input-radius:              $radius !default
     font-size: 1em
     outline: none
     padding-right: 2.5em
+    max-width: 100%
     &:hover
       border-color: $input-hover-border
     &::-ms-expand


### PR DESCRIPTION
### Problem
When having long text inside the options of a select (even if they are not currently selected), the select will overflow to adjacent columns.

### Proposed solution
If `max-width: 100%` is set on `.select` and `.select select` the select will no longer overflow, this does not affect other situations.
This is not the same as adding `.is-fullwidth` since this class would force the 100% width even when the select is small.

### Testing Done
<img width="1142" alt="screen shot 2017-04-27 at 13 08 47" src="https://cloud.githubusercontent.com/assets/2814874/25497593/c288545c-2b4a-11e7-99b8-92e446c2b008.png">
Left is before, right is after 