### PR TITLE
Fix the last link under npm dependencies

### DIFF
--- a/docs/bulma-start.html
+++ b/docs/bulma-start.html
@@ -66,7 +66,7 @@ npm_url: https://www.npmjs.com/package/bulma-start
         <li><code><a href="https://github.com/jgthms/bulma" target="_blank">bulma</a></code></li>
         <li><code><a href="https://github.com/sass/node-sass" target="_blank">node-sass</a></code> to compile your own Sass file</li>
         <li><code><a href="https://github.com/postcss/postcss-cli" target="_blank">postcss-cli</a></code> and <code><a href="https://github.com/postcss/autoprefixer" target="_blank">autoprefixer</a></code> to add support for older browsers</li>
-        <li><code><a href="https://babeljs.io/docs/usage/cli/" target="_blank">babel-cli</a></code>, <code><a href="https://github.com/babel/babel-preset-env" target="_blank">babel-preset-env</a></code> and <code>[babel-preset-es2015-ie](https://github.com/jmcriffey/babel-preset-es2015-ie)</code> for compiling ES6 JavaScript files</li>
+        <li><code><a href="https://babeljs.io/docs/usage/cli/" target="_blank">babel-cli</a></code>, <code><a href="https://github.com/babel/babel-preset-env" target="_blank">babel-preset-env</a></code> and <code><a href="https://github.com/jmcriffey/babel-preset-es2015-ie">babel-preset-es2015-ie</a></code> for compiling ES6 JavaScript files</li>
       </ul>
 
       <p>Apart from <code>package.json</code>, the following files are included:</p>


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **documentation fix**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
I fixed the last link under dependencies in bulma-start. 
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
I fixed the issue, by converting it from Markdown to HTML. 
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

### Tradeoffs
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->

### Testing Done
<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->
 No, however it worked for the others. 

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Run `npm install` to install all Bulma dependencies -->
<!-- 3. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 4. Make sure your PR only affects `.sass` or documentation files -->

<!-- Thanks! -->
