### PR TITLE
visibility: hidden !important

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Bulma Changelog
 
+## 0.6.1
+
+### New features
+
+* #1287 New `.is-invisible` helper
+
 ## 0.6.0
 
 ### Breaking changes

--- a/docs/documentation/modifiers/helpers.html
+++ b/docs/documentation/modifiers/helpers.html
@@ -37,7 +37,7 @@ doc-subtab: helpers
           <td>Removes any <strong>padding</strong></td>
         </tr>
         <tr>
-          <th rowspan="5">Other</th>
+          <th rowspan="6">Other</th>
           <td><code>is-overlay</code></td>
           <td>Completely covers the first positioned parent</td>
         </tr>

--- a/docs/documentation/modifiers/helpers.html
+++ b/docs/documentation/modifiers/helpers.html
@@ -56,6 +56,10 @@ doc-subtab: helpers
           <td><code>is-unselectable</code></td>
           <td>Prevents the text from being <strong>selectable</strong></td>
         </tr>
+        <tr>
+          <td><code>is-invisible</code></td>
+          <td>Adds visibility <strong>hidden</strong></td>
+        </tr>
       </tbody>
     </table>
   </div>

--- a/sass/base/helpers.sass
+++ b/sass/base/helpers.sass
@@ -185,6 +185,45 @@ $displays: 'block' 'flex' 'inline' 'inline-block' 'inline-flex'
   .is-hidden-fullhd
     display: none !important
 
+.is-invisible
+  visibility: hidden !important
+
++mobile
+  .is-invisible-mobile
+    visibility: hidden !important
+
++tablet
+  .is-invisible-tablet
+    visibility: hidden !important
+
++tablet-only
+  .is-invisible-tablet-only
+    visibility: hidden !important
+
++touch
+  .is-invisible-touch
+    visibility: hidden !important
+
++desktop
+  .is-invisible-desktop
+    visibility: hidden !important
+
++desktop-only
+  .is-invisible-desktop-only
+    visibility: hidden !important
+
++widescreen
+  .is-invisible-widescreen
+    visibility: hidden !important
+
++widescreen-only
+  .is-invisible-widescreen-only
+    visibility: hidden !important
+
++fullhd
+  .is-invisible-fullhd
+    visibility: hidden !important
+
 // Other
 
 .is-marginless


### PR DESCRIPTION
This is a **new feature**.

### Proposed solution
By using new `.is-invisible` helper the login/registration form will not be resized after showing/hiding error labels.

![Animation](https://user-images.githubusercontent.com/30025319/31443682-75d16ec2-ae9a-11e7-98ba-ff200dbc0e84.gif)
![Error Animation](https://user-images.githubusercontent.com/30025319/31443685-776c4d60-ae9a-11e7-900a-fc012e1f2f38.gif)


### Testing Done
Tested by running `npm run build` successfully and using `.is-invisible` helper also.