### PR TITLE
Update level.sass to fix issue with icons

### DIFF
--- a/sass/components/level.sass
+++ b/sass/components/level.sass
@@ -41,8 +41,6 @@
   +mobile
     &:not(:last-child)
       margin-bottom: 0.75rem
-    // margin for icons
-    & > .icon
       margin-right: 0.75rem
     
 .level-left,

--- a/sass/components/level.sass
+++ b/sass/components/level.sass
@@ -20,6 +20,7 @@
         margin-bottom: 0
       &:not(.is-narrow)
         flex-grow: 1
+      margin-right: 0.75rem
   // Responsiveness
   +tablet
     display: flex
@@ -41,7 +42,6 @@
   +mobile
     &:not(:last-child)
       margin-bottom: 0.75rem
-      margin-right: 0.75rem
     
 .level-left,
 .level-right

--- a/sass/components/level.sass
+++ b/sass/components/level.sass
@@ -44,6 +44,7 @@
     // margin for icons
     & > .icon
       margin-right: 0.75rem
+    
 .level-left,
 .level-right
   flex-basis: auto

--- a/sass/components/level.sass
+++ b/sass/components/level.sass
@@ -48,6 +48,9 @@
   flex-grow: 0
   flex-shrink: 0
   .level-item
+    // margin for icons
+    & > .icon
+      margin-right: 0.75rem
     // Modifiers
     &.is-flexible
       flex-grow: 1

--- a/sass/components/level.sass
+++ b/sass/components/level.sass
@@ -41,16 +41,15 @@
   +mobile
     &:not(:last-child)
       margin-bottom: 0.75rem
-
+    // margin for icons
+    & > .icon
+      margin-right: 0.75rem
 .level-left,
 .level-right
   flex-basis: auto
   flex-grow: 0
   flex-shrink: 0
   .level-item
-    // margin for icons
-    & > .icon
-      margin-right: 0.75rem
     // Modifiers
     &.is-flexible
       flex-grow: 1


### PR DESCRIPTION
Removing `margin-right: 0.75rem` from the `level is-mobile` in #1153 changed the spacing of icons used in the `level-item`. [See the docs for the example code](http://bulma.io/documentation/elements/box/) of `box`, in mobile view, the icons get squashed together. 

This pr restores the margin-right **for the icon class only** to restore the behavior as before while also keeping changes made in #1153.

### Proposed solution
added margin-right for icon class only

### Tradeoffs
none


### Testing Done
yes
