### PR TITLE
Add button is-link html example

### DIFF
--- a/docs/documentation/modifiers/syntax.html
+++ b/docs/documentation/modifiers/syntax.html
@@ -92,6 +92,9 @@ doc-subtab: syntax
 <a class="button is-primary">
   Button
 </a>
+<a class="button is-link">
+  Button
+</a>
 <a class="button is-info">
   Button
 </a>


### PR DESCRIPTION
This is a **documentation fix**.
Adds missing example html.

![missing-html](https://user-images.githubusercontent.com/4753511/32223041-a96bf704-be33-11e7-9bc4-1ec8a867842a.png)
