### PR TITLE
#942 Add .is-vertically-paddingless and other class helpers

### DIFF
--- a/sass/base/helpers.sass
+++ b/sass/base/helpers.sass
@@ -145,8 +145,24 @@ $displays: 'block' 'flex' 'inline' 'inline-block' 'inline-flex'
 .is-marginless
   margin: 0 !important
 
+.is-vertically-marginless
+  margin-top: 0 !important
+  margin-bottom: 0 !important
+
+.is-horizontally-marginless
+  margin-left: 0 !important
+  margin-right: 0 !important
+
 .is-paddingless
   padding: 0 !important
+
+.is-vertically-paddingless
+  padding-top: 0 !important
+  padding-bottom: 0 !important
+
+.is-horizontally-paddingless
+  padding-left: 0 !important
+  padding-right: 0 !important
 
 .is-radiusless
   border-radius: 0 !important


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->
Add 4 classes similar to `.is-paddingless` and `.is-marginless` for left/right and top/bottom

### Tradeoffs
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
Is adding 12 lines of SASS a drawback ?
<!-- Think of performance, build time, usability, complexity, coupling…) -->

### Testing Done
<!-- How have you confirmed this feature works? -->
I didn't really test it because this feature is simple as hell

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Run `npm install` to install all Bulma dependencies -->
<!-- 3. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 4. If your PR fixes an issue, reference that issue -->
<!-- 5. If your PR has lots of commits, **rebase** first -->
<!-- 6. Your PR should only affect `.sass` and documentation files -->
