### PR TITLE
Adding 'is-hidden' to helpers in docs

### DIFF
--- a/docs/documentation/modifiers/helpers.html
+++ b/docs/documentation/modifiers/helpers.html
@@ -50,7 +50,7 @@ doc-subtab: helpers
           <td>Text is right-aligned</td>
         </tr>
         <tr>
-          <th rowspan="3">Other</th>
+          <th rowspan="4">Other</th>
           <td><code>is-marginless</code></td>
           <td>Removes any <strong>margin</strong></td>
         </tr>
@@ -61,6 +61,10 @@ doc-subtab: helpers
         <tr>
           <td><code>is-unselectable</code></td>
           <td>Prevents the text from being <strong>selectable</strong></td>
+        </tr>
+        <tr>
+          <td><code>is-hidden</code></td>
+          <td>Hides element</td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
This is kinda mentioned in the responsive helpers, but I didn't notice at first and had to search through the repo.