### PR TITLE
Fixes #760 Issue that causes nav-right to overflow to be hidden on wide-screen

### DIFF
--- a/sass/components/nav.sass
+++ b/sass/components/nav.sass
@@ -70,7 +70,7 @@ a.nav-item
   max-width: 100%
   overflow: auto
   +widescreen
-    flex-basis: 0
+    flex-basis: auto
 
 .nav-left
   justify-content: flex-start


### PR DESCRIPTION
### Proposed solution

Solves the displaying problem of the nav-right on wide-screen display by setting the flex-basis to auto.

This issue is related to https://github.com/jgthms/bulma/issues/760

### Tradeoffs
No aware of any.

### Testing Done
No testing done.
