### PR TITLE
Fixes #26 Textarea now respects rows attribute

### DIFF
--- a/sass/elements/form.sass
+++ b/sass/elements/form.sass
@@ -74,13 +74,11 @@ $input-radius:              $radius !default
   min-width: 100%
   padding: 0.625em
   resize: vertical
-
-.textarea:not([rows])
-  max-height: 600px
-  min-height: 120px
-
-.textarea[rows]
-  height: auto
+  &:not([rows])
+    max-height: 600px
+    min-height: 120px
+  &[rows]
+    height: unset
 
 .checkbox,
 .radio

--- a/sass/elements/form.sass
+++ b/sass/elements/form.sass
@@ -70,18 +70,17 @@ $input-radius:              $radius !default
 
 .textarea
   display: block
-  max-height: 600px
   max-width: 100%
-  min-height: 120px
   min-width: 100%
   padding: 0.625em
   resize: vertical
 
-.textarea[rows] {
+.textarea:not([rows])
+  max-height: 600px
+  min-height: 120px
+
+.textarea[rows]
   height: auto
-  max-height: none
-  min-height: 0
-}
 
 .checkbox,
 .radio

--- a/sass/elements/form.sass
+++ b/sass/elements/form.sass
@@ -77,6 +77,12 @@ $input-radius:              $radius !default
   padding: 0.625em
   resize: vertical
 
+.textarea[rows] {
+  height: auto
+  max-height: none
+  min-height: 0
+}
+
 .checkbox,
 .radio
   cursor: pointer


### PR DESCRIPTION
### Proposed solution
This pull request fixes issue #26. Previously the `.textarea` class would override the ability to set the height to the `<textarea>` tag using the `rows="2"` attribute. I've added a CSS selector to detect if the `.textarea` has the `rows` attribute and in it - reset all height related properties to their default values.

Properties include: `height: auto`, `min-height: 0`, and `max-height: none`

### Tradeoffs
- Unfortunately this has to override the values as I am unaware of anyway to create a CSS selector to target **.textarea classes that do not have the `rows` attribute**. If this is possible, we would not have to override - but alas.
- This is a breaking change for those with rows attribute defined.
- It is not a **purely** class based solution - so you may not be a fan.


### Testing Done
[Working CodePen](https://codepen.io/timacdonald/pen/zzyRGx)

If you are keen to have this in Bulma, do you think we should do the same for the `cols` attribute.