### PR TITLE
Remove iTemplate from from related projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ Browse the [online documentation here.](http://bulma.io/documentation/overview/s
 |------------------------------------------------------------------------------------|--------------------------------------------------------------------|
 | [Bulma with Attribute Modules](https://github.com/j5bot/bulma-attribute-selectors) | Adds support for attribute-based selectors.                        |
 | [Bulma with Rails](https://github.com/joshuajansen/bulma-rails)                    | Integrates Bulma with the rails asset pipeline                     |
-| [iTemplate](http://itemplate.ga/)                                                  | Admin Dashboard based on Bulma                                     |
 | [Vue Admin](https://github.com/vue-bulma/vue-admin)                                | Vue Admin framework powered by Bulma                               |
 | [Bulmaswatch](https://github.com/jenil/bulmaswatch)                                | Free themes for Bulma                                              |
 | [Goldfish](https://github.com/Caiyeon/goldfish)                                    | Vault UI with Bulma, Golang, and Vue Admin                         |


### PR DESCRIPTION
I was checking out the related projects and the link to iTemplate project appears to have been hijacked and redirected to a suspect site. It should be removed until @bendo01 fixes the link, or alternatively change to project repository.

**Redirects to freenom.link**
![screencap](https://user-images.githubusercontent.com/7320379/30960267-5fa011d8-a3f7-11e7-8538-9ea74854a2c1.jpg)
