### PR TITLE
Fix syntax issue with the docs scss file by removing a semi-colon.  T…

### DIFF
--- a/docs/sass/specific.sass
+++ b/docs/sass/specific.sass
@@ -4,7 +4,7 @@
       width: 320px
 
 .color
-  border-radius: 2px;
+  border-radius: 2px
   box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.1), inset 0 0 0 1px rgba(0, 0, 0, 0.1)
   display: inline-block
   float: left


### PR DESCRIPTION
…his brings it in line with the style buide in .github/CONTRIBUTING.md

### Proposed solution
Bring the docs/sass files up-to-date with the CONTRIBUTING.md file by removing a semi-colon.  This helps to keep the code base consistent in both framework and documentation.

### Tradeoffs
No drawbacks for this.  Alternative would be to allow semi-colons in the code, but that loses consistency.


### Testing Done
re-build the docs CSS with the change without issue.