### PR TITLE
Remove black line from progress bar in IE

### DIFF
--- a/sass/elements/progress.sass
+++ b/sass/elements/progress.sass
@@ -20,6 +20,7 @@ $progress-value-background-color: $text !default
     background-color: $progress-value-background-color
   &::-ms-fill
     background-color: $progress-value-background-color
+    border: none
   // Colors
   @each $name, $pair in $colors
     $color: nth($pair, 1)


### PR DESCRIPTION
This is a **bugfix** for inconsistent progress bar styling in IE.

### Proposed solution

This PR removes the border from the `::-ms-fill` pseudo-element of the progress bar.  The problem and solution are discussed in this SO post: https://stackoverflow.com/questions/21780059/why-are-my-progress-bars-displaying-incorrectly-in-ie

Fixes #1340.

### Tradeoffs

This adds one additional declaration to the build, but improves support for IE.

### Testing Done

I built my branch of Bulma locally, added it to my project, and confirmed that the progress bar looks as intended.

Before fix:

![progress_ie](https://user-images.githubusercontent.com/1829450/31830598-9401f560-b575-11e7-9196-042caf2ecebf.png)

After fix:

![progress_ie_fixed](https://user-images.githubusercontent.com/1829450/31778943-d20f557a-b4a6-11e7-8035-47656e5abdb7.png)