### PR TITLE
Update typography-helpers.html

### DIFF
--- a/docs/documentation/modifiers/typography-helpers.html
+++ b/docs/documentation/modifiers/typography-helpers.html
@@ -363,7 +363,6 @@ doc-subtab: typography-helpers
         </tr>
       </tbody>
     </table>
-    </div>
 
     <hr>
 


### PR DESCRIPTION
Remove extra div closing tag.

<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

### Proposed solution
This PR removes and extra closing div in the typography helpers doc page. 
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

### Tradeoffs
None
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->