### PR TITLE
Fix small syntax issue in navbar doc

### DIFF
--- a/docs/documentation/components/navbar.html
+++ b/docs/documentation/components/navbar.html
@@ -111,7 +111,7 @@ doc-subtab: navbar
 <div class="navbar-item">
   <div class="field is-grouped">
     <p class="control">
-      <a id="class="button">
+      <a class="button">
         <span class="icon">
           <i class="fa fa-twitter"></i>
         </span>


### PR DESCRIPTION
This isn't a major issue but it does break any HTML that it's copy/pasted into.

### Proposed solution

Removes unnecessary `id` modifier in anchor.

### Testing Done

I have built the site locally to ensure that it works as expected.
