### PR TITLE
Disable table hover in .content #1295

### DIFF
--- a/docs/documentation/elements/content.html
+++ b/docs/documentation/elements/content.html
@@ -26,8 +26,6 @@ variables:
   value: 0.5em 0.75em
 - name: $content-table-cell-heading-color
   value: $text-strong
-- name: $content-table-row-hover-background-color
-  value: $background
 - name: $content-table-head-cell-border-width
   value: 0 0 2px
 - name: $content-table-head-cell-color

--- a/sass/elements/content.sass
+++ b/sass/elements/content.sass
@@ -12,7 +12,6 @@ $content-table-cell-border: 1px solid $border !default
 $content-table-cell-border-width: 0 0 1px !default
 $content-table-cell-padding: 0.5em 0.75em !default
 $content-table-cell-heading-color: $text-strong !default
-$content-table-row-hover-background-color: $background !default
 $content-table-head-cell-border-width: 0 0 2px !default
 $content-table-head-cell-color: $text-strong !default
 $content-table-foot-cell-border-width: 2px 0 0 !default

--- a/sass/elements/content.sass
+++ b/sass/elements/content.sass
@@ -117,9 +117,6 @@ $content-table-foot-cell-color: $text-strong !default
     th
       color: $content-table-cell-heading-color
       text-align: left
-    tr
-      &:hover
-        background-color: $content-table-row-hover-background-color
     thead
       td,
       th


### PR DESCRIPTION
This is about **Bulma**.

<!-- Is it a bug/feature/question or do you need help? -->
<!-- If it's a bug, is it a browser bug? -->

### Overview of the problem

<!-- UNCOMMENT THE APPROPRIATE LINES -->

This is about the Bulma **CSS framework**
I'm using Bulma **version** [0.6.0] 

### Description

Referencing #1236 - this issue of the table row `:hover` behaviour is also set as default to `.table` inside `.content` class elements. I propose that we remove this behaviour as default, inline with #1236 as it caught me out after upgrading bulma just to avoid this. 

### Expected behavior

When hovering on a table, by default nothing should happen, only if `.is-hoverable` is added should the visual state change.

### Actual behavior

When interacting with a `.table` within `.content` the hover state is applied by default.
