### PR TITLE
Update references to variables in docs

### DIFF
--- a/docs/_includes/variables.html
+++ b/docs/_includes/variables.html
@@ -2,7 +2,7 @@
 
 <div class="content">
   <p>
-    You can use these variables to <strong>customize</strong> this {%if include.element %}element{% elsif include.layout %}layout{% else %}component{% endif %}. Simply set one or multiple of these variables <em>before</em> importing Bulma. <a href="{{ site.url }}/documentation/overview/customize/">Learn how</a>.
+    {% if include.custom_message %}{{ include.custom_message }}{% else %}You can use these variables to <strong>customize</strong> this {%if include.element %}element{% elsif include.layout %}layout{% else %}component{% endif %}. Simply set one or multiple of these variables <em>before</em> importing Bulma. <a href="{{ site.url }}/documentation/overview/customize/">Learn how</a>.{% endif %}
   </p>
 </div>
 

--- a/docs/_includes/variables.html
+++ b/docs/_includes/variables.html
@@ -2,7 +2,7 @@
 
 <div class="content">
   <p>
-    You can use these variables to <strong>customize</strong> this {%if include.element %}element{% else %}component{% endif %}. Simply set one or multiple of these variables <em>before</em> importing Bulma. <a href="{{ site.url }}/documentation/overview/customize/">Learn how</a>.
+    You can use these variables to <strong>customize</strong> this {%if include.element %}element{% elsif include.layout %}layout{% else %}component{% endif %}. Simply set one or multiple of these variables <em>before</em> importing Bulma. <a href="{{ site.url }}/documentation/overview/customize/">Learn how</a>.
   </p>
 </div>
 

--- a/docs/documentation/components/navbar.html
+++ b/docs/documentation/components/navbar.html
@@ -17,6 +17,8 @@ variables:
   value: $black
 - name: $navbar-item-active-background-color
   value: transparent
+- name: $navbar-item-img-max-height
+  value: 1.75rem
 - name: $navbar-tab-hover-background-color
   value: transparent
 - name: $navbar-tab-hover-border-bottom-color

--- a/docs/documentation/components/pagination.html
+++ b/docs/documentation/components/pagination.html
@@ -5,8 +5,6 @@ doc-subtab: pagination
 variables:
 - name: $pagination-color
   value: $grey-darker
-- name: $pagination-background
-  value: $white
 - name: $pagination-border-color
   value: $grey-lighter
 - name: $pagination-margin
@@ -37,8 +35,6 @@ variables:
   value: $link
 - name: $pagination-ellipsis-color
   value: $grey-light
