### PR TITLE
Fix progress bar colors in IE

### DIFF
--- a/sass/elements/progress.sass
+++ b/sass/elements/progress.sass
@@ -18,6 +18,8 @@ $progress-value-background-color: $text !default
     background-color: $progress-value-background-color
   &::-moz-progress-bar
     background-color: $progress-value-background-color
+  &::-ms-fill
+    background-color: $progress-value-background-color
   // Colors
   @each $name, $pair in $colors
     $color: nth($pair, 1)
@@ -25,6 +27,8 @@ $progress-value-background-color: $text !default
       &::-webkit-progress-value
         background-color: $color
       &::-moz-progress-bar
+        background-color: $color
+      &::-ms-fill
         background-color: $color
   // Sizes
   &.is-small


### PR DESCRIPTION
This is a **bugfix** for progress bar colors in IE.

### Proposed solution

This PR adds the necessary `::-ms-fill` declarations to style the progress bar in IE, as explained here: https://developer.mozilla.org/en-US/docs/Web/CSS/::-ms-fill

Fixes #1333.

### Tradeoffs

This slightly increases the size of the build, but improves support for IE.  There are other `-ms-*` declarations in the code base so I think it is reasonable to add this.

### Testing Done

I built my branch of Bulma locally, added it to my project, removed my workaround, and confirmed that the progress bar color can be changed:

![ie_progress_fixed](https://user-images.githubusercontent.com/1829450/31733375-4a7c8b20-b3f0-11e7-816f-100a4023145c.png)
