### PR TITLE
Fix .pagination-next alignment

### DIFF
--- a/sass/components/pagination.sass
+++ b/sass/components/pagination.sass
@@ -54,6 +54,9 @@ $pagination-shadow-inset: inset 0 1px 2px rgba($black, 0.2)
   margin: 0.25rem
   text-align: center
 
+.pagination-next:only-child
+  margin-left: auto
+
 .pagination-previous,
 .pagination-next,
 .pagination-link


### PR DESCRIPTION
This PR fix #1364

Correct `.navigation-next` alignment when it is the only child of `.navigation`.