### PR TITLE
[Suggestion] Make title and subtitle element responsive

### DIFF
--- a/sass/elements/title.sass
+++ b/sass/elements/title.sass
@@ -36,6 +36,31 @@ $subtitle-weight:   $weight-light !default
     $i: index($sizes, $size)
     &.is-#{$i}
       font-size: $size
+  +mobile
+    @each $size in $sizes
+      $i: index($sizes, $size)
+      &.is-#{$i}-mobile
+        font-size: $size
+  +tablet
+    @each $size in $sizes
+      $i: index($sizes, $size)
+      &.is-#{$i}-tablet
+        font-size: $size
+  +touch
+    @each $size in $sizes
+      $i: index($sizes, $size)
+      &.is-#{$i}-touch
+        font-size: $size
+  +desktop
+    @each $size in $sizes
+      $i: index($sizes, $size)
+      &.is-#{$i}-desktop
+        font-size: $size
+  +widescreen
+    @each $size in $sizes
+      $i: index($sizes, $size)
+      &.is-#{$i}-widescreen
+        font-size: $size
 
 .subtitle
   color: $subtitle
@@ -51,3 +76,28 @@ $subtitle-weight:   $weight-light !default
     $i: index($sizes, $size)
     &.is-#{$i}
       font-size: $size
+  +mobile
+    @each $size in $sizes
+      $i: index($sizes, $size)
+      &.is-#{$i}-mobile
+        font-size: $size
+  +tablet
+    @each $size in $sizes
+      $i: index($sizes, $size)
+      &.is-#{$i}-tablet
+        font-size: $size
+  +touch
+    @each $size in $sizes
+      $i: index($sizes, $size)
+      &.is-#{$i}-touch
+        font-size: $size
+  +desktop
+    @each $size in $sizes
+      $i: index($sizes, $size)
+      &.is-#{$i}-desktop
+        font-size: $size
+  +widescreen
+    @each $size in $sizes
+      $i: index($sizes, $size)
+      &.is-#{$i}-widescreen
+        font-size: $size


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->
I often want to use a smaller title on different screen sizes. With this solution you can add responsiveness to the title and subtitle class.

Example:

`<p class="title is-1-widescreen is-4-mobile">Hello World</p>`

### Tradeoffs
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->

If you use the `<h1-7>` tags and not the `<p>` tag you are not consistent. 

Example: 

`<h1 class="title is-1-widescreen is-4-mobile">Hello World</h1>`

### Testing Done
<!-- How have you confirmed this feature works? -->

I used this solution in my own project. It works perfect.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Run `npm install` to install all Bulma dependencies -->
<!-- 3. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 4. If your PR fixes an issue, reference that issue -->
<!-- 5. If your PR has lots of commits, **rebase** first -->
<!-- 6. Your PR should only affect `.sass` and documentation files -->
