### PR TITLE
Fix #833 Adding .is-sticky-top and .is-sticky-bottom modifiers to notifications

### DIFF
--- a/sass/elements/notification.sass
+++ b/sass/elements/notification.sass
@@ -35,7 +35,12 @@ $notification-padding: 1.25rem 2.5rem 1.25rem 1.5rem !default
       background-color: $color
       color: $color-invert
   // Modifiers
+  &.is-sticky-top,
+  &.is-sticky-bottom
+    border-radius: 0
   &.is-sticky-top
     +sticky(top, $notification-background-opacity)
+    border-bottom: 1px solid rgba($black, 0.2)
   &.is-sticky-bottom
     +sticky(bottom, $notification-background-opacity)
+    border-top: 1px solid rgba($black, 0.2)

--- a/sass/elements/notification.sass
+++ b/sass/elements/notification.sass
@@ -1,4 +1,5 @@
 $notification-background-color: $background !default
+$notification-background-opacity: 0.95 !default
 $notification-radius: $radius !default
 $notification-padding: 1.25rem 2.5rem 1.25rem 1.5rem !default
 
@@ -33,3 +34,8 @@ $notification-padding: 1.25rem 2.5rem 1.25rem 1.5rem !default
     &.is-#{$name}
       background-color: $color
       color: $color-invert
+  // Modifiers
+  &.is-sticky-top
+    +sticky(top, $notification-background-opacity)
+  &.is-sticky-bottom
+    +sticky(bottom, $notification-background-opacity)

--- a/sass/utilities/mixins.sass
+++ b/sass/utilities/mixins.sass
@@ -172,13 +172,9 @@
       @content
 
 =sticky($position, $opacity: 0.95)
-  border-radius: 0
   opacity: $opacity
   width: 100%
-  @if $position == top
-    border-bottom: 1px solid rgba($black, 0.2)
   @if $position == bottom
-    border-top: 1px solid rgba($black, 0.2)
     bottom: 0
     position: fixed
     z-index: 1000

--- a/sass/utilities/mixins.sass
+++ b/sass/utilities/mixins.sass
@@ -171,6 +171,18 @@
     &:#{$placeholder}-placeholder
       @content
 
+=sticky($position, $opacity: 0.95)
+  border-radius: 0
+  opacity: $opacity
+  width: 100%
+  @if $position == top
+    border-bottom: 1px solid rgba($black, 0.2)
+  @if $position == bottom
+    border-top: 1px solid rgba($black, 0.2)
+    bottom: 0
+    position: fixed
+    z-index: 1000
+
 =unselectable
   -webkit-touch-callout: none
   -webkit-user-select: none


### PR DESCRIPTION
### Proposed solution
##### Fixes [#833](https://github.com/jgthms/bulma/pull/833)

1. Add modifiers `.is-sticky-top` and `.is-sticky-bottom` to notifications.
2. Creates `=sticky()` mixin for future use in other elements/components.


##### Examples :

```html
<div class="notification is-dark is-marginless is-sticky-top">
  <button class="delete"></button>
  This site uses cookies. By continuing to browse the site you are agreeing to our use of cookies. <a href="#">Find out more here</a>.
</div>
```

```html
<div class="notification is-dark is-marginless is-sticky-bottom">
  <button class="delete"></button>
  This site uses cookies. By continuing to browse the site you are agreeing to our use of cookies. <a href="#">Find out more here</a>.
</div>
```

### Tradeoffs
- `.notification.is-sticky-top` must be the first element in the `<body>`.
I could have used `position: absolute` or `position: fixed`, but this would make the notification appear over the content. Keeping the position relative allows the following elements to appear after the notification.
[View Codepen](https://codepen.io/acanana/pen/pryaZV)

### Testing Done
[Testing Codepen](https://codepen.io/acanana/pen/wqGyrJ)
