### PR TITLE
Fix button style in navbar

### DIFF
--- a/sass/components/nav.sass
+++ b/sass/components/nav.sass
@@ -31,8 +31,8 @@ $nav-height: 3.25rem !default
   +mobile
     justify-content: flex-start
 
-.nav-item a,
-a.nav-item
+.nav-item a:not(.button),
+a.nav-item:not(.button)
   color: $text-light
   &:hover
     color: $link-hover


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

### Problem & solution
Currently, button inside a `<nav>` get the nav link styles. this shouldn't happen:
<img width="321" alt="screen shot 2017-06-30 at 00 48 12" src="https://user-images.githubusercontent.com/2725836/27713970-877626d0-5d2e-11e7-8d27-099dfc8f2f74.png">

This PR solves the issue by not overwriting buttons.

### Testing Done
I checked whether button styles inside navs are still overwritten, which they are not...

<!-- How have you confirmed this feature works? -->

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Run `npm install` to install all Bulma dependencies -->
<!-- 3. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 4. If your PR fixes an issue, reference that issue -->
<!-- 5. If your PR has lots of commits, **rebase** first -->
<!-- 6. Your PR should only affect `.sass` and documentation files -->
