### PR TITLE
Replace deprecated .nav with .navbar in .hero layout

### DIFF
--- a/sass/layout/hero.sass
+++ b/sass/layout/hero.sass
@@ -5,7 +5,7 @@
   display: flex
   flex-direction: column
   justify-content: space-between
-  .nav
+  .navbar
     background: none
     box-shadow: 0 1px 0 rgba($border, 0.3)
   .tabs
@@ -28,13 +28,13 @@
         a:not(.button),
         strong
           color: $color-invert
-      .nav
+      .navbar
         box-shadow: 0 1px 0 rgba($color-invert, 0.2)
-      .nav-menu
+      .navbar-menu
         +mobile
           background-color: $color
-      a.nav-item,
-      .nav-item a:not(.button)
+      a.navbar-item,
+      .navbar-item a:not(.button)
         color: rgba($color-invert, 0.7)
         &:hover,
         &.is-active
@@ -66,7 +66,7 @@
         $gradient-bottom-right: lighten(saturate(adjust-hue($color, 10deg), 5%), 5%)
         background-image: linear-gradient(141deg, $gradient-top-left 0%, $color 71%, $gradient-bottom-right 100%)
         +mobile
-          .nav-menu
+          .navbar-menu
             background-image: linear-gradient(141deg, $gradient-top-left 0%, $color 71%, $gradient-bottom-right 100%)
       // Responsiveness
       +mobile
@@ -78,8 +78,8 @@
           &.is-active
             span
               background-color: $color-invert
-        .nav-menu
-          .nav-item
+        .navbar-menu
+          .navbar-item
             border-top-color: rgba($color-invert, 0.2)
   // Sizes
   &.is-medium


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

### Proposed solution

Replacing deprecated `.nav` with `.navbar` in `.hero`.

### Tradeoffs

None.