### PR TITLE
Fixes #913: Safari button text-centering

### DIFF
--- a/sass/elements/button.sass
+++ b/sass/elements/button.sass
@@ -33,6 +33,7 @@ $button-shadow-inset: inset 0 1px 2px rgba($black, 0.2) !default
   border-color: $button-border
   color: $button
   cursor: pointer
+  display: table-cell
   justify-content: center
   padding-left: 0.75em
   padding-right: 0.75em


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
Solves problem #913 
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

### Tradeoffs
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
Sets display of button to table-cell. Seems like somewhat of a hack, but it's the only way text on `<button>` can be horizontally centered.

### Testing Done
<!-- How have you confirmed this feature works? -->
Tested in Safari, works.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Run `npm install` to install all Bulma dependencies -->
<!-- 3. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 4. If your PR fixes an issue, reference that issue -->
<!-- 5. If your PR has lots of commits, **rebase** first -->
<!-- 6. Your PR should only affect `.sass` and documentation files -->