### PR TITLE
Implement simple version of source tag for module docs

### DIFF
--- a/docs/_includes/meta.html
+++ b/docs/_includes/meta.html
@@ -25,6 +25,15 @@
     </div>
   {% endif %}
 
+  {% if include.module %}
+    <div class="control">
+      <div class="tags has-addons">
+        <span class="tag">Source</span>
+        <span class="tag is-info">{{ include.module }}</span>
+      </div>
+    </div>
+  {% endif %}
+
   <div class="control">
     <div class="tags has-addons">
       <span class="tag">Colors</span>

--- a/docs/documentation/components/breadcrumb.html
+++ b/docs/documentation/components/breadcrumb.html
@@ -141,6 +141,7 @@ doc-subtab: breadcrumb
       variables=true
       colors=false
       sizes=true
+      module="components/breadcrumb.sass"
     %}
 
     <hr>

--- a/docs/documentation/layout/container.html
+++ b/docs/documentation/layout/container.html
@@ -45,6 +45,11 @@ doc-subtab: container
     <h2 class="subtitle">
       A simple <strong>container</strong> to center your content horizontally
     </h2>
+    {%
+      include meta.html
+      module="elements/container.sass"
+    %}
+
 
     <hr>
 

--- a/docs/documentation/layout/footer.html
+++ b/docs/documentation/layout/footer.html
@@ -27,6 +27,11 @@ doc-subtab: footer
     <h2 class="subtitle">
       A simple responsive <strong>footer</strong> which can include anything: lists, headings, columns, icons, buttons, etc.
     </h2>
+    {%
+      include meta.html
+      module="layout/footer.sass"
+    %}
+
 
     {% include snippet.html content=footer_example horizontal=true more=true %}
 

--- a/docs/documentation/layout/hero.html
+++ b/docs/documentation/layout/hero.html
@@ -13,6 +13,11 @@ doc-subtab: hero
     <h2 class="subtitle">
       An imposing <strong>hero banner</strong> to showcase something
     </h2>
+    {%
+      include meta.html
+      module="layout/hero.sass"
+    %}
+
   </div>
 </section>
 

--- a/docs/documentation/layout/level.html
+++ b/docs/documentation/layout/level.html
@@ -124,6 +124,11 @@ doc-subtab: level
   <div class="container">
     <h1 class="title">Level</h1>
     <h2 class="subtitle">A multi-purpose <strong>horizontal level</strong>, which can contain almost any other element</h2>
+    {%
+      include meta.html
+      module="components/level.sass"
+    %}
+
 
     <hr>
 

--- a/docs/documentation/layout/media-object.html
+++ b/docs/documentation/layout/media-object.html
@@ -162,6 +162,10 @@ doc-subtab: media-object
   <div class="container">
     <h1 class="title">Media Object</h1>
     <h2 class="subtitle">The famous <strong>media object</strong> prevalent in social media interfaces, but useful in any context</h2>
+    {%
+      include meta.html
+      module="components/media.sass"
+    %}
 
     <hr>
 

--- a/docs/documentation/layout/section.html
+++ b/docs/documentation/layout/section.html
@@ -13,6 +13,10 @@ doc-subtab: section
     <h2 class="subtitle">
       A simple container to divide your page into <strong>sections</strong>, like the one you're currently reading
     </h2>
+    {%
+      include meta.html
+      module="layout/section.sass"
+    %}
 
     <hr>
 

--- a/docs/documentation/layout/tiles.html
+++ b/docs/documentation/layout/tiles.html
@@ -11,6 +11,10 @@ doc-subtab: tiles
   <div class="container">
     <h1 class="title">Tiles</h1>
     <h2 class="subtitle">A <strong>single tile</strong> element to build 2-dimensional Metro-like, Pinterest-like, or whatever-you-like grids</h2>
+    {%
+      include meta.html
+      module="grid/tiles.sass"
+    %}
 
     <hr>
 


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **documentation improvement**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Run `npm install` to install all Bulma dependencies -->
<!-- 3. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 4. Make sure your PR only affects `.sass` or documentation files -->

<!-- Thanks! -->

As mentioned as in #1205 I think it would be a good idea to have source file links/references directly in the documentation. This is one idea on how to do this, I like the tag look 😄 .  I thought I would get some feedback before adding all of them (or implementing an automatic solution).
