### PR TITLE
Adds sup and sub to titles and subtitles

### DIFF
--- a/sass/elements/title.sass
+++ b/sass/elements/title.sass
@@ -3,12 +3,16 @@ $title-size: $size-3 !default
 $title-weight: $weight-semibold !default
 $title-strong-color: inherit !default
 $title-strong-weight: inherit !default
+$title-sub-size: 75% !default
+$title-sup-size: 75% !default
 
 $subtitle-color: $grey-dark !default
 $subtitle-size: $size-5 !default
 $subtitle-weight: $weight-normal !default
 $subtitle-strong-color: $grey-darker !default
 $subtitle-strong-weight: $weight-semibold !default
+$subtitle-sub-size: 75% !default
+$subtitle-sup-size: 75% !default
 
 .title,
 .subtitle
@@ -29,9 +33,9 @@ $subtitle-strong-weight: $weight-semibold !default
     color: $title-strong-color
     font-weight: $title-strong-weight
   sub
-    font-size: calc(#{$title-size} - 50%)
+    font-size: $title-sub-size
   sup
-    font-size: calc(#{$title-size} - 50%)
+    font-size: $title-sup-size
   & + .highlight
     margin-top: -0.75rem
   &:not(.is-spaced) + .subtitle
@@ -41,10 +45,6 @@ $subtitle-strong-weight: $weight-semibold !default
     $i: index($sizes, $size)
     &.is-#{$i}
       font-size: $size
-      sub
-        font-size: calc(#{$size} - 50%)
-      sup
-        font-size: calc(#{$size} - 50%)
 
 .subtitle
   color: $subtitle-color
@@ -55,9 +55,9 @@ $subtitle-strong-weight: $weight-semibold !default
     color: $subtitle-strong-color
     font-weight: $subtitle-strong-weight
   sub
-    font-size: calc(#{$subtitle-size} - 50%)
+    font-size: $subtitle-sub-size
   sup
-    font-size: calc(#{$subtitle-size} - 50%)
+    font-size: $subtitle-sup-size
   &:not(.is-spaced) + .title
     margin-top: -1.5rem
   // Sizes
@@ -65,7 +65,3 @@ $subtitle-strong-weight: $weight-semibold !default
     $i: index($sizes, $size)
     &.is-#{$i}
       font-size: $size
-      sub
-        font-size: calc(#{$size} - 50%)
-      sup
-        font-size: calc(#{$size} - 50%)

--- a/sass/elements/title.sass
+++ b/sass/elements/title.sass
@@ -28,6 +28,10 @@ $subtitle-strong-weight: $weight-semibold !default
   strong
     color: $title-strong-color
     font-weight: $title-strong-weight
+  sub
+    font-size: calc(#{$title-size} - 50%)
+  sup
+    font-size: calc(#{$title-size} - 50%)
   & + .highlight
     margin-top: -0.75rem
   &:not(.is-spaced) + .subtitle
@@ -37,6 +41,10 @@ $subtitle-strong-weight: $weight-semibold !default
     $i: index($sizes, $size)
     &.is-#{$i}
       font-size: $size
+      sub
+        font-size: calc(#{$size} - 50%)
+      sup
+        font-size: calc(#{$size} - 50%)
 
 .subtitle
   color: $subtitle-color
@@ -46,6 +54,10 @@ $subtitle-strong-weight: $weight-semibold !default
   strong
     color: $subtitle-strong-color
     font-weight: $subtitle-strong-weight
+  sub
+    font-size: calc(#{$subtitle-size} - 50%)
+  sup
+    font-size: calc(#{$subtitle-size} - 50%)
   &:not(.is-spaced) + .title
     margin-top: -1.5rem
   // Sizes
@@ -53,3 +65,7 @@ $subtitle-strong-weight: $weight-semibold !default
     $i: index($sizes, $size)
     &.is-#{$i}
       font-size: $size
+      sub
+        font-size: calc(#{$size} - 50%)
+      sup
+        font-size: calc(#{$size} - 50%)

--- a/sass/elements/title.sass
+++ b/sass/elements/title.sass
@@ -11,8 +11,6 @@ $subtitle-size: $size-5 !default
 $subtitle-weight: $weight-normal !default
 $subtitle-strong-color: $grey-darker !default
 $subtitle-strong-weight: $weight-semibold !default
-$subtitle-sub-size: 75% !default
-$subtitle-sup-size: 75% !default
 
 .title,
 .subtitle
@@ -21,6 +19,10 @@ $subtitle-sup-size: 75% !default
   em,
   span
     font-weight: inherit
+  sub
+    font-size: $title-sub-size
+  sup
+    font-size: $title-sup-size
   .tag
     vertical-align: middle
 
@@ -32,10 +34,6 @@ $subtitle-sup-size: 75% !default
   strong
     color: $title-strong-color
     font-weight: $title-strong-weight
-  sub
-    font-size: $title-sub-size
-  sup
-    font-size: $title-sup-size
   & + .highlight
     margin-top: -0.75rem
   &:not(.is-spaced) + .subtitle
@@ -54,10 +52,6 @@ $subtitle-sup-size: 75% !default
   strong
     color: $subtitle-strong-color
     font-weight: $subtitle-strong-weight
-  sub
-    font-size: $subtitle-sub-size
-  sup
-    font-size: $subtitle-sup-size
   &:not(.is-spaced) + .title
     margin-top: -1.5rem
   // Sizes


### PR DESCRIPTION
This is a **new improvement**.

### Proposed solution
This PR fixes sizing when using either `<sub>` and `<sup>` elements inside a .title element.

### Testing Done
Compiled with yarn and tested across all of the various sizes and configurations.

Before:
<img width="178" alt="screen shot 2017-10-19 at 11 31 59 pm" src="https://user-images.githubusercontent.com/6202961/31795926-f9294ec8-b527-11e7-81d3-dd400c249c1a.png">

After:
<img width="120" alt="screen shot 2017-10-19 at 11 32 15 pm" src="https://user-images.githubusercontent.com/6202961/31795935-00ab6014-b528-11e7-93aa-3b9e86b47acd.png">
<img width="165" alt="screen shot 2017-10-19 at 11 32 32 pm" src="https://user-images.githubusercontent.com/6202961/31795941-044749e0-b528-11e7-821c-1d58dfda1e11.png">


