### PR TITLE
Programmatically set bulma's sass files count in docs

### DIFF
--- a/docs/_plugins/sass_files_count.rb
+++ b/docs/_plugins/sass_files_count.rb
@@ -1,0 +1,61 @@
+module Jekyll
+  module Bulma
+    # A Jekyll Tag type that renders the count of Bulma Sass files.
+    # 
+    # It works by reading Bulma's primary Sass file `bulma.sass`
+    # from the `git` repository.
+    #
+		class SassFilesCount < Liquid::Tag
+			def render(context)
+			
+				# bulma primary sass file
+				file = '../bulma1.sass'
+				
+				if !File.readable?(file)
+				
+					# sort of a fallback in case the primary bulma file 
+					# doesn't exist or is unreadable
+					return 40
+					
+				end
+					
+				# ----------------------------------------------------------------------
+				
+				# initiate counter
+				count = 0
+				
+				File.readlines(file).each do |line|
+				
+					# only interested in imported sass files
+					next if !line.start_with? '@import'
+					
+					# remove @import, double quotes and trim it
+					file = line.gsub('@import ', '').gsub(/\A"+(.*?)"+\Z/m, '\1').strip
+					file = "../#{file}.sass"
+				
+					# make sure it's readable
+					next if !File.readable?(file)
+					
+					File.readlines(file).each do |sub_line|
+				
+						# skip anything that's not an imported file
+						next if !sub_line.start_with? '@import'
+						
+						# increase count
+						count += 1
+				
+					end
+					
+				end
+					
+				# ----------------------------------------------------------------------
+				
+				# return counted files
+				count
+
+			end
+		end
+	end
+end
+
+Liquid::Template.register_tag('sass_files_count', Jekyll::Bulma::SassFilesCount)

--- a/docs/documentation/overview/modular.html
+++ b/docs/documentation/overview/modular.html
@@ -16,7 +16,7 @@ doc-subtab: modular
 
     <div class="content">
       <p>
-        Bulma consists of <strong>29</strong> <code>.sass</code> files that you can import <strong>individually.</strong>
+        Bulma consists of <strong>{% sass_files_count %}</strong> <code>.sass</code> files that you can import <strong>individually.</strong>
       </p>
       <p>
         For example, let's say you only want the Bulma <strong>columns.</strong>


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

This is related to the [Modular Page](http://bulma.io/documentation/overview/modular/) in the Docs.

### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

Currently, the sass files count is set manually to `29` files, which is an outdated count.  This solution aims at avoiding the need of manually setting this count.

This was achieved by creating a new [Jekyll plugin](http://jekyllrb.com/docs/plugins/), namely `Jekyll::Bulma::SassFilesCount`, which takes care of counting the imported sass files used in bulma.

### Tradeoffs

None that I can think of.


### Testing Done

Tested in local development environment using:
```bash
cd docs && \
jekyll serve --config _config.local.yml
```

### Additional Notes

If this is considered useful, then we can consider cooking up other Jekyll plugins to dynamically set values such as the version number and other related config settings.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Run `npm install` to install all Bulma dependencies -->
<!-- 3. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 4. If your PR fixes an issue, reference that issue -->
<!-- 5. If your PR has lots of commits, **rebase** first -->
<!-- 6. Your PR should only affect `.sass` and documentation files -->
