### PR TITLE
Removed html overflow and .columns margin (#931)

### DIFF
--- a/sass/base/generic.sass
+++ b/sass/base/generic.sass
@@ -4,8 +4,6 @@ html
   -moz-osx-font-smoothing: grayscale
   -webkit-font-smoothing: antialiased
   min-width: 300px
-  overflow-x: hidden
-  overflow-y: scroll
   text-rendering: $render-mode
 
 article,

--- a/sass/grid/columns.sass
+++ b/sass/grid/columns.sass
@@ -278,13 +278,6 @@
         margin-left: ($i / 12) * 100%
 
 .columns
-  margin-left: -0.75rem
-  margin-right: -0.75rem
-  margin-top: -0.75rem
-  &:last-child
-    margin-bottom: -0.75rem
-  &:not(:last-child)
-    margin-bottom: 0.75rem
   // Modifiers
   &.is-centered
     justify-content: center


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

### Proposed solution
This PR remove overflow from `html` and remove negative margins from `.columns`.

### Tradeoffs
Before
![before](https://user-images.githubusercontent.com/7015206/28638252-acc45488-721a-11e7-9997-52ba1728c63e.png)
After
![after](https://user-images.githubusercontent.com/7015206/28638251-acbb76d8-721a-11e7-8785-46683386fcd4.png)