-- name: $pagination-shadow-inset
-  value: inset 0 1px 2px rgba($black, 0
 ---
 
 {% capture pagination_example %}

--- a/docs/documentation/components/tabs.html
+++ b/docs/documentation/components/tabs.html
@@ -32,7 +32,7 @@ variables:
 - name: $tabs-boxed-link-active-border-color
   value: $border
 - name: $tabs-boxed-link-active-border-bottom-color
-  value: transparent !important
+  value: transparent
 - name: $tabs-toggle-link-border-color
   value: $border
 - name: $tabs-toggle-link-border-style

--- a/docs/documentation/elements/button.html
+++ b/docs/documentation/elements/button.html
@@ -46,8 +46,6 @@ variables:
   value: $white-ter
 - name: $button-static-border-color
   value: $grey-lighter
-- name: $button-shadow-inset
-  value: inset 0 1px 2px rgba($black, 0.2)
 ---
 
 {% capture button_example %}

--- a/docs/documentation/elements/table.html
+++ b/docs/documentation/elements/table.html
@@ -16,8 +16,6 @@ variables:
   value: 0.5em 0.75em
 - name: $table-cell-heading-color
   value: $text-strong
-- name: $table-head-color
-  value: $grey
 - name: $table-head-cell-border-width
   value: 0 0 2px
 - name: $table-head-cell-color

--- a/docs/documentation/elements/title.html
+++ b/docs/documentation/elements/title.html
@@ -10,9 +10,9 @@ variables:
   value: $size-3
 - name: $title-weight
   value: $weight-semibold
-- name: $title-strong-weight
-  value: inherit
 - name: $title-strong-color
+  value: inherit
+- name: $title-strong-weight
   value: inherit
 - name: $subtitle-color
   value: $grey-dark

--- a/docs/documentation/form/general.html
+++ b/docs/documentation/form/general.html
@@ -3,6 +3,21 @@ title: Form controls
 layout: documentation
 doc-tab: form
 doc-subtab: general
+variables:
+- name: $control-radius
+  value: $radius
+- name: $control-radius-small
+  value: $radius-small
+- name: $control-padding-vertical
+  value: calc(0.375em - 1px)
+- name: $control-padding-horizontal
+  value: calc(0.625em - 1px)
+- name: $label-color
+  value: $grey-darker
+- name: $label-weight
+  value: $weight-bold
+- name: $help-size
+  value: $size-small
 ---
 
 {% capture example %}
@@ -1027,6 +1042,10 @@ doc-subtab: general
     </div>
 
     {% include snippet.html content=field_label_example horizontal=true clipped=true %}
+		
+		{% capture custom_message %}Form elements can be <strong>customized</strong> using the following generic variables. Simply set one or multiple of these variables <em>before</em> importing Bulma. <a href="{{ site.url }}/documentation/overview/customize/">Learn how</a>.{% endcapture %}
+			
+    {% include variables.html custom_message = custom_message %}
 
   </div>
 </section>

--- a/docs/documentation/layout/footer.html
+++ b/docs/documentation/layout/footer.html
@@ -3,6 +3,9 @@ title: Footer
 layout: documentation
 doc-tab: layout
 doc-subtab: footer
+variables:
+- name: $footer-background-color
+  value: $background
 ---
 
 {% include subnav-layout.html %}
@@ -51,5 +54,7 @@ doc-subtab: footer
   </div>
 </footer>
 {% endhighlight %}
+
+    {% include variables.html layout=true %}
   </div>
 </section>

--- a/docs/documentation/layout/section.html
+++ b/docs/documentation/layout/section.html
@@ -3,6 +3,13 @@ title: Section
 layout: documentation
 doc-tab: layout
 doc-subtab: section
+variables:
+- name: $section-padding
+  value: 3rem 1.5rem
+- name: $section-padding-medium
+  value: 9rem 1.5rem
+- name: $section-padding-large
+  value: 18rem 1.5rem
 ---
 
 {% include subnav-layout.html %}
@@ -36,6 +43,8 @@ doc-subtab: section
     <div class="content">
       <p>You can use the modifiers <code>is-medium</code> and <code>is-large</code> to change the <strong>spacing</strong>.</p>
     </div>
+
+    {% include variables.html layout=true %}
 
   </div>
 </section>

--- a/docs/documentation/overview/modular.html
+++ b/docs/documentation/overview/modular.html
@@ -16,7 +16,7 @@ doc-subtab: modular
 
     <div class="content">
       <p>
-        Bulma consists of <strong>29</strong> <code>.sass</code> files that you can import <strong>individually.</strong>
+        Bulma consists of <strong>40</strong> <code>.sass</code> files that you can import <strong>individually.</strong>
       </p>
       <p>
         For example, let's say you only want the Bulma <strong>columns.</strong>

--- a/docs/documentation/overview/variables.html
+++ b/docs/documentation/overview/variables.html
@@ -72,7 +72,7 @@ initial_variables:
 - name: $weight-bold
   value: 700
 - name: $gap
-  value: 24px
+  value: 32px
 - name: $tablet
   value: 769px
 - name: $desktop

--- a/docs/documentation/overview/variables.html
+++ b/docs/documentation/overview/variables.html
@@ -192,6 +192,39 @@ derived_variables:
   value: '("black-bis": $black-bis, "black-ter": $black-ter, "grey-darker": $grey-darker, "grey-dark": $grey-dark, "grey": $grey, "grey-light": $grey-light, "grey-lighter": $grey-lighter, "white-ter": $white-ter, "white-bis": $white-bis)'
 - name: $sizes
   value: $size-1 $size-2 $size-3 $size-4 $size-5 $size-6
+generic_variables:
+- name: $body-background-color
+  value: '#fff'
+- name: $body-size
+  value: 16px
+- name: $body-rendering
+  value: optimizeLegibility
+- name: $body-family
+  value: $family-primary
+- name: $body-color
+  value: $text
+- name: $body-weight
+  value: $weight-normal
+- name: $body-line-height
+  value: 1.5
+- name: $code-family
+  value: $family-code
+- name: $code-padding
+  value: 0.25em 0.5em 0.25em
+- name: $code-weight
+  value: normal
+- name: $code-size
+  value: 0.875em
+- name: $hr-background-color
+  value: $border
+- name: $hr-height
+  value: 1px
+- name: $hr-margin
+  value: 1.5rem 0
+- name: $strong-color
+  value: $text-strong
+- name: $strong-weight
+  value: $weight-bold
 ---
 
 {% include subnav-overview.html %}
@@ -291,6 +324,27 @@ derived_variables:
 
     <table class="table is-bordered is-striped">
       {% for variable in page.derived_variables %}
+        <tr>
+          <td>
+            <code style="white-space: nowrap;">{{ variable.name }}</code>
+          </td>
+          <td>
+            <code>{{ variable.value }}</code>
+          </td>
+        </tr>
+      {% endfor %}
+    </table>
+
+    {% include anchor.html name="Generic variables" %}
+
+    <div class="content">
+      <p>
+        The following generic variables are provided in <code>./sass/base/generic.sass</code>.
+      </p>
+    </div>
+
+    <table class="table is-bordered is-striped">
+      {% for variable in page.generic_variables %}
         <tr>
           <td>
             <code style="white-space: nowrap;">{{ variable.name }}</code>


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

### Proposed solution

Update outdated references to variables in addition to adding missing ones such as the following:

- section variables
- footer variables
- form generic variables - `$control-*`, `$label-*`, `$help-size`
- generic variables from `./sass/base/generic.sass`


### Tradeoffs

Can't think of any


### Testing Done

Done locally using `jekyll serve --config _config.local.yml`


### Additional Notes

This process is done manually which is prone to errors; we should automate it.

This can be easily achieved using something like a custom Jekyll plugin, but that's not possible as custom plugins are understandably disabled in GitHub pages.  One way around this, is to use a [CI](https://en.wikipedia.org/wiki/Continuous_integration) tool, such as [travis-ci](https://travis-ci.org/), and setup a script that would handle the building of the static files every time a commit is pushed.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Run `npm install` to install all Bulma dependencies -->
<!-- 3. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 4. If your PR fixes an issue, reference that issue -->
<!-- 5. If your PR has lots of commits, **rebase** first -->
<!-- 6. Your PR should only affect `.sass` and documentation files -->
