### PR TITLE
[Suggestion] Add responsive helpers to text-align helpers

### DIFF
--- a/sass/base/helpers.sass
+++ b/sass/base/helpers.sass
@@ -46,12 +46,66 @@
 
 .has-text-centered
   text-align: center !important
++mobile
+  .has-text-centered-mobile
+    text-align: center !important
++tablet
+  .has-text-centered-tablet
+    text-align: center !important
++touch
+  .has-text-centered-touch
+    text-align: center !important
++desktop
+  .has-text-centered-desktop
+    text-align: center !important
++widescreen
+  .has-text-centered-widescreen
+    text-align: center !important
++fullhd
+  .has-text-centered-fullhd
+    text-align: center !important
 
 .has-text-left
   text-align: left !important
++mobile
+  .has-text-left-mobile
+    text-align: left !important
++tablet
+  .has-text-left-tablet
+    text-align: left !important
++touch
+  .has-text-left-touch
+    text-align: left !important
++desktop
+  .has-text-left-desktop
+    text-align: left !important
++widescreen
+  .has-text-left-widescreen
+    text-align: left !important
++fullhd
+  .has-text-left-fullhd
+    text-align: left !important
 
 .has-text-right
   text-align: right !important
++mobile
+  .has-text-right-mobile
+    text-align: right !important
++tablet
+  .has-text-right-tablet
+    text-align: right !important
++touch
+  .has-text-right-touch
+    text-align: right !important
++desktop
+  .has-text-right-desktop
+    text-align: right !important
++widescreen
+  .has-text-right-widescreen
+    text-align: right !important
++fullhd
+  .has-text-right-fullhd
+    text-align: right !important
 
 @each $name, $pair in $colors
   $color: nth($pair, 1)

--- a/sass/base/helpers.sass
+++ b/sass/base/helpers.sass
@@ -46,35 +46,35 @@
 
 $alignments: ('centered': 'center', 'left': 'left', 'right': 'right')
 
-@each $position, $text-align in $alignments
-  .has-text-#{$position}
+@each $alignment, $text-align in $alignments
+  .has-text-#{$alignment}
     text-align: #{$text-align} !important
   +mobile
-    .has-text-#{$position}-mobile
+    .has-text-#{$alignment}-mobile
       text-align: #{$text-align} !important
   +tablet
-    .has-text-#{$position}-tablet
+    .has-text-#{$alignment}-tablet
       text-align: #{$text-align} !important
   +tablet-only
-    .has-text-#{$position}-tablet-only
+    .has-text-#{$alignment}-tablet-only
       text-align: #{$text-align} !important
   +touch
-    .has-text-#{$position}-touch
+    .has-text-#{$alignment}-touch
       text-align: #{$text-align} !important
   +desktop
-    .has-text-#{$position}-desktop
+    .has-text-#{$alignment}-desktop
       text-align: #{$text-align} !important
   +desktop-only
-    .has-text-#{$position}-desktop-only
+    .has-text-#{$alignment}-desktop-only
       text-align: #{$text-align} !important
   +widescreen
-    .has-text-#{$position}-widescreen
+    .has-text-#{$alignment}-widescreen
       text-align: #{$text-align} !important
   +widescreen-only
-    .has-text-#{$position}-widescreen-only
+    .has-text-#{$alignment}-widescreen-only
       text-align: #{$text-align} !important
   +fullhd
-    .has-text-#{$position}-fullhd
+    .has-text-#{$alignment}-fullhd
       text-align: #{$text-align} !important
 
 @each $name, $pair in $colors

--- a/sass/base/helpers.sass
+++ b/sass/base/helpers.sass
@@ -44,68 +44,38 @@
     .is-size-#{$i}-fullhd
       font-size: $size !important
 
-.has-text-centered
-  text-align: center !important
-+mobile
-  .has-text-centered-mobile
-    text-align: center !important
-+tablet
-  .has-text-centered-tablet
-    text-align: center !important
-+touch
-  .has-text-centered-touch
-    text-align: center !important
-+desktop
-  .has-text-centered-desktop
-    text-align: center !important
-+widescreen
-  .has-text-centered-widescreen
-    text-align: center !important
-+fullhd
-  .has-text-centered-fullhd
-    text-align: center !important
+$alignments: ('centered': 'center', 'left': 'left', 'right': 'right')
 
-.has-text-left
-  text-align: left !important
-+mobile
-  .has-text-left-mobile
-    text-align: left !important
-+tablet
-  .has-text-left-tablet
-    text-align: left !important
-+touch
-  .has-text-left-touch
-    text-align: left !important
-+desktop
-  .has-text-left-desktop
-    text-align: left !important
-+widescreen
-  .has-text-left-widescreen
-    text-align: left !important
-+fullhd
-  .has-text-left-fullhd
-    text-align: left !important
-
-.has-text-right
-  text-align: right !important
-+mobile
-  .has-text-right-mobile
-    text-align: right !important
-+tablet
-  .has-text-right-tablet
-    text-align: right !important
-+touch
-  .has-text-right-touch
-    text-align: right !important
-+desktop
-  .has-text-right-desktop
-    text-align: right !important
-+widescreen
-  .has-text-right-widescreen
-    text-align: right !important
-+fullhd
-  .has-text-right-fullhd
-    text-align: right !important
+@each $position, $text-align in $alignments
+  .has-text-#{$position}
+    text-align: #{$text-align} !important
+  +mobile
+    .has-text-#{$position}-mobile
+      text-align: #{$text-align} !important
+  +tablet
+    .has-text-#{$position}-tablet
+      text-align: #{$text-align} !important
+  +tablet-only
+    .has-text-#{$position}-tablet-only
+      text-align: #{$text-align} !important
+  +touch
+    .has-text-#{$position}-touch
+      text-align: #{$text-align} !important
+  +desktop
+    .has-text-#{$position}-desktop
+      text-align: #{$text-align} !important
+  +desktop-only
+    .has-text-#{$position}-desktop-only
+      text-align: #{$text-align} !important
+  +widescreen
+    .has-text-#{$position}-widescreen
+      text-align: #{$text-align} !important
+  +widescreen-only
+    .has-text-#{$position}-widescreen-only
+      text-align: #{$text-align} !important
+  +fullhd
+    .has-text-#{$position}-fullhd
+      text-align: #{$text-align} !important
 
 @each $name, $pair in $colors
   $color: nth($pair, 1)


### PR DESCRIPTION
### Add response helpers [*-mobile, *-tablet etc] to text-align helpers [.has-text-centered etc]

This allows the use of text-align helpers for specific screen sizes. Perhaps you would like to ONLY center text on mobile: `has-text-centered-mobile` is now available to do so. I did this on my latest project and it worked well.

### Tradeoffs
None I can think of.

### Testing Done
Checkout this pen using CSS generated from the changes made in this PR: https://codepen.io/timacdonald/pen/dzMdwo