### PR TITLE
Add jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ bower install bulma
 
 ### CDN
 
+[https://www.jsdelivr.com/package/npm/bulma](https://www.jsdelivr.com/package/npm/bulma)
+
 [https://cdnjs.com/libraries/bulma](https://cdnjs.com/libraries/bulma)
 
 Feel free to raise an issue or submit a pull request.


### PR DESCRIPTION
<!-- Choose one of the following: -->
This is a **documentation fix**.


### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
I added a [jsDelivr CDN link](https://www.jsdelivr.com/package/npm/bulma) to your readme as an alternative to cdnjs. jsDelivr is the fastest opensource CDN available and built specifically for production usage. It can instantly serve any project from npm with zero config and offers a large network and better reliability.


