### PR TITLE
Highlighting important info in typography helper 

### DIFF
--- a/docs/documentation/modifiers/typography-helpers.html
+++ b/docs/documentation/modifiers/typography-helpers.html
@@ -355,11 +355,11 @@ doc-subtab: typography-helpers
       </tr>
       <tr>
         <td><code>is-lowercase</code></td>
-        <td>Transforms all characters to <strong>lowercase</strong></td>
+        <td>Transforms <strong>all characters</strong> to <strong>lowercase</strong></td>
       </tr>
       <tr>
         <td><code>is-uppercase</code></td>
-        <td>Transforms all characters to <strong>uppercase</strong></td>
+        <td>Transforms <strong>all characters</strong> to <strong>uppercase</strong></td>
       </tr>
       </tbody>
     </table>


### PR DESCRIPTION

This is a **documentation fix**.

### Proposed solution
In this table, the first box was highlighting which characters as well as how it will be transformed. This PR updates remaining two boxes to use this clearer style.
