### PR TITLE
Add `is-centered|right` modifiers to `.tags`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * 🎉 #1235 Support for five column grid: `.is-one-fifth, .is-two-fifths, .is-three-fifths, .is-four-fifths`
 * 🎉 #1287 New `.is-invisible` helper
 * 🎉 #1255 New `.is-expanded` modifier for `navbar-item`
+* 🎉 #1384 New `.is-centered` and `.is-right` modifiers for `tags`
 
 ### Improvements
 

--- a/sass/elements/tag.sass
+++ b/sass/elements/tag.sass
@@ -8,16 +8,6 @@ $tag-delete-margin: 1px !default
   display: flex
   flex-wrap: wrap
   justify-content: flex-start
-  &.is-centered
-    justify-content: center
-    .tag
-      margin-right: 0.25rem
-      margin-left: 0.25rem
-  &.is-right
-    justify-content: flex-end
-    .tag
-      margin-left: 0.5rem
-      margin-right: 0
   .tag
     margin-bottom: 0.5rem
     &:not(:last-child)
@@ -35,6 +25,16 @@ $tag-delete-margin: 1px !default
       &:not(:last-child)
         border-bottom-right-radius: 0
         border-top-right-radius: 0
+  &.is-centered
+    justify-content: center
+    .tag
+      margin-right: 0.25rem
+      margin-left: 0.25rem
+  &.is-right
+    justify-content: flex-end
+    .tag
+      margin-left: 0.5rem
+      margin-right: 0
 
 .tag:not(body)
   align-items: center

--- a/sass/elements/tag.sass
+++ b/sass/elements/tag.sass
@@ -8,6 +8,16 @@ $tag-delete-margin: 1px !default
   display: flex
   flex-wrap: wrap
   justify-content: flex-start
+  &.is-centered
+    justify-content: center
+    .tag
+      margin-right: 0.25rem
+      margin-left: 0.25rem
+  &.is-right
+    justify-content: flex-end
+    .tag
+      margin-left: 0.5rem
+      margin-right: 0
   .tag
     margin-bottom: 0.5rem
     &:not(:last-child)

--- a/sass/elements/tag.sass
+++ b/sass/elements/tag.sass
@@ -33,8 +33,10 @@ $tag-delete-margin: 1px !default
   &.is-right
     justify-content: flex-end
     .tag
-      margin-left: 0.5rem
-      margin-right: 0
+      &:not(:first-child)
+        margin-left: 0.5rem
+      &:not(:last-child)
+        margin-right: 0
 
 .tag:not(body)
   align-items: center


### PR DESCRIPTION
This is a **new feature**.

### Proposed solution

This allows `.tags .tag` groups to be aligned centre and aligned right. Currently they are only aligned left.

### Tradeoffs

None come to mind.

### Testing Done

Currently doing this in production, works great. Also, [here is a codepen](https://codepen.io/timacdonald/pen/VrwREG) I created to show the feature.