### PR TITLE
Stop is-selected row from changing color on hoverable row

### DIFF
--- a/sass/elements/table.sass
+++ b/sass/elements/table.sass
@@ -85,7 +85,7 @@ $table-striped-row-even-hover-background-color: $white-ter !default
     width: 100%
   &.is-hoverable
     tbody
-      tr
+      tr:not(.is-selected)
         &:hover
           background-color: $table-row-hover-background-color
     &.is-striped

--- a/sass/elements/table.sass
+++ b/sass/elements/table.sass
@@ -102,4 +102,3 @@ $table-striped-row-even-hover-background-color: $white-ter !default
       tr:not(.is-selected)
         &:nth-child(even)
           background-color: $table-striped-row-even-background-color
-


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **bugfix**, fixing #1313.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution
Fixes #1313, where instead of using the base active hover color for a table, will only apply that color if the table itself is not hoverable.
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

### Tradeoffs
This doesn't show any visual difference when hovering over an row that has `is-selected` applied to it.
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->

### Testing Done
I checked the style based on the example in the documentation by adding `is-hoverable` to the table demonstrating the `is-selected` class.
<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

Side note: I'm not entirely sure why git considers this entire file to be changed, I only changed line 88.
<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Run `npm install` to install all Bulma dependencies -->
<!-- 3. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 4. Make sure your PR only affects `.sass` or documentation files -->

<!-- Thanks! -->
