### PR TITLE
Update short name of CC license

### DIFF
--- a/docs/documentation/layout/footer.html
+++ b/docs/documentation/layout/footer.html
@@ -21,7 +21,7 @@ doc-subtab: footer
       <p>
         <strong>Bulma</strong> by <a href="http://jgthms.com">Jeremy Thomas</a>. The source code is licensed
         <a href="http://opensource.org/licenses/mit-license.php">MIT</a>. The website content
-        is licensed <a href="http://creativecommons.org/licenses/by-nc-sa/4.0/">CC ANS 4.0</a>.
+        is licensed <a href="http://creativecommons.org/licenses/by-nc-sa/4.0/">CC BY NC SA 4.0</a>.
       </p>
       <p>
         <a class="icon" href="https://github.com/jgthms/bulma">
@@ -40,7 +40,7 @@ doc-subtab: footer
       <p>
         <strong>Bulma</strong> by <a href="http://jgthms.com">Jeremy Thomas</a>. The source code is licensed
         <a href="http://opensource.org/licenses/mit-license.php">MIT</a>. The website content
-        is licensed <a href="http://creativecommons.org/licenses/by-nc-sa/4.0/">CC ANS 4.0</a>.
+        is licensed <a href="http://creativecommons.org/licenses/by-nc-sa/4.0/">CC BY NC SA 4.0</a>.
       </p>
       <p>
         <a class="icon" href="https://github.com/jgthms/bulma">


### PR DESCRIPTION
BY NC SA, not ANS

<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

### Proposed solution

The name used for the CC license, which is also the one used by this very site, is incorrect: it is BY NC SA, not ANS

### Tradeoffs

Not relevant.

### Testing Done

Not relevant.