### PR TITLE
Changed ES6 function syntax to ES5 in JS example

### DIFF
--- a/docs/documentation/components/navbar.html
+++ b/docs/documentation/components/navbar.html
@@ -417,7 +417,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
     // Add a click event on each of them
     $navbarBurgers.forEach(function ($el) {
-      $el.addEventListener('click', () => {
+      $el.addEventListener('click', function () {
 
         // Get the target from the "data-target" attribute
         var target = $el.dataset.target;


### PR DESCRIPTION
Simple change to bulma docs.

In Navburger JS example there is a blip of ES6 function syntax. I changed it to ES5 so people who copy and paste it into a vanilla JS file don't run into issues.