### PR TITLE
Fixed hardcoded localhost image url

### DIFF
--- a/docs/_includes/features.html
+++ b/docs/_includes/features.html
@@ -362,7 +362,7 @@
 <article class="media">
   <figure class="media-left">
     <p class="image is-64x64">
-      <img src="http://localhost:4000/images/placeholders/128x128.png">
+      <img src="{{ site.url }}/images/placeholders/128x128.png">
     </p>
   </figure>
   <div class="media-content">


### PR DESCRIPTION
### Proposed solution
In the current documentation the media object element image on the front page is hardcoded to `localhost:4000` which fails for example on the `bulma.io` page.

I simply use the variable `site.url`

Before:
![wrong](https://user-images.githubusercontent.com/15618191/28713973-8f97f7c0-7391-11e7-88b9-0dc18b088cd2.png)


After:
![bildschirmfoto 2017-07-28 um 12 37 57](https://user-images.githubusercontent.com/15618191/28713977-99fd93fa-7391-11e7-8a5d-76874636d964.png)



Have a nice day,
Jordan