### PR TITLE
Add is-halfheight to hero

### DIFF
--- a/sass/layout/hero.sass
+++ b/sass/layout/hero.sass
@@ -142,6 +142,14 @@
       .hero-body
         padding-bottom: 18rem
         padding-top: 18rem
+  &.is-halfheight
+    min-height: 50vh
+    .hero-body
+      align-items: center
+      display: flex
+      & > .container
+        flex-grow: 1
+        flex-shrink: 1
   &.is-fullheight
     min-height: 100vh
     .hero-body

--- a/sass/layout/hero.sass
+++ b/sass/layout/hero.sass
@@ -142,19 +142,15 @@
       .hero-body
         padding-bottom: 18rem
         padding-top: 18rem
+  &.is-halfheight,
+  &.is-fullheight
+    .hero-body
+      align-items: center
+      display: flex
+      & > .container
+        flex-grow: 1
+        flex-shrink: 1
   &.is-halfheight
     min-height: 50vh
-    .hero-body
-      align-items: center
-      display: flex
-      & > .container
-        flex-grow: 1
-        flex-shrink: 1
   &.is-fullheight
     min-height: 100vh
-    .hero-body
-      align-items: center
-      display: flex
-      & > .container
-        flex-grow: 1
-        flex-shrink: 1


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

### Proposed solution
I proposed to have an `is-halfheight ` selector to the hero layout, this is just an implementation of what was suggested in #782.

### Testing Done
the hero with `is-halfheight ` has exctaly half the height of the screen, did not aftected `is-fullheight`.
