### PR TITLE
Feature: allow default table styles to be opt in (instead of mandatory) 

### DIFF
--- a/sass/base/generic.sass
+++ b/sass/base/generic.sass
@@ -118,7 +118,7 @@ pre
     font-size: 1em
     padding: 0
 
-table
+.table
   td,
   th
     text-align: left

--- a/sass/elements/content.sass
+++ b/sass/elements/content.sass
@@ -106,7 +106,7 @@ $content-table-foot-cell-color: $text-strong !default
   sup,
   sub
     font-size: 75%
-  table
+  .table
     width: 100%
     td,
     th


### PR DESCRIPTION
### Proposed solution

I am using bulma and I need to use `table>` element without bulma's default styles.

However in generic.sass and content.sass, the styles are applied to "table" instead of ".table".
The styles in content.sass, in particular, can not be overridden without "!important" 

This PR changes the selectors from "table" to ".table", so users have to specifically opt in for the generic styles to trigger.
 
### Tradeoffs

There is no trade-off other than adding class "table" for generic styles to kick in.

Technically, this is a minor breaking change. However bulma docs advocate using ".table" for styling anyway. So  this should be standard practice anyway

### Testing Done

Yep, I have successfully built it and tested it against my project.

PS: this is a duplicate of #1248 , I closed that one due to large number of changes shown in diff