### PR TITLE
Implemented navbar-breakpoint variable (Fixes #1042)

### DIFF
--- a/sass/components/navbar.sass
+++ b/sass/components/navbar.sass
@@ -188,7 +188,6 @@ a.navbar-item,
 +from($navbar-breakpoint)
   .navbar-burger
     display: none
-+desktop
   .navbar,
   .navbar-menu,
   .navbar-start,

--- a/sass/components/navbar.sass
+++ b/sass/components/navbar.sass
@@ -1,6 +1,9 @@
 $navbar-background-color: $white !default
 $navbar-height: 3.25rem !default
 
+// Breakpoint for minimum width when hamburger is hidden
+$navbar-breakpoint: $desktop !default
+
 $navbar-item-color: $grey-dark !default
 $navbar-item-hover-color: $black !default
 $navbar-item-hover-background-color: $background !default
@@ -182,6 +185,9 @@ a.navbar-item,
     &.is-active
       display: block
 
++from($navbar-breakpoint)
+  .navbar-burger
+    display: none
 +desktop
   .navbar,
   .navbar-menu,
@@ -210,8 +216,6 @@ a.navbar-item,
           &.is-active
             background-color: $navbar-dropdown-item-active-background-color
             color: $navbar-dropdown-item-active-color
-  .navbar-burger
-    display: none
   .navbar-item,
   .navbar-link
     align-items: center


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

I like the suggestion in #1042 and tried implementing it myself. I added the requested variable and changed the relevant rule for `.navbar-burger`. The breakpoint can now be adjusted by setting this variable.

### Tradeoffs
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->
I used the `from` mixin which was not used in `navbar.sass` before but I think the file depends on `utilities` anyway so this should not be a problem for modularity. 

### Testing Done
<!-- How have you confirmed this feature works? -->
I tested it by not setting the variable myself without any changes in behavior. Then I set the variable to various widths and it worked as expected.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Run `npm install` to install all Bulma dependencies -->
<!-- 3. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 4. If your PR fixes an issue, reference that issue -->
<!-- 5. If your PR has lots of commits, **rebase** first -->
<!-- 6. Your PR should only affect `.sass` and documentation files -->
