### PR TITLE
Code Highlighter Collision

### DIFF
--- a/sass/elements/other.sass
+++ b/sass/elements/other.sass
@@ -24,7 +24,7 @@
 .loader
   +loader
 
-.number
+.numbers
   align-items: center
   background-color: $background
   border-radius: 290486px


### PR DESCRIPTION

### Improvement
I see it was previously discussed in #1201.

### Proposed solution
This is a common class used by most code highlighters.  I can't find where we're using it in Bulma, but simply changing the class to .numbers instead fixes the problem.

### Testing Done
![result](https://user-images.githubusercontent.com/2184080/32011447-749abc26-b97a-11e7-8409-1e1904083ac6.jpg)

