### PR TITLE
Remove merge conflicts from the built JS file. Fixes #1281.

### DIFF
--- a/docs/lib/main.js
+++ b/docs/lib/main.js
@@ -109,114 +109,12 @@ document.addEventListener('DOMContentLoaded', function () {
       var expandEl = '<button class="button is-small bd-expand">Expand</button>';
       $el.insertAdjacentHTML('beforeend', copyEl);
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> Add show code
-=======
->>>>>>> Improve snippet
-=======
->>>>>>> Improve snippet
-=======
->>>>>>> Fix rebase
-=======
-=======
->>>>>>> Add show code
->>>>>>> Add show code
-=======
->>>>>>> Improve snippet
-=======
->>>>>>> Fix rebase
-=======
->>>>>>> Build assets
       var $parent = $el.parentNode;
       if ($parent && $parent.classList.contains('bd-is-more')) {
         var showEl = '<button class="bd-show"><div><span class="icon"><i class="fa fa-code"></i></span> <strong>Show code</strong></div></button>';
         $el.insertAdjacentHTML('beforeend', showEl);
       } else if ($el.firstElementChild.scrollHeight > 480 && $el.firstElementChild.clientHeight <= 480) {
         $el.insertAdjacentHTML('beforeend', expandEl);
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-      if ($el.firstElementChild.scrollHeight > 480 && $el.firstElementChild.clientHeight <= 480) {
-        $el.insertAdjacentHTML('beforeend', expandEl);
-      }
-
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> Add show code
-=======
->>>>>>> Improve snippet
-      var $parent = $el.parentNode;
-      if ($parent && $parent.classList.contains('bd-is-more')) {
-        var showEl = '<button class="bd-show"><div><span class="icon"><i class="fa fa-code"></i></span> <strong>Show code</strong></div></button>';
-        $el.insertAdjacentHTML('beforeend', showEl);
-<<<<<<< HEAD
->>>>>>> Add show code
-=======
-      } else if ($el.firstElementChild.scrollHeight > 480 && $el.firstElementChild.clientHeight <= 480) {
-        $el.insertAdjacentHTML('beforeend', expandEl);
->>>>>>> Improve snippet
-=======
-<<<<<<< HEAD
-=======
->>>>>>> Improve snippet
-=======
-=======
->>>>>>> Improve snippet
->>>>>>> Improve snippet
-      var $parent = $el.parentNode;
-      if ($parent && $parent.classList.contains('bd-is-more')) {
-        var showEl = '<button class="bd-show"><div><span class="icon"><i class="fa fa-code"></i></span> <strong>Show code</strong></div></button>';
-        $el.insertAdjacentHTML('beforeend', showEl);
-<<<<<<< HEAD
->>>>>>> Add show code
-<<<<<<< HEAD
->>>>>>> Add show code
-=======
-=======
-      } else if ($el.firstElementChild.scrollHeight > 480 && $el.firstElementChild.clientHeight <= 480) {
-        $el.insertAdjacentHTML('beforeend', expandEl);
->>>>>>> Improve snippet
->>>>>>> Improve snippet
-=======
-<<<<<<< HEAD
-=======
-=======
->>>>>>> Improve snippet
->>>>>>> Improve snippet
-      var $parent = $el.parentNode;
-      if ($parent && $parent.classList.contains('bd-is-more')) {
-        var showEl = '<button class="bd-show"><div><span class="icon"><i class="fa fa-code"></i></span> <strong>Show code</strong></div></button>';
-        $el.insertAdjacentHTML('beforeend', showEl);
-<<<<<<< HEAD
->>>>>>> Add show code
-<<<<<<< HEAD
->>>>>>> Add show code
-<<<<<<< HEAD
->>>>>>> Add show code
-=======
-=======
-=======
-      } else if ($el.firstElementChild.scrollHeight > 480 && $el.firstElementChild.clientHeight <= 480) {
-        $el.insertAdjacentHTML('beforeend', expandEl);
->>>>>>> Improve snippet
->>>>>>> Improve snippet
->>>>>>> Improve snippet
-=======
->>>>>>> Fix rebase
->>>>>>> Fix rebase
-=======
->>>>>>> Build assets
       }
 
       itemsProcessed++;
@@ -247,107 +145,11 @@ document.addEventListener('DOMContentLoaded', function () {
       });
     });
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> Improve snippet
-=======
->>>>>>> Add show code
-=======
-=======
->>>>>>> Fix rebase
-=======
->>>>>>> Improve snippet
->>>>>>> Improve snippet
-=======
->>>>>>> Build assets
     var $highlightShows = getAll('.highlight .bd-show');
 
     $highlightShows.forEach(function ($el) {
       $el.addEventListener('click', function () {
         $el.parentNode.parentNode.classList.remove('bd-is-more-clipped');
-<<<<<<< HEAD
-=======
-    var $highlightShows = getAll('.bd-highlight-clipped .bd-show');
-
-    $highlightShows.forEach(function ($el) {
-      $el.addEventListener('click', function () {
-        $el.parentNode.classList.remove('bd-is-clipped');
->>>>>>> Add show code
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> Add show code
-=======
->>>>>>> Improve snippet
-=======
-=======
->>>>>>> Add show code
->>>>>>> Add show code
-=======
-=======
->>>>>>> Add show code
-=======
->>>>>>> Improve snippet
-<<<<<<< HEAD
->>>>>>> Improve snippet
-=======
-=======
->>>>>>> Fix rebase
->>>>>>> Fix rebase
-    var $highlightShows = getAll('.highlight .bd-show');
-
-    $highlightShows.forEach(function ($el) {
-      $el.addEventListener('click', function () {
-        $el.parentNode.parentNode.classList.remove('bd-is-more-clipped');
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
->>>>>>> Improve snippet
-=======
-=======
-    var $highlightShows = getAll('.bd-highlight-clipped .bd-show');
-
-    $highlightShows.forEach(function ($el) {
-      $el.addEventListener('click', function () {
-        $el.parentNode.classList.remove('bd-is-clipped');
->>>>>>> Add show code
->>>>>>> Add show code
-=======
->>>>>>> Improve snippet
-=======
->>>>>>> Add show code
-=======
->>>>>>> Improve snippet
-=======
->>>>>>> Fix rebase
->>>>>>> Improve snippet
-=======
-=======
-    var $highlightShows = getAll('.bd-highlight-clipped .bd-show');
-
-    $highlightShows.forEach(function ($el) {
-      $el.addEventListener('click', function () {
-        $el.parentNode.classList.remove('bd-is-clipped');
->>>>>>> Add show code
->>>>>>> Add show code
-=======
->>>>>>> Improve snippet
->>>>>>> Improve snippet
-=======
->>>>>>> Fix rebase
-=======
->>>>>>> Build assets
       });
     });
   }


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **documentation fix**.

### Proposed solution
This PR simply rebuilds the main Javascript library in the docs to get rid of the merge conflicts. Fixes issue #1281.

### Tradeoffs
N/A

### Testing Done
After rebuilding `main.js`, the Javascript examples in the documentation now work as expected.
