### PR TITLE
Fixes #781 Add min/max height/width to delete class size modifiers

### DIFF
--- a/sass/utilities/mixins.sass
+++ b/sass/utilities/mixins.sass
@@ -74,12 +74,18 @@
   // Sizes
   &.is-small
     height: 16px
+    min-height: 16px
+    min-width: 16px
     width: 16px
   &.is-medium
     height: 24px
+    max-height: 24px
+    max-width: 24px
     width: 24px
   &.is-large
     height: 32px
+    max-height: 32px
+    max-width: 32px
     width: 32px
 
 =fa($size, $dimensions)

--- a/sass/utilities/mixins.sass
+++ b/sass/utilities/mixins.sass
@@ -74,6 +74,8 @@
   // Sizes
   &.is-small
     height: 16px
+    max-height: 16px
+    max-width: 16px
     min-height: 16px
     min-width: 16px
     width: 16px
@@ -81,11 +83,15 @@
     height: 24px
     max-height: 24px
     max-width: 24px
+    min-height: 24px
+    min-width: 24px
     width: 24px
   &.is-large
     height: 32px
     max-height: 32px
     max-width: 32px
+    min-height: 32px
+    min-width: 32px
     width: 32px
 
 =fa($size, $dimensions)


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
This solves #781 by adding min-height and min-width properties to .delete .is-small elements, and by adding max-height and max-width properties to .delete .is-medium and .delete .is-large elements. These properties will override the min/max height/width properties that are set on the .delete class, allowing the delete element to be sized correctly.
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

### Tradeoffs
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
Ideally, the min/max width/height properties on the .delete class could simply be removed, and that would allow the width and height properties on the size modifiers to work correctly. However, those properties were added to the .delete element to solve another issue, and cannot be removed. 
<!-- Think of performance, build time, usability, complexity, coupling…) -->


### Testing Done
<!-- How have you confirmed this feature works? -->
Forked repository
Cloned a local repository
Made changes
Ran `npm run build`
Copied bulma.css to my local dev server
Tested delete element sizes in Chrome 59 and Firefox 53, they seem correct

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Run `npm install` to install all Bulma dependencies -->
<!-- 3. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 4. If your PR fixes an issue, reference that issue -->
<!-- 5. If your PR has lots of commits, **rebase** first -->
<!-- 6. Your PR should only affect `.sass` and documentation files -->
