### PR TITLE
Add `is-empty` modifier to file upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 * 🎉 #1235 Support for five column grid: `.is-one-fifth, .is-two-fifths, .is-three-fifths, .is-four-fifths`
 * 🎉 #1287 New `.is-invisible` helper
 * 🎉 #1255 New `.is-expanded` modifier for `navbar-item`
+* 🎉 #1383 New `.is-empty` modifier for `file`
+
 
 ### Improvements
 

--- a/sass/elements/form.sass
+++ b/sass/elements/form.sass
@@ -269,6 +269,11 @@ $help-size: $size-small !default
     .file-name
       border-bottom-left-radius: 0
       border-top-left-radius: 0
+    &.is-empty
+      .file-cta
+        border-radius: $file-radius
+      .file-name
+        display: none
   &.is-centered
     justify-content: center
   &.is-right


### PR DESCRIPTION
This is a **new feature**.

### Proposed solution

Currently the file upload looks like this when there is no filename yet provided. The thing this addresses is the empty white box where the name would go once populated.

<img width="206" alt="screen shot 2017-10-29 at 11 51 51 pm" src="https://user-images.githubusercontent.com/24803032/32143848-2c1d6b82-bd04-11e7-9674-d0f1f24aaaf3.png">

This allows devs to add the `is-empty` (not sure if there is an already established name that would be better for this - and if not I'm sure there is a better name - so feedback welcomed) modifier to the `.file` to remove the name box, thus the input will look like this:

<img width="190" alt="screen shot 2017-10-29 at 11 53 28 pm" src="https://user-images.githubusercontent.com/24803032/32143863-64c44f8c-bd04-11e7-8279-62938b99ed1b.png">

Then when the user has selected a file you simply remove the `is-empty` class and it will appear as expected...

<img width="441" alt="screen shot 2017-10-29 at 11 54 17 pm" src="https://user-images.githubusercontent.com/24803032/32143872-7f4beb80-bd04-11e7-8cb2-2ba4e9b59816.png">

This also works similar with the `is-boxed` modifier.

### Tradeoffs

Not really any use without JS, but then again, you can't change the name with JS anyway so 👍

### Testing Done

Currently running this in production, works great. Also, check out [the code pen](https://codepen.io/timacdonald/pen/EbxMbX) I did to show it working.