### PR TITLE
Typo Github -> GitHub

### DIFF
--- a/docs/_includes/navbar.html
+++ b/docs/_includes/navbar.html
@@ -153,7 +153,7 @@
 
     <div class="navbar-end">
       <a class="navbar-item is-hidden-desktop-only" href="{{ site.github }}" target="_blank">
-        Github
+        GitHub
       </a>
       <a class="navbar-item is-hidden-desktop-only" href="{{ site.twitter }}" target="_blank">
         Twitter


### PR DESCRIPTION
Small typo in `Github`. This PR fix the typo. :octocat: 