### PR TITLE
Adds Laravel-Enso to related projects in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Browse the [online documentation here.](http://bulma.io/documentation/overview/s
 | [elm-bulma-classes](https://github.com/danielnarey/elm-bulma-classes)              | Bulma prepared for usage with ELM                                  |
 | [Bulma Customizer](https://bulma-customizer.bstash.io/)                            | Bulma Customizer &#8211; Create your own **bespoke** Bulma build   |
 | [Fulma](https://mangelmaxime.github.io/Fulma/)                                     | Wrapper around Bulma for [fable-react](https://github.com/fable-compiler/fable-react)   |
+| [Laravel Enso](https://github.com/laravel-enso/enso)                               | SPA Admin Panel built with Bulma, VueJS and Laravel 			      |
 
 ## Copyright and license
 


### PR DESCRIPTION
Proposed

We migrated our project, Laravel-Enso, from a conventional web app based on AdminLTE and Bootstrap to a whole new SPA. The code is open-source and we want to share it with the community. The documentation will be updated in the following weeks.

Tradeoffs

Nothing. 