### PR TITLE
Fix #702, Add .select select to .control.has-icons-left .input

### DIFF
--- a/css/bulma.css
+++ b/css/bulma.css
@@ -2594,7 +2594,7 @@ input[type="submit"].button {
   z-index: 4;
 }
 
-.control.has-icons-left .input, .select select {
+.control.has-icons-left .input, .control.has-icons-left .select select {
   padding-left: 2.25em;
 }
 

--- a/css/bulma.css
+++ b/css/bulma.css
@@ -2594,7 +2594,7 @@ input[type="submit"].button {
   z-index: 4;
 }
 
-.control.has-icons-left .input {
+.control.has-icons-left .input, .select select {
   padding-left: 2.25em;
 }
 


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->
Change `.control.has-icons-left .input` to `.control.has-icons-left .input, .control.has-icons-left .select select` in order to correct padding for select dropdowns including a left icon.

### Testing Done
<!-- How have you confirmed this feature works? -->
Reproduced issue with a custom html file and achieved #702's desired result with css code change (viewed in Chrome).
![iconselect](https://cloud.githubusercontent.com/assets/9830262/25929171/58a2a0fe-35b5-11e7-94ee-b824f67bf288.png)

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Run `npm install` to install all Bulma dependencies -->
<!-- 3. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 4. If your PR fixes an issue, reference that issue -->
<!-- 5. If your PR has lots of commits, **rebase** first -->
<!-- 6. Your PR should only affect `.sass` and documentation files -->
