### PR TITLE
Added vue-bulma-components to Related projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Browse the [online documentation here.](http://bulma.io/documentation/overview/s
 * Re-bulma – Bulma components build with React: https://github.com/bokuweb/re-bulma
 * React-bulma – React.js components for bulma: https://github.com/kulakowka/react-bulma
 * Buefy — Lightweight UI components for Vue.js based on Bulma: https://buefy.github.io
+* vue-bulma-components — Bulma components for Vue.js with straightforward syntax: https://github.com/vouill/vue-bulma-components
 
 ## Copyright and license
 


### PR DESCRIPTION
I know there are some vue-related links in the related projects section, but I really think `vue-bulma-components` deserves to be there, it has the cleanest syntax:

For example, consider the following snippet:
```text-html-basic
<div class="columns is-mobile">
  <div class="column is-half is-offset-one-quarter">
    A column 
   </div>
</div>
```
After including `vue-bulma-components`:
```text-html-basic
<columns is-mobile>
  <column is-half is-offset-one-quarter>
    A column
  </column>
</columns>
```
**Note**: I'm not the maintainer of the project, just a user that finds it really useful! :)