### PR TITLE
Make class notation in documentation consistent with other usage.

### DIFF
--- a/docs/documentation/modifiers/typography-helpers.html
+++ b/docs/documentation/modifiers/typography-helpers.html
@@ -204,24 +204,24 @@ doc-subtab: typography-helpers
         </tr>
       </thead>
       <tbody>
-        <tr><td><code>.has-text-white</code></td><td>{% include color/white.html %}</td></tr>
-        <tr><td><code>.has-text-black</code></td><td>{% include color/black.html %}</td></tr>
-        <tr><td><code>.has-text-light</code></td><td>{% include color/white-ter.html %}</td></tr>
-        <tr><td><code>.has-text-dark</code></td><td>{% include color/grey-darker.html %}</td></tr>
-        <tr><td><code>.has-text-primary</code></td><td>{% include color/turquoise.html %}</td></tr>
-        <tr><td><code>.has-text-info</code></td><td>{% include color/blue.html %}</td></tr>
-        <tr><td><code>.has-text-success</code></td><td>{% include color/green.html %}</td></tr>
-        <tr><td><code>.has-text-warning</code></td><td>{% include color/yellow.html %}</td></tr>
-        <tr><td><code>.has-text-danger</code></td><td>{% include color/red.html %}</td></tr>
-        <tr><td><code>.has-text-black-bis</code></td><td>{% include color/black-bis.html %}</td></tr>
-        <tr><td><code>.has-text-black-ter</code></td><td>{% include color/black-ter.html %}</td></tr>
-        <tr><td><code>.has-text-grey-darker</code></td><td>{% include color/grey-darker.html %}</td></tr>
-        <tr><td><code>.has-text-grey-dark</code></td><td>{% include color/grey-dark.html %}</td></tr>
-        <tr><td><code>.has-text-grey</code></td><td>{% include color/grey.html %}</td></tr>
-        <tr><td><code>.has-text-grey-light</code></td><td>{% include color/grey-light.html %}</td></tr>
-        <tr><td><code>.has-text-grey-lighter</code></td><td>{% include color/grey-lighter.html %}</td></tr>
-        <tr><td><code>.has-text-white-ter</code></td><td>{% include color/white-ter.html %}</td></tr>
-        <tr><td><code>.has-text-white-bis</code></td><td>{% include color/white-bis.html %}</td></tr>
+        <tr><td><code>has-text-white</code></td><td>{% include color/white.html %}</td></tr>
+        <tr><td><code>has-text-black</code></td><td>{% include color/black.html %}</td></tr>
+        <tr><td><code>has-text-light</code></td><td>{% include color/white-ter.html %}</td></tr>
+        <tr><td><code>has-text-dark</code></td><td>{% include color/grey-darker.html %}</td></tr>
+        <tr><td><code>has-text-primary</code></td><td>{% include color/turquoise.html %}</td></tr>
+        <tr><td><code>has-text-info</code></td><td>{% include color/blue.html %}</td></tr>
+        <tr><td><code>has-text-success</code></td><td>{% include color/green.html %}</td></tr>
+        <tr><td><code>has-text-warning</code></td><td>{% include color/yellow.html %}</td></tr>
+        <tr><td><code>has-text-danger</code></td><td>{% include color/red.html %}</td></tr>
+        <tr><td><code>has-text-black-bis</code></td><td>{% include color/black-bis.html %}</td></tr>
+        <tr><td><code>has-text-black-ter</code></td><td>{% include color/black-ter.html %}</td></tr>
+        <tr><td><code>has-text-grey-darker</code></td><td>{% include color/grey-darker.html %}</td></tr>
+        <tr><td><code>has-text-grey-dark</code></td><td>{% include color/grey-dark.html %}</td></tr>
+        <tr><td><code>has-text-grey</code></td><td>{% include color/grey.html %}</td></tr>
+        <tr><td><code>has-text-grey-light</code></td><td>{% include color/grey-light.html %}</td></tr>
+        <tr><td><code>has-text-grey-lighter</code></td><td>{% include color/grey-lighter.html %}</td></tr>
+        <tr><td><code>has-text-white-ter</code></td><td>{% include color/white-ter.html %}</td></tr>
+        <tr><td><code>has-text-white-bis</code></td><td>{% include color/white-bis.html %}</td></tr>
       </tbody>
     </table>
 
@@ -246,19 +246,19 @@ doc-subtab: typography-helpers
       </thead>
       <tbody>
         <tr>
-        <td><code>.has-text-centered</code></td>
+        <td><code>has-text-centered</code></td>
         <td>Makes the text <strong>centered</strong></td>
         </tr>
         <tr>
-        <td><code>.has-text-justified</code></td>
+        <td><code>has-text-justified</code></td>
         <td>Makes the text <strong>justified</strong></td>
         </tr>
         <tr>
-        <td><code>.has-text-left</code></td>
+        <td><code>has-text-left</code></td>
         <td>Makes the text aligned to the <strong>left</strong></td>
         </tr>
         <tr>
-        <td><code>.has-text-right</code></td>
+        <td><code>has-text-right</code></td>
         <td>Makes the text aligned to the <strong>right</strong></td>
         </tr>
       </tbody>
@@ -272,7 +272,7 @@ doc-subtab: typography-helpers
       </p>
 
       <p>
-        For example, here are the modifiers for <code>.has-text-left</code>:
+        For example, here are the modifiers for <code>has-text-left</code>:
       </p>
     </div>
 
@@ -375,15 +375,15 @@ doc-subtab: typography-helpers
       </thead>
       <tbody>
       <tr>
-        <td><code>.is-capitalized</code></td>
+        <td><code>is-capitalized</code></td>
         <td>Transforms <strong>the first character</strong> of each word to <strong>uppercase</strong></td>
       </tr>
       <tr>
-        <td><code>.is-lowercase</code></td>
+        <td><code>is-lowercase</code></td>
         <td>Transforms all characters to <strong>lowercase</strong></td>
       </tr>
       <tr>
-        <td><code>.is-uppercase</code></td>
+        <td><code>is-uppercase</code></td>
         <td>Transforms all characters to <strong>uppercase</strong></td>
       </tr>
       </tbody>
@@ -410,19 +410,19 @@ doc-subtab: typography-helpers
       </thead>
       <tbody>
       <tr>
-        <td><code>.has-text-weight-light</code></td>
+        <td><code>has-text-weight-light</code></td>
         <td>Transforms  text weight to <strong>light</strong></td>
       </tr>
       <tr>
-        <td><code>.has-text-weight-normal</code></td>
+        <td><code>has-text-weight-normal</code></td>
         <td>Transforms text weight to <strong>normal</strong></td>
       </tr>
       <tr>
-        <td><code>.has-text-weight-semibold</code></td>
+        <td><code>has-text-weight-semibold</code></td>
         <td>Transforms text weight to <strong>semi-bold</strong></td>
       </tr>
       <tr>
-        <td><code>.has-text-weight-bold</code></td>
+        <td><code>has-text-weight-bold</code></td>
         <td>Transforms text weight to <strong>bold</strong></td>
       </tr>
       </tbody>


### PR DESCRIPTION
This is a cosmetic adjustment to the documentation. A class is `foo`, not `.foo`.  Most of the documentation is correct in this regard; make the typographer helpers consistent.