### PR TITLE
Fix for issue #963.

### DIFF
--- a/sass/utilities/mixins.sass
+++ b/sass/utilities/mixins.sass
@@ -42,7 +42,7 @@
   display: inline-block
   flex-grow: 0
   flex-shrink: 0
-  font-size: $size-normal
+  font-size: 0
   height: 20px
   max-height: 20px
   max-width: 20px


### PR DESCRIPTION
iOS <button> element's minimum width is dependant on its font-size, so the .delete width wasn't able to be as small as it's height, resulting in one arm of the X being longer than the other. font-size: 0 does the trick.

Bugfix. Fixes issue #963 

### Proposed solution
Fixes issue #963 

### Tradeoffs
Only drawback is if you put text inside your Button, which you shouldn't as it's an icon only.

### Testing Done
Tested in iOS, Safari, Firefox, and Chrome on Mac. No access to IE.
