### PR TITLE
[Suggestion] Improve tag > icon spacing

### DIFF
--- a/sass/elements/tag.sass
+++ b/sass/elements/tag.sass
@@ -53,6 +53,16 @@ $tag-radius: $radius !default
     font-size: $size-normal
   &.is-large
     font-size: $size-medium
+  .icon
+    &:first-child:not(:last-child)
+      margin-left: -0.375em
+      margin-right: 0.1875em
+    &:last-child:not(:first-child)
+      margin-left: 0.1875em
+      margin-right: -0.375em
+    &:first-child:last-child
+      margin-left: -0.375em
+      margin-right: -0.375em
   // Modifiers
   &.is-delete
     margin-left: 1px


### PR DESCRIPTION
### Change the spacing of an icon when in a tag - similar to icon in a button.

Currently, if you have a button with an icon in it, for example:

```html
<a class="button">
    <span class="icon is-small">
        <i class="fa fa-user"></I>
    </span>
    <span>Profile</span>
</a>
```

The icon has margin applied to it to make it sit nicer and more balanced within the button. I propose doing the same thing for a tag:

```html
<div class="tag">
    <span class="icon is-small">
        <i class="fa fa-user"></I>
    </span>
    <span>Profile</span>
</div>
```

It is much more subtle with a tag, but I still think its a nicer look. I duplicated the button > icon spacing and it seemed to actually work really well, so I just left it.

### Tradeoffs
None I can think of.


### Testing Done

Example: https://codepen.io/timacdonald/pen/qXZxwB