### PR TITLE
Adding ";" on @require statements to avoid  errors

### DIFF
--- a/docs/documentation/overview/customize.html
+++ b/docs/documentation/overview/customize.html
@@ -7,7 +7,7 @@ doc-subtab: customize
 
 {% capture sass %}
 // 1. Import the initial variables
-@import "../sass/utilities/initial-variables"
+@import "../sass/utilities/initial-variables";
 
 // 2. Set your own initial variables
 // Update blue
@@ -28,7 +28,7 @@ $danger: $orange
 $family-primary: $family-serif
 
 // 4. Import the rest of Bulma
-@import "../bulma"
+@import "../bulma";
 {% endcapture %}
 
 {% include subnav-overview.html %}


### PR DESCRIPTION
If not using the semicolon at the end of the @import lines this might cause syntax errors like "Media query expression must begin with '('"

<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

### Tradeoffs
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->


### Testing Done
<!-- How have you confirmed this feature works? -->

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Run `npm install` to install all Bulma dependencies -->
<!-- 3. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 4. If your PR fixes an issue, reference that issue -->
<!-- 5. If your PR has lots of commits, **rebase** first -->
<!-- 6. Your PR should only affect `.sass` and documentation files -->
