### PR TITLE
Bring oferflow wrapping in line with W3C spec.

### DIFF
--- a/docs/sass/specific.sass
+++ b/docs/sass/specific.sass
@@ -4,7 +4,7 @@
       width: 320px
 
 .color
-  border-radius: 2px
+  border-radius: 2px;
   box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.1), inset 0 0 0 1px rgba(0, 0, 0, 0.1)
   display: inline-block
   float: left

--- a/docs/sass/specific.sass
+++ b/docs/sass/specific.sass
@@ -4,7 +4,7 @@
       width: 320px
 
 .color
-  border-radius: 2px;
+  border-radius: 2px
   box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.1), inset 0 0 0 1px rgba(0, 0, 0, 0.1)
   display: inline-block
   float: left

--- a/sass/elements/title.sass
+++ b/sass/elements/title.sass
@@ -11,7 +11,7 @@ $subtitle-weight:   $weight-light !default
 .title,
 .subtitle
   +block
-  word-break: break-word
+  overflow-wrap: break-word
   em,
   span
     font-weight: $title-weight


### PR DESCRIPTION
CSS  didn't conform to the W3C specification for the  attributes (which only allows normal, break-all, and keep-all).  Change the  property for  to allow the use of the break-word behaviour.

### Proposed solution
Doesn't fix an existing raised issue from what I can see, but does fix a W3C spec incompatibility without altering the behaviour in a browser.

### Tradeoffs
An alternative would be to use `word-break: break-all`, but that changes the way the output is rendered.


### Testing Done
I checked the before and after browser outputs and the developer console style applied.  The display was the same and the developer console no longer had an issue with the word-break property (see https://garybell.co.uk/blog/open-source-contribution-first-attempt for the before and after images of browser output and developer console.)