### PR TITLE
Changed the $tablet variable value to 768px.

### DIFF
--- a/sass/utilities/initial-variables.sass
+++ b/sass/utilities/initial-variables.sass
@@ -47,7 +47,7 @@ $weight-bold: 700 !default
 // The container gap, which acts as the offset for breakpoints
 $gap: 24px !default
 // 960, 1152, and 1344 have been chosen because they are divisible by both 12 and 16
-$tablet: 769px !default
+$tablet: 768px !default
 // 960px container + 3rem
 $desktop: 960px + (2 * $gap) !default
 // 1152px container + 3rem

--- a/sass/utilities/variables.sass
+++ b/sass/utilities/variables.sass
@@ -49,7 +49,7 @@ $body-size: 16px !default
 
 // Responsiveness
 // 960, 1152, and 1344 have been chosen because they are divisible by both 12 and 16
-$tablet: 769px !default
+$tablet: 768px !default
 // 960px container + 40px
 $desktop: 1000px !default
 // 1152px container + 40


### PR DESCRIPTION
### Proposed solution
Currently the $tablet variable has a value of 769px. This means that iPad and other tablets that have a portrait resolution of 768x1024 will show mobile styles instead of the expected tablet styles.
Amending this value to 768px fixes this issue.

### Testing Done
Testing complete. No issues. Behaves as expected.
