### PR TITLE
Wrap labels if inside a field with addons. Fixes #777

### DIFF
--- a/sass/elements/form.sass
+++ b/sass/elements/form.sass
@@ -365,10 +365,10 @@ $help-size: $size-small !default
   display: block
   font-size: $size-normal
   font-weight: $label-weight
-  &:not(:last-child)
-    margin-bottom: 0.5em
   .has-addons &
     flex: 0 0 100%
+  &:not(:last-child)
+    margin-bottom: 0.5em
   // Sizes
   &.is-small
     font-size: $size-small
@@ -394,8 +394,8 @@ $help-size: $size-small !default
   // Modifiers
   &.has-addons
     display: flex
-    justify-content: flex-start
     flex-wrap: wrap
+    justify-content: flex-start
     .control
       &:not(:last-child)
         margin-right: -1px

--- a/sass/elements/form.sass
+++ b/sass/elements/form.sass
@@ -367,6 +367,8 @@ $help-size: $size-small !default
   font-weight: $label-weight
   &:not(:last-child)
     margin-bottom: 0.5em
+  .has-addons &
+    flex: 0 0 100%
   // Sizes
   &.is-small
     font-size: $size-small
@@ -393,6 +395,7 @@ $help-size: $size-small !default
   &.has-addons
     display: flex
     justify-content: flex-start
+    flex-wrap: wrap
     .control
       &:not(:last-child)
         margin-right: -1px


### PR DESCRIPTION
Currently less elegant markup workarounds are needed when combining field addons and labels.

### Proposed solution
Set labels to full width and wrap if inside a field with the `.has-addons` modifier. Fixes #777

### Tradeoffs
I'd argue it retains the structure of the affected classes and adds very little complexity while removing the need for ugly workarounds.

### Testing Done
I've tested all relevant modifiers (`.is-expanded`, `.is-fullwidth`, `.has-addons-centered`, `.has-addons-right`) and the issue doesn't affect horizontal forms because they're divided into `.field-label` and `.field-body`.