### PR TITLE
[Suggestion] Add column vertical alignment helper

### DIFF
--- a/sass/grid/columns.sass
+++ b/sass/grid/columns.sass
@@ -4,6 +4,7 @@
   flex-grow: 1
   flex-shrink: 1
   padding: 0.75rem
+  // Modifiers
   &.has-vertically-aligned-content
     display: flex
     flex-direction: column

--- a/sass/grid/columns.sass
+++ b/sass/grid/columns.sass
@@ -4,6 +4,10 @@
   flex-grow: 1
   flex-shrink: 1
   padding: 0.75rem
+  &.has-vertically-aligned-content
+    display: flex
+    flex-direction: column
+    justify-content: center
   .columns.is-mobile > &.is-narrow
     flex: none
   .columns.is-mobile > &.is-full


### PR DESCRIPTION
### Proposed solution
This allows the class `has-vertically-aligned-content` to be added to a `column`, if the column is taller than the contents, the contents will be vertically centered.

### Tradeoffs
I'm not CSS guru, so no tradeoffs I can think of. I've been using it in production happily.


### Testing Done
Yes - [working example](https://codepen.io/timacdonald/pen/vZVavL)

I haven't updated the documentation yet, but happy to add a note about this if you are interested in pulling this into Bulma.