### PR TITLE
:memo: Redact note about local environment setup to include env key

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ The documentation HTML is produced with the Ruby-based `jekyll` tool.
 
 Then to view the documentation in your local checkout:
 
-1. Before you begin, cd into `docs/` directory, and `cp _config.yml _config.local.yml`. Then edit `_config.local.yml` and change the `url:` value to `http://localhost:4000`. This local config file will be ignored by git. 
+1. Before you begin, cd into `docs/` directory, and `cp _config.yml _config.local.yml`. Then edit `_config.local.yml` and change the `url:` value to `http://localhost:4000` and the `env` value to `development`. This local config file will be ignored by git.
 1. In a separate shell session, `cd` to the `docs/` directory, and do:
 ```
 jekyll serve --incremental --config _config.local.yml


### PR DESCRIPTION
This PR intends to improve development/contributors tooling setup.

The change allows to use `development` checks already used in the source - for example
exclude 3rd party scripts fetching on local machine removing errors from console.

Thanks!