### PR TITLE
Add .is-right to .navbar-dropdown

### DIFF
--- a/sass/components/navbar.sass
+++ b/sass/components/navbar.sass
@@ -217,6 +217,9 @@ a.navbar-item,
       transform: translateY(-5px)
       transition-duration: $speed
       transition-property: opacity, transform
+    &.is-right
+      left: auto
+      right: 0
   .navbar-divider
     display: block
   .container > .navbar


### PR DESCRIPTION
As it is possible to have `is-right` on a `dropdown`, it should be possible to have this class on `navbar-dropdown` as well.

Possibly fixes https://github.com/jgthms/bulma/issues/903

Example code:

```html
<nav class="navbar">
    <div class="navbar-menu">
        <div class="navbar-end">
                <div class="navbar-item has-dropdown is-hoverable ">
                    <span class="navbar-link" style="cursor: pointer;">User</span>
                    <div class="navbar-dropdown is-right">
                        <a class="navbar-item" href="/logout">
                            Long text logout
                        </a>
                    </div>
                </div>
        </div>
    </div>
</nav>
```

Before 

![before](https://user-images.githubusercontent.com/5840038/28716772-385cfd08-739f-11e7-8e48-013661c3efbc.png)

After

![after](https://user-images.githubusercontent.com/5840038/28716771-385731ca-739f-11e7-9690-48229260fafc.png)
