### PR TITLE
Allow is-selected class on <td> and <th> tags

### DIFF
--- a/sass/elements/table.sass
+++ b/sass/elements/table.sass
@@ -44,7 +44,9 @@ $table-striped-row-even-hover-background-color: $white-ter !default
   th
     color: $table-cell-heading-color
     text-align: left
-  tr
+  tr,
+  td,
+  th
     &.is-selected
       background-color: $table-row-active-background-color
       color: $table-row-active-color

--- a/sass/elements/table.sass
+++ b/sass/elements/table.sass
@@ -41,12 +41,16 @@ $table-striped-row-even-hover-background-color: $white-ter !default
     &.is-narrow
       white-space: nowrap
       width: 1%
+    &.is-selected
+      background-color: $table-row-active-background-color
+      color: $table-row-active-color
+      a,
+      strong
+        color: currentColor
   th
     color: $table-cell-heading-color
     text-align: left
-  tr,
-  td,
-  th
+  tr
     &.is-selected
       background-color: $table-row-active-background-color
       color: $table-row-active-color


### PR DESCRIPTION
This is an **improvement**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution
Allows individual cells in a table to be selected, instead of just rows.
Similar issue is mentioned in issue #1278. 

### Tradeoffs
Let me know if you think there are downsides.

### Testing Done
Have tested locally and doesn't seem to affect existing table classes.

![tabletest](https://user-images.githubusercontent.com/17063901/32139715-aa905850-bc49-11e7-9815-45062003c805.JPG)

