### PR TITLE
Add figure/figcaption as content element

### DIFF
--- a/docs/documentation/elements/content.html
+++ b/docs/documentation/elements/content.html
@@ -108,6 +108,13 @@ doc-subtab: content
   <p>Phasellus porttitor enim id metus volutpat ultricies. Ut nisi nunc, blandit sed dapibus at, vestibulum in felis. Etiam iaculis lorem ac nibh bibendum rhoncus. Nam interdum efficitur ligula sit amet ullamcorper. Etiam tristique, leo vitae porta faucibus, mi lacus laoreet metus, at cursus leo est vel tellus. Sed ac posuere est. Nunc ultricies nunc neque, vitae ultricies ex sodales quis. Aliquam eu nibh in libero accumsan pulvinar. Nullam nec nisl placerat, pretium metus vel, euismod ipsum. Proin tempor cursus nisl vel condimentum. Nam pharetra varius metus non pellentesque.</p>
   <h5>Fifth level</h5>
   <p>Aliquam sagittis rhoncus vulputate. Cras non luctus sem, sed tincidunt ligula. Vestibulum at nunc elit. Praesent aliquet ligula mi, in luctus elit volutpat porta. Phasellus molestie diam vel nisi sodales, a eleifend augue laoreet. Sed nec eleifend justo. Nam et sollicitudin odio.</p>
+  <figure>
+    <img src="{{site.url}}/images/placeholders/256x256.png">
+    <img src="{{site.url}}/images/placeholders/256x256.png">
+    <figcaption>
+      Figure 1: Some beautiful placeholders
+    </figcaption>
+  </figure>
   <h6>Sixth level</h6>
   <p>Cras in nibh lacinia, venenatis nisi et, auctor urna. Donec pulvinar lacus sed diam dignissim, ut eleifend eros accumsan. Phasellus non tortor eros. Ut sed rutrum lacus. Etiam purus nunc, scelerisque quis enim vitae, malesuada ultrices turpis. Nunc vitae maximus purus, nec consectetur dui. Suspendisse euismod, elit vel rutrum commodo, ipsum tortor maximus dui, sed varius sapien odio vitae est. Etiam at cursus metus.</p>
 </div>

--- a/sass/elements/content.sass
+++ b/sass/elements/content.sass
@@ -68,6 +68,12 @@
         list-style-type: square
   dd
     margin-left: 2em
+  figure
+    text-align: center
+    img
+      display: inline-block
+    figcaption
+      font-style: italic
   pre
     +overflow-touch
     overflow-x: auto


### PR DESCRIPTION
### Proposed solution
Add `<figure>` and `<figcaption>` to `.content`

![Example](http://i.imgur.com/l1NwQGx.png)

### Tradeoffs
No real tradeoffs as this wasn't implemented at all before

### Testing Done
Tested out in the documentation