### PR TITLE
Add $icon-selector variable

### DIFF
--- a/docs/documentation/overview/variables.html
+++ b/docs/documentation/overview/variables.html
@@ -91,6 +91,8 @@ initial_variables:
   value: 5px
 - name: $speed
   value: 86ms
+- name: $icon-selector
+  value: fa
 derived_variables:
 - name: $primary
   value: $turquoise

--- a/sass/components/panel.sass
+++ b/sass/components/panel.sass
@@ -96,6 +96,6 @@ label.panel-block
   +fa(14px, 1em)
   color: $panel-icon-color
   margin-right: 0.75em
-  .fa
+  .#{$icon-selector}
     font-size: inherit
     line-height: inherit

--- a/sass/elements/form.sass
+++ b/sass/elements/form.sass
@@ -242,12 +242,12 @@ $help-size: $size-small !default
   &.is-medium
     font-size: $size-medium
     .file-icon
-      .fa
+      .#{$icon-selector}
         font-size: 21px
   &.is-large
     font-size: $size-large
     .file-icon
-      .fa
+      .#{$icon-selector}
         font-size: 28px
   // Modifiers
   &.has-name
@@ -273,16 +273,16 @@ $help-size: $size-small !default
     .file-icon
       height: 1.5em
       width: 1.5em
-      .fa
+      .#{$icon-selector}
         font-size: 21px
     &.is-small
-      .file-icon .fa
+      .file-icon .#{$icon-selector}
         font-size: 14px
     &.is-medium
-      .file-icon .fa
+      .file-icon .#{$icon-selector}
         font-size: 28px
     &.is-large
-      .file-icon .fa
+      .file-icon .#{$icon-selector}
         font-size: 35px
     &.has-name
       .file-cta
@@ -363,7 +363,7 @@ $help-size: $size-small !default
   justify-content: center
   margin-right: 0.5em
   width: 1em
-  .fa
+  .#{$icon-selector}
     font-size: 14px
 
 .label

--- a/sass/elements/icon.sass
+++ b/sass/elements/icon.sass
@@ -9,21 +9,21 @@ $icon-dimensions-large: 3rem !default
   justify-content: center
   height: $icon-dimensions
   width: $icon-dimensions
-  .fa
+  .#{$icon-selector}
     font-size: 21px
   // Sizes
   &.is-small
     height: $icon-dimensions-small
     width: $icon-dimensions-small
-    .fa
+    .#{$icon-selector}
       font-size: 14px
   &.is-medium
     height: $icon-dimensions-medium
     width: $icon-dimensions-medium
-    .fa
+    .#{$icon-selector}
       font-size: 28px
   &.is-large
     height: $icon-dimensions-large
     width: $icon-dimensions-large
-    .fa
+    .#{$icon-selector}
       font-size: 42px

--- a/sass/elements/other.sass
+++ b/sass/elements/other.sass
@@ -4,7 +4,7 @@
 .delete
   +delete
 
-.fa
+.#{$icon-selector}
   font-size: 21px
   text-align: center
   vertical-align: top

--- a/sass/utilities/initial-variables.sass
+++ b/sass/utilities/initial-variables.sass
@@ -62,3 +62,4 @@ $radius-small: 2px !default
 $radius: 3px !default
 $radius-large: 5px !default
 $speed: 86ms !default
+$icon-selector: fa !default


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->
I noticed that `.fa` is hardcoded in multiple places and thus makes using icon fonts other than Font Awesome a little frusterating. To combat this, I added a variable `$icon-selector` which allows us to change the `.fa` selector using interpolation.

### Tradeoffs
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->
No tradeoffs whatsoever.

### Testing Done
<!-- How have you confirmed this feature works? -->
 I have compiled and tested with everything working as expected.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Run `npm install` to install all Bulma dependencies -->
<!-- 3. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 4. If your PR fixes an issue, reference that issue -->
<!-- 5. If your PR has lots of commits, **rebase** first -->
<!-- 6. Your PR should only affect `.sass` and documentation files -->
