### PR TITLE
Add `.has-text-justified` support

### DIFF
--- a/docs/documentation/modifiers/typography-helpers.html
+++ b/docs/documentation/modifiers/typography-helpers.html
@@ -250,6 +250,10 @@ doc-subtab: typography-helpers
         <td>Makes the text <strong>centered</strong></td>
         </tr>
         <tr>
+        <td><code>.has-text-justified</code></td>
+        <td>Makes the text <strong>justified</strong></td>
+        </tr>
+        <tr>
         <td><code>.has-text-left</code></td>
         <td>Makes the text aligned to the <strong>left</strong></td>
         </tr>

--- a/sass/base/helpers.sass
+++ b/sass/base/helpers.sass
@@ -47,7 +47,7 @@
 +fullhd
   +typography-size('fullhd')
 
-$alignments: ('centered': 'center', 'left': 'left', 'right': 'right')
+$alignments: ('centered': 'center', 'justified': 'justify', 'left': 'left', 'right': 'right')
 
 @each $alignment, $text-align in $alignments
   .has-text-#{$alignment}


### PR DESCRIPTION
Hello,

I know the idea was duplicated and denied before (https://github.com/jgthms/bulma/pull/465, https://github.com/jgthms/bulma/pull/796), but it's really useful in `Chinese`— the `Square Characters`.

Justified content is more formal and has good looking with Chinese, or says Sino-Tibetan languages.

Maybe your main users almost use English, or you don't want to increase the bundle size just for the useless feature. But you can measure the pros and cons again :)

Anyway, add this option would not make the content unreadable, users can still choose how to alignment the contents at the end.

By the way, is it necessary to provide different alignment in several resolutions? Could someone show me when to use it?

\- Bulma lover ❤️ 