### PR TITLE
fix: Typo in 'Progress'

### DIFF
--- a/docs/documentation/elements/progress.html
+++ b/docs/documentation/elements/progress.html
@@ -1,5 +1,5 @@
 ---
-title: Progess Bar
+title: Progress Bar
 layout: documentation
 doc-tab: elements
 doc-subtab: progress

--- a/docs/versions/0.5.0/documentation/elements/progress/index.html
+++ b/docs/versions/0.5.0/documentation/elements/progress/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Bulma v0.5.0 is an open source CSS framework based on Flexbox and built with Sass. It's 100% responsive, fully modular, and available for free.">
 
-  <title>Progess Bar | Bulma v0.5.0: a modern CSS framework based on Flexbox</title>
+  <title>Progress Bar | Bulma v0.5.0: a modern CSS framework based on Flexbox</title>
 
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css">
   <link rel="stylesheet" href="http://bulma.io/versions/0.5.0/css/bulma-docs.css">

--- a/docs/versions/0.5.1/documentation/elements/progress/index.html
+++ b/docs/versions/0.5.1/documentation/elements/progress/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Bulma v0.5.1 is an open source CSS framework based on Flexbox and built with Sass. It's 100% responsive, fully modular, and available for free.">
 
-  <title>Progess Bar | Bulma v0.5.1: a modern CSS framework based on Flexbox</title>
+  <title>Progress Bar | Bulma v0.5.1: a modern CSS framework based on Flexbox</title>
 
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css">
   <link rel="stylesheet" href="http://bulma.io/versions/0.5.1/css/bulma-docs.css">

--- a/docs/versions/0.5.1/versions/0.5.0/documentation/elements/progress/index.html
+++ b/docs/versions/0.5.1/versions/0.5.0/documentation/elements/progress/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Bulma v0.5.0 is an open source CSS framework based on Flexbox and built with Sass. It's 100% responsive, fully modular, and available for free.">
 
-  <title>Progess Bar | Bulma v0.5.0: a modern CSS framework based on Flexbox</title>
+  <title>Progress Bar | Bulma v0.5.0: a modern CSS framework based on Flexbox</title>
 
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css">
   <link rel="stylesheet" href="http://bulma.io/versions/0.5.0/css/bulma-docs.css">

--- a/docs/versions/0.5.2/documentation/elements/progress/index.html
+++ b/docs/versions/0.5.2/documentation/elements/progress/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Bulma v0.5.2 is an open source CSS framework based on Flexbox and built with Sass. It's 100% responsive, fully modular, and available for free.">
 
-  <title>Progess Bar | Bulma v0.5.2: a modern CSS framework based on Flexbox</title>
+  <title>Progress Bar | Bulma v0.5.2: a modern CSS framework based on Flexbox</title>
 
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
   

--- a/docs/versions/0.5.2/versions/0.5.0/documentation/elements/progress/index.html
+++ b/docs/versions/0.5.2/versions/0.5.0/documentation/elements/progress/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Bulma v0.5.0 is an open source CSS framework based on Flexbox and built with Sass. It's 100% responsive, fully modular, and available for free.">
 
-  <title>Progess Bar | Bulma v0.5.0: a modern CSS framework based on Flexbox</title>
+  <title>Progress Bar | Bulma v0.5.0: a modern CSS framework based on Flexbox</title>
 
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css">
   <link rel="stylesheet" href="http://bulma.io/versions/0.5.0/css/bulma-docs.css">

--- a/docs/versions/0.5.2/versions/0.5.1/documentation/elements/progress/index.html
+++ b/docs/versions/0.5.2/versions/0.5.1/documentation/elements/progress/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Bulma v0.5.1 is an open source CSS framework based on Flexbox and built with Sass. It's 100% responsive, fully modular, and available for free.">
 
-  <title>Progess Bar | Bulma v0.5.1: a modern CSS framework based on Flexbox</title>
+  <title>Progress Bar | Bulma v0.5.1: a modern CSS framework based on Flexbox</title>
 
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css">
   <link rel="stylesheet" href="http://bulma.io/versions/0.5.1/css/bulma-docs.css">

--- a/docs/versions/0.5.2/versions/0.5.1/versions/0.5.0/documentation/elements/progress/index.html
+++ b/docs/versions/0.5.2/versions/0.5.1/versions/0.5.0/documentation/elements/progress/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Bulma v0.5.0 is an open source CSS framework based on Flexbox and built with Sass. It's 100% responsive, fully modular, and available for free.">
 
-  <title>Progess Bar | Bulma v0.5.0: a modern CSS framework based on Flexbox</title>
+  <title>Progress Bar | Bulma v0.5.0: a modern CSS framework based on Flexbox</title>
 
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css">
   <link rel="stylesheet" href="http://bulma.io/versions/0.5.0/css/bulma-docs.css">

--- a/docs/versions/0.5.3/documentation/elements/progress/index.html
+++ b/docs/versions/0.5.3/documentation/elements/progress/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Bulma v0.5.3 is an open source CSS framework based on Flexbox and built with Sass. It's 100% responsive, fully modular, and available for free.">
 
