### PR TITLE
Addition of Sass Color Map to Customize Page

### DIFF
--- a/docs/documentation/overview/customize.html
+++ b/docs/documentation/overview/customize.html
@@ -27,7 +27,19 @@ $danger: $orange
 // Use the new serif family
 $family-primary: $family-serif
 
-// 4. Import the rest of Bulma
+// 4. Setup your Custom Colors
+$linkedin: #0077B5;
+$linkedin-invert: findColorInvert($linkedin);
+$twitter: #1DA1F2;
+$twitter-invert: findColorInvert($twitter);
+$github: #222222;
+$github-invert: findColorInvert($github);
+// Add new color variables to the color map.
+$colors: map-merge($colors, ("twitter":($twitter, $twitter-invert)));
+$colors: map-merge($colors, ("linkedin": ($linkedin, $linkedin-invert)));
+$colors: map-merge($colors, ("github": ($github, $github-invert)));
+
+// 5. Import the rest of Bulma
 @import "../bulma"
 {% endcapture %}
 

--- a/docs/documentation/overview/customize.html
+++ b/docs/documentation/overview/customize.html
@@ -28,16 +28,19 @@ $danger: $orange
 $family-primary: $family-serif
 
 // 4. Setup your Custom Colors
-$linkedin: #0077B5;
-$linkedin-invert: findColorInvert($linkedin);
-$twitter: #1DA1F2;
-$twitter-invert: findColorInvert($twitter);
-$github: #222222;
-$github-invert: findColorInvert($github);
+$linkedin: #0077B5
+$linkedin-invert: findColorInvert($linkedin)
+$twitter: #1DA1F2
+$twitter-invert: findColorInvert($twitter)
+$github: #222222
+$github-invert: findColorInvert($github)
 // Add new color variables to the color map.
-$colors: map-merge($colors, ("twitter":($twitter, $twitter-invert)));
-$colors: map-merge($colors, ("linkedin": ($linkedin, $linkedin-invert)));
-$colors: map-merge($colors, ("github": ($github, $github-invert)));
+$addColors: (
+  "twitter":($twitter, $twitter-invert), 
+  "linkedin": ($linkedin, $linkedin-invert),
+  "github": ($github, $github-invert)
+)
+$colors: map-merge($colors, $addColors)
 
 // 5. Import the rest of Bulma
 @import "../bulma"


### PR DESCRIPTION
This is a documentation fix.

Added verbiage to Customization page to demonstrate how to add new colors to the color map. 
Using this methodology allows for the dev to use `<i class="fa fa-github has-text-github"></i>`.

### Proposed solution
- Fixes #271 by documenting the easiest method of adding colors to the color map.
- Like #1200 Makes the information more ready for new developers to bulma.

### Tradeoffs
No Tradeoffs, Just makes it easier to add additional colors to be used by developers that utilize bulma.

### Testing Done
Yes, the use case that I reference in my documentation change on my own website. [Keithstolte.io](keithstolte.io)