### PR TITLE
Added .is-up modifier for dropdown.

### DIFF
--- a/docs/documentation/components/dropdown.html
+++ b/docs/documentation/components/dropdown.html
@@ -192,6 +192,26 @@ variables:
 </div>
 {% endcapture %}
 
+{% capture dropdown_up_example %}
+<div class="dropdown is-up is-active">
+  <div class="dropdown-trigger">
+    <button class="button is-info" aria-haspopup="true" aria-controls="dropdown-menu7">
+      <span>Dropup button</span>
+      <span class="icon is-small">
+        <i class="fa fa-angle-up" aria-hidden="true"></i>
+      </span>
+    </button>
+  </div>
+  <div class="dropdown-menu" id="dropdown-menu7" role="menu">
+    <div class="dropdown-content">
+      <div class="dropdown-item">
+        <p>You can add the <code>is-up</code> modifier to have a dropdown menu that appears above the dropdown button.</p>
+      </div>
+    </div>
+  </div>
+</div>
+{% endcapture %}
+
 {% include subnav-components.html %}
 
 <section class="section">
@@ -326,6 +346,23 @@ variables:
       </div>
       <div class="column is-half">
         {% highlight html %}{{dropdown_right_example}}{% endhighlight %}
+      </div>
+    </div>
+
+    {% include anchor.html name="Dropup" %}
+
+    <div class="content">
+      <p>
+        You can add the <code>is-up</code> modifier to have a dropdown menu that appears above the dropdown button.
+      </p>
+    </div>
+
+    <div class="columns">
+      <div class="column is-half" style="display: flex; align-items: flex-end;">
+        {{dropdown_up_example}}
+      </div>
+      <div class="column is-half">
+        {% highlight html %}{{dropdown_up_example}}{% endhighlight %}
       </div>
     </div>
 

--- a/sass/components/dropdown.sass
+++ b/sass/components/dropdown.sass
@@ -25,6 +25,12 @@ $dropdown-divider-background-color: $border !default
     .dropdown-menu
       left: auto
       right: 0
+  &.is-up
+    .dropdown-menu
+      top: auto
+      bottom: 100%
+      padding-top: unset
+      padding-bottom: $dropdown-content-offset
 
 .dropdown-menu
   display: none


### PR DESCRIPTION
### Proposed solution
This allows dropdown-menu to appear above the dropdown button by adding the .is-up modifier.

### Tradeoffs
Not really. More to gain. 👍 

### Testing Done
Yes. Attaching screenshot:
![2017-10-03_14-36-10](https://user-images.githubusercontent.com/1287077/31126378-e81ecfc4-a84b-11e7-8e2d-f24935156b60.jpeg)
