### PR TITLE
Justified alignment helper class

### DIFF
--- a/docs/documentation/modifiers/helpers.html
+++ b/docs/documentation/modifiers/helpers.html
@@ -37,7 +37,7 @@ doc-subtab: helpers
           <td>Takes up the whole width (100%)</td>
         </tr>
         <tr>
-          <th rowspan="3">Text</th>
+          <th rowspan="4">Text</th>
           <td><code>has-text-centered</code></td>
           <td>Centers the text</td>
         </tr>
@@ -48,6 +48,10 @@ doc-subtab: helpers
         <tr>
           <td><code>has-text-right</code></td>
           <td>Text is right-aligned</td>
+        </tr>
+        <tr>
+          <td><code>has-text-justified</code></td>
+          <td>Text alignment is justified</td>
         </tr>
         <tr>
           <th rowspan="3">Other</th>

--- a/sass/base/helpers.sass
+++ b/sass/base/helpers.sass
@@ -59,6 +59,9 @@ $displays: 'block' 'flex' 'inline' 'inline-block' 'inline-flex'
 .has-text-right
   text-align: right
 
+.has-text-justified
+  text-align: justify
+
 @each $name, $pair in $colors
   $color: nth($pair, 1)
   .has-text-#{$name}


### PR DESCRIPTION
### Proposed solution
When using Right-To-Left and Left-To-Right layout flows you often need to use `text-align: justify`, this PR adds a helper class (`.has-text-justified`) just for that, using Bulmas' naming conventions.

### Tradeoffs
No tradeoffs here.

### Testing Done
Yes