### PR TITLE
fix typo in Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Issues closed
 
-* #1030 Add `!importnant` to non responsive display helpers
+* #1030 Add `!important` to non responsive display helpers
 * #1020 Customizing `.navbar-item img` max height
 * #998 `.navbar-dropdown` with **right** alignment
 * #877 `.pagination` isn't using `$pagination-background`


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

### Proposed solution
#### Which specific problem does this PR solve and how?
Fixes a typo in the CHANGELOG
#### If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title
It fixes the particuliar issue of this  typo in the CHANGELOG, even though it was not yet tracked in the bug tracker.

### Tradeoffs
#### What are the drawbacks of this solution? Are there alternative ones?
Drawbacks include a lack of typos, which make the CHANGELOG, while more readable, maybe a tad more boring to read. Also, it reduces the number of easy fixes available for new comers like me, because that's one less typo to fix in the CHANGELOG
#### Think of performance, build time, usability, complexity, coupling…
Oh, I think of those all the time. That being said, I can assert with a quite high level of confidence that fixing a typo in the CHANGELOG should not impact all those things. If one thing, there's one less character to process when parsing the changelog, but one more commit (2 with the merge commit, depending how you manage it) when you clone the project. We may win and loose one or two nanoseconds here and there 


### Testing Done
#### How have you confirmed this feature works?
I've previewed the file on GitHub, and confirmed that this specific typo is gone. Can't promise anything for other typos, though.

🤣 

Taking the opportunity to publicly say that I really like Bulma and thank you for building and open sourcing it ! It's been loads of fun to work with it so far, and while my current proficiency in CSS matters may not allow my contributions to be more useful than fixing typos in the CHANGELOG, I'm really happy to have the opportunity to help :)