### PR TITLE
Add a new modifier class for disabling resizability of a textarea

### DIFF
--- a/sass/elements/form.sass
+++ b/sass/elements/form.sass
@@ -98,6 +98,9 @@ $help-size: $size-small !default
     min-height: 120px
   &[rows]
     height: unset
+  // Modifiers
+  &.has-fixed-size
+    resize: none
 
 .checkbox,
 .radio


### PR DESCRIPTION
### Proposed solution
It is sometimes necessary to disable resizability of textareas (e.g. when it is done automatically with JS).  
I propose adding a new modifier to the existing `.textarea` class.

A simple example:
```html
<div class="field">
  <label class="label">Message</label>
  <div class="control">
    <textarea class="textarea has-fixed-size" placeholder="Textarea" rows="1"></textarea>
  </div>
</div>
```
If this PR is acceptable I could update the documentation.
### Tradeoffs
I'm not aware of any.

### Testing Done
I implemented the example described in the proposal to verify it disables resizability of textarea elements with the `.textarea` class.