### PR TITLE
Include placeholder mixin in input

### DIFF
--- a/sass/elements/form.sass
+++ b/sass/elements/form.sass
@@ -45,6 +45,8 @@ $help-size: $size-small !default
   background-color: $input-background-color
   border-color: $input-border-color
   color: $input-color
+  +placeholder
+    color: rgba($input-color, 0.3)
   &:hover,
   &.is-hovered
     border-color: $input-hover-border-color


### PR DESCRIPTION
...so that its color is consistent with $input-color.

<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->
`.input[disabled]` already includes placeholder mixin, feels like `.input`should also do that.
### Tradeoffs
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->
None.

### Testing Done
<!-- How have you confirmed this feature works? -->
Tested on my local branch, seems to work as expected.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Run `npm install` to install all Bulma dependencies -->
<!-- 3. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 4. If your PR fixes an issue, reference that issue -->
<!-- 5. If your PR has lots of commits, **rebase** first -->
<!-- 6. Your PR should only affect `.sass` and documentation files -->
