### PR TITLE
Remove gap between tag and delete button

### DIFF
--- a/docs/documentation/elements/tag.html
+++ b/docs/documentation/elements/tag.html
@@ -10,6 +10,8 @@ variables:
   value: $text
 - name: $tag-radius
   value: $radius
+- name: $tag-delete-margin
+  value: 1px
 ---
 
 {% capture tag %}

--- a/sass/elements/tag.sass
+++ b/sass/elements/tag.sass
@@ -1,6 +1,7 @@
 $tag-background-color: $background !default
 $tag-color: $text !default
 $tag-radius: $radius !default
+$tag-delete-margin: 1px !default
 
 .tags
   align-items: center
@@ -55,6 +56,7 @@ $tag-radius: $radius !default
     font-size: $size-medium
   // Modifiers
   &.is-delete
+  	margin-left: $tag-delete-margin
     padding: 0
     position: relative
     width: 2em

--- a/sass/elements/tag.sass
+++ b/sass/elements/tag.sass
@@ -56,7 +56,7 @@ $tag-delete-margin: 1px !default
     font-size: $size-medium
   // Modifiers
   &.is-delete
-  	margin-left: $tag-delete-margin
+    margin-left: $tag-delete-margin
     padding: 0
     position: relative
     width: 2em

--- a/sass/elements/tag.sass
+++ b/sass/elements/tag.sass
@@ -55,7 +55,6 @@ $tag-radius: $radius !default
     font-size: $size-medium
   // Modifiers
   &.is-delete
-    margin-left: 1px
     padding: 0
     position: relative
     width: 2em


### PR DESCRIPTION
This PR removes the 1px wide gap between tag and delete tag.

| Before | After |
|:----------:|:--------:|
| ![before](https://user-images.githubusercontent.com/5840038/29480364-3038c186-8478-11e7-9da2-1da350afd4dd.png)   |   ![after](https://user-images.githubusercontent.com/5840038/29480365-303ce93c-8478-11e7-874f-ffe9a5a38f72.png)    |

It seemed to me that that gap was intentional (since it was explicitly added), but it feels somewhat unnatural to me. Plus there's no gap between plain attached tags.


