### PR TITLE
remove min-width in the html element.

### DIFF
--- a/sass/base/generic.sass
+++ b/sass/base/generic.sass
@@ -23,7 +23,6 @@ html
   font-size: $body-size
   -moz-osx-font-smoothing: grayscale
   -webkit-font-smoothing: antialiased
-  min-width: 300px
   overflow-x: hidden
   overflow-y: scroll
   text-rendering: $body-rendering


### PR DESCRIPTION
remove min-width of 300px in the html element, as it causes the page to break slightly at the left on mobile