### PR TITLE
Fix typo in documentation

### DIFF
--- a/docs/documentation/elements/icon.html
+++ b/docs/documentation/elements/icon.html
@@ -92,7 +92,7 @@ variables:
 
     <div class="content">
       <p>
-        By defualt, the <code>icon</code> container will take up <em>exactly</em> <code>1.5rem x 1.5rem</code>. The icon itself is sized accordingly to the icon library you're using. For example, Font Awesome icons will <strong>inherit</strong> the font size.</p>
+        By default, the <code>icon</code> container will take up <em>exactly</em> <code>1.5rem x 1.5rem</code>. The icon itself is sized accordingly to the icon library you're using. For example, Font Awesome icons will <strong>inherit</strong> the font size.</p>
     </div>
 
     {% include anchor.html name="Colors" %}


### PR DESCRIPTION
### Proposed solution

This corrects a typo found in the documentation (`defualts` -> `defaults`).

### Tradeoffs

N/A

### Testing Done

N/A