-  <title>Progess Bar | Bulma v0.5.3: a modern CSS framework based on Flexbox</title>
+  <title>Progress Bar | Bulma v0.5.3: a modern CSS framework based on Flexbox</title>
 
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
   

--- a/docs/versions/0.5.3/versions/0.5.0/documentation/elements/progress/index.html
+++ b/docs/versions/0.5.3/versions/0.5.0/documentation/elements/progress/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Bulma v0.5.0 is an open source CSS framework based on Flexbox and built with Sass. It's 100% responsive, fully modular, and available for free.">
 
-  <title>Progess Bar | Bulma v0.5.0: a modern CSS framework based on Flexbox</title>
+  <title>Progress Bar | Bulma v0.5.0: a modern CSS framework based on Flexbox</title>
 
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css">
   <link rel="stylesheet" href="http://bulma.io/versions/0.5.0/css/bulma-docs.css">

--- a/docs/versions/0.5.3/versions/0.5.1/documentation/elements/progress/index.html
+++ b/docs/versions/0.5.3/versions/0.5.1/documentation/elements/progress/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Bulma v0.5.1 is an open source CSS framework based on Flexbox and built with Sass. It's 100% responsive, fully modular, and available for free.">
 
-  <title>Progess Bar | Bulma v0.5.1: a modern CSS framework based on Flexbox</title>
+  <title>Progress Bar | Bulma v0.5.1: a modern CSS framework based on Flexbox</title>
 
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css">
   <link rel="stylesheet" href="http://bulma.io/versions/0.5.1/css/bulma-docs.css">

--- a/docs/versions/0.5.3/versions/0.5.1/versions/0.5.0/documentation/elements/progress/index.html
+++ b/docs/versions/0.5.3/versions/0.5.1/versions/0.5.0/documentation/elements/progress/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Bulma v0.5.0 is an open source CSS framework based on Flexbox and built with Sass. It's 100% responsive, fully modular, and available for free.">
 
-  <title>Progess Bar | Bulma v0.5.0: a modern CSS framework based on Flexbox</title>
+  <title>Progress Bar | Bulma v0.5.0: a modern CSS framework based on Flexbox</title>
 
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css">
   <link rel="stylesheet" href="http://bulma.io/versions/0.5.0/css/bulma-docs.css">

--- a/docs/versions/0.5.3/versions/0.5.2/documentation/elements/progress/index.html
+++ b/docs/versions/0.5.3/versions/0.5.2/documentation/elements/progress/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Bulma v0.5.2 is an open source CSS framework based on Flexbox and built with Sass. It's 100% responsive, fully modular, and available for free.">
 
-  <title>Progess Bar | Bulma v0.5.2: a modern CSS framework based on Flexbox</title>
+  <title>Progress Bar | Bulma v0.5.2: a modern CSS framework based on Flexbox</title>
 
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
   

--- a/docs/versions/0.5.3/versions/0.5.2/versions/0.5.0/documentation/elements/progress/index.html
+++ b/docs/versions/0.5.3/versions/0.5.2/versions/0.5.0/documentation/elements/progress/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Bulma v0.5.0 is an open source CSS framework based on Flexbox and built with Sass. It's 100% responsive, fully modular, and available for free.">
 
-  <title>Progess Bar | Bulma v0.5.0: a modern CSS framework based on Flexbox</title>
+  <title>Progress Bar | Bulma v0.5.0: a modern CSS framework based on Flexbox</title>
 
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css">
   <link rel="stylesheet" href="http://bulma.io/versions/0.5.0/css/bulma-docs.css">

--- a/docs/versions/0.5.3/versions/0.5.2/versions/0.5.1/documentation/elements/progress/index.html
+++ b/docs/versions/0.5.3/versions/0.5.2/versions/0.5.1/documentation/elements/progress/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Bulma v0.5.1 is an open source CSS framework based on Flexbox and built with Sass. It's 100% responsive, fully modular, and available for free.">
 
-  <title>Progess Bar | Bulma v0.5.1: a modern CSS framework based on Flexbox</title>
+  <title>Progress Bar | Bulma v0.5.1: a modern CSS framework based on Flexbox</title>
 
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css">
   <link rel="stylesheet" href="http://bulma.io/versions/0.5.1/css/bulma-docs.css">

--- a/docs/versions/0.5.3/versions/0.5.2/versions/0.5.1/versions/0.5.0/documentation/elements/progress/index.html
+++ b/docs/versions/0.5.3/versions/0.5.2/versions/0.5.1/versions/0.5.0/documentation/elements/progress/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Bulma v0.5.0 is an open source CSS framework based on Flexbox and built with Sass. It's 100% responsive, fully modular, and available for free.">
 
-  <title>Progess Bar | Bulma v0.5.0: a modern CSS framework based on Flexbox</title>
+  <title>Progress Bar | Bulma v0.5.0: a modern CSS framework based on Flexbox</title>
 
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css">
   <link rel="stylesheet" href="http://bulma.io/versions/0.5.0/css/bulma-docs.css">


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **documentation fix**. It corrects the word "Progress" which was misspelled as "Progess" in some docs.