### PR TITLE
Fixes #1308, rainbow button glitch

### DIFF
--- a/docs/_sass/love.sass
+++ b/docs/_sass/love.sass
@@ -64,11 +64,11 @@
 
 @keyframes rainbow
     0%
-      background-position: 0% 80%
+      background-position: 1% 80%
     50%
-      background-position: 100% 20%
+      background-position: 99% 20%
     100%
-      background-position: 0% 80%
+      background-position: 1% 80%
 
 .bd-hug
   align-items: flex-start


### PR DESCRIPTION
This is a **bugfix**.

### Proposed solution
Initially, the keyframes transition from 0% to 100%, traversing till the edges of the gradient background and producing the glitch. This PR fixes it by making the transition happen between 1% to 99%.

### Tradeoffs
I don't think there is a tradeoff.

### Testing Done
Manually tested on all browsers, including mobile.