### PR TITLE
Add support for is-static to textareas

### DIFF
--- a/docs/documentation/form/textarea.html
+++ b/docs/documentation/form/textarea.html
@@ -129,6 +129,21 @@ doc-subtab: textarea
 </div>
 {% endcapture %}
 
+{% capture static_example %}
+<div class="field is-horizontal">
+  <div class="field-label is-normal">
+    <label class="label">Description</label>
+  </div>
+  <div class="field-body">
+    <div class="field">
+      <p class="control">
+        <textarea class="textarea is-static" type="text"></textarea>
+      </p>
+    </div>
+  </div>
+</div>
+{% endcapture %}
+
 {% include subnav-form.html %}
 
 <section class="section">
@@ -222,6 +237,17 @@ doc-subtab: textarea
     </div>
 
     {% include snippet.html content=fixed_size_example %}
+    
+    <div class="content">
+      <p>
+        If you <em>also</em> append the <code>is-static</code> modifier, it removes the background, border, shadow, and horizontal padding, while maintaining the <strong>vertical spacing</strong> so you can easily align the input in any context, like a horizontal form.
+      </p>
+    </div>
+
+    <div class="bd-example">
+      {{ static_example }}
+    </div>
+    {% highlight html %}{{ static_example }}{% endhighlight %}
 
   </div>
 </section>

--- a/docs/documentation/form/textarea.html
+++ b/docs/documentation/form/textarea.html
@@ -123,6 +123,12 @@ doc-subtab: textarea
 </div>
 {% endcapture %}
 
+{% capture fixed_size_example %}
+<div class="control">
+  <textarea class="textarea has-fixed-size" type="text">This textarea cannot be resized</textarea>
+</div>
+{% endcapture %}
+
 {% include subnav-form.html %}
 
 <section class="section">
@@ -194,7 +200,7 @@ doc-subtab: textarea
 
     {% include snippet.html content=disabled_example %}
 
-    <h4 class="subtitle">Readonly</h4>
+    <h4 class="subtitle">Readonly, fixed-size and static textareas</h4>
 
     <div class="tags has-addons">
       <span class="tag">New</span>
@@ -208,6 +214,14 @@ doc-subtab: textarea
     </div>
 
     {% include snippet.html content=readonly_example %}
+    
+    <div class="content">
+      <p>
+        You can append the <code>has-fixed-size</code> modifier to turn off resizing the textarea.
+      </p>
+    </div>
+
+    {% include snippet.html content=fixed_size_example %}
 
   </div>
 </section>

--- a/sass/elements/form.sass
+++ b/sass/elements/form.sass
@@ -98,8 +98,6 @@ $help-size: $size-small !default
   &.is-inline
     display: inline
     width: auto
-
-.input
   &.is-static
     background-color: transparent
     border-color: transparent


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **new feature and documentation fix**.
Adds support for `is-static` on textareas.
Also adds documentation for `is-static`,  as well as `has-fixed-size`.

### Tradeoffs
None

### Testing Done
Tested on supported browsers

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Run `npm install` to install all Bulma dependencies -->
<!-- 3. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 4. Make sure your PR only affects `.sass` or documentation files -->

<!-- Thanks! -->
