### PR TITLE
add missing default statements to box and image

### DIFF
--- a/sass/elements/box.sass
+++ b/sass/elements/box.sass
@@ -4,8 +4,8 @@ $box-radius: $radius-large !default
 $box-shadow: 0 2px 3px rgba($black, 0.1), 0 0 0 1px rgba($black, 0.1) !default
 $box-padding: 1.25rem !default
 
-$box-link-hover-shadow: 0 2px 3px rgba($black, 0.1), 0 0 0 1px $link
-$box-link-active-shadow: inset 0 1px 2px rgba($black, 0.2), 0 0 0 1px $link
+$box-link-hover-shadow: 0 2px 3px rgba($black, 0.1), 0 0 0 1px $link !default
+$box-link-active-shadow: inset 0 1px 2px rgba($black, 0.2), 0 0 0 1px $link !default
 
 .box
   +block

--- a/sass/elements/image.sass
+++ b/sass/elements/image.sass
@@ -1,4 +1,4 @@
-$dimensions: 16 24 32 48 64 96 128
+$dimensions: 16 24 32 48 64 96 128 !default
 
 .image
   display: block


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

### Proposed solution
Fixes issue where you could not override variables in box.sass and image.sass

### Testing Done
Override image dimensions and get more classes i.e. `is-640x640`
