### PR TITLE
Removed the width property of .textarea.is-inline

### DIFF
--- a/sass/elements/form.sass
+++ b/sass/elements/form.sass
@@ -97,7 +97,6 @@ $help-size: $size-small !default
     width: 100%
   &.is-inline
     display: inline
-    width: auto
 
 .input
   &.is-static


### PR DESCRIPTION
This is a **bugfix**.

### Proposed solution
Remove the width property of the `.textarea.is-inline` class.

### Tradeoffs
The property is just ignored due to the display type (`display: inline`) therefore the removal is reasonable?

> For display: inline, the width, height, margin-top, margin-bottom, and float properties have no effect because inline elements don't have a formal box with which to apply the styles. 

### Testing Done
Tested by running `npm run build` successfully and using `.textarea.is-inline` class.