### PR TITLE
remove redundant max-width on img

### DIFF
--- a/sass/base/generic.sass
+++ b/sass/base/generic.sass
@@ -84,7 +84,6 @@ hr
 
 img
   height: auto
-  max-width: 100%
 
 input[type="checkbox"],
 input[type="radio"]


### PR DESCRIPTION
- img max-width is already assigned in minireset

This is an improvement.

Remove the redundant max-width declaration on img in generic.sass. The same property is already set in minireset.scss.

```
img
  max-width: 100%
```

### Proposed solution

Remove the redundant max-width declaration on img in generic.sass.

### Tradeoffs

If minireset.scss is not imported, then this property will not be set. However, not importing minireset.sass breaks a lot of other assumptions, so it seems reasonable to assume it will be imported.

### Testing Done

I confirmed that removing this property has 0 impact on the rendered output.