### PR TITLE
[Documentation] Include example of widescreen and fullhd modifiers

### DIFF
--- a/docs/documentation/columns/responsiveness.html
+++ b/docs/documentation/columns/responsiveness.html
@@ -25,13 +25,13 @@ doc-subtab: responsiveness
 
 {% capture columns_multiple_breakpoints %}
 <div class="columns is-mobile">
-  <div class="column is-half-mobile is-one-third-tablet is-one-quarter-desktop">
-    <code>is-half-mobile</code><br>
-    <code>is-one-third-tablet</code><br>
-    <code>is-one-quarter-desktop</code>
+  <div class="column is-three-quarters-mobile is-two-thirds-tablet is-half-desktop is-one-third-widescreen is-one-quarter-fullhd">
+    <code>is-three-quarters-mobile</code><br>
+    <code>is-two-thirds-tablet</code><br>
+    <code>is-half-desktop</code>
+    <code>is-one-third-widescreen</code>
+    <code>is-one-quarter-fullhd</code>
   </div>
-  <div class="column">1</div>
-  <div class="column">1</div>
   <div class="column">1</div>
   <div class="column">1</div>
 </div>


### PR DESCRIPTION
The `widescreen` and `fullhd` modifiers are explained on the [Overview | Responsiveness](http://bulma.io/documentation/overview/responsiveness/) documentation page but there is no mention of them in [Columns | Responsiveness](http://bulma.io/documentation/columns/responsiveness/) which can be misleading.

I extended the responsiveness example by these two modifiers.

The last two columns were removed because in mobile, with the first column taking up 75% of the space, they were overflowing to the right.
