### PR TITLE
Make alignment modifiers !important

### DIFF
--- a/sass/base/helpers.sass
+++ b/sass/base/helpers.sass
@@ -33,10 +33,10 @@ $displays: 'block' 'flex' 'inline' 'inline-block' 'inline-flex'
   +clearfix
 
 .is-pulled-left
-  float: left
+  float: left !important
 
 .is-pulled-right
-  float: right
+  float: right !important
 
 // Overflow
 
@@ -51,13 +51,13 @@ $displays: 'block' 'flex' 'inline' 'inline-block' 'inline-flex'
 // Text
 
 .has-text-centered
-  text-align: center
+  text-align: center !important
 
 .has-text-left
-  text-align: left
+  text-align: left !important
 
 .has-text-right
-  text-align: right
+  text-align: right !important
 
 @each $name, $pair in $colors
   $color: nth($pair, 1)


### PR DESCRIPTION
### Proposed solution
Currently the text alignment modifiers cannot be applied to table headers.

```html
<table class="table">
  <thead>
  <tr>
    <th class="has-text-centered">Header</th>
  </tr>
  </thead>
  <tbody>
    <tr>
      <td class="has-text-centered">
        Data
      </td>
    </tr>
  </tbody>
</table>
```

### Tradeoffs
I realize `!important` is a bit of a no-no, but I think this usage is ok as you are deliberately applying the class to an element.


### Testing Done
Tested this branch on an private app I am developing.
