### PR TITLE
remove unwanted margin-right on .level-item at mobile breakpoint [Fixes #1152]

### DIFF
--- a/sass/components/level.sass
+++ b/sass/components/level.sass
@@ -48,11 +48,13 @@
   flex-grow: 0
   flex-shrink: 0
   .level-item
-    &:not(:last-child)
-      margin-right: 0.75rem
     // Modifiers
     &.is-flexible
       flex-grow: 1
+    // Responsiveness
+    +tablet
+      &:not(:last-child)
+        margin-right: 0.75rem
 
 .level-left
   align-items: center


### PR DESCRIPTION
### Proposed solution
This fixes [#1152](https://github.com/jgthms/bulma/issues/1152) by moving the `margin-right` to the tablet breakpoint

This fixes the alignment on mobile:

<img width="1280" alt="fixed_mobile" src="https://user-images.githubusercontent.com/2229721/30015087-18a9a934-9104-11e7-828b-214de4ce6f92.png">

It also preserves the behavior at the tablet breakpoint:

<img width="1280" alt="fixed_desktop" src="https://user-images.githubusercontent.com/2229721/30015115-37856ad2-9104-11e7-9946-7bbf46ad884a.png">
