### PR TITLE
Fixes #1190 - Use Sass variable and Sass mixin to generate is-variable rules

### DIFF
--- a/docs/documentation/columns/gap.html
+++ b/docs/documentation/columns/gap.html
@@ -201,13 +201,5 @@ doc-subtab: gap
 
     {% include klmn.html %}
 
-    <div class="message is-warning">
-      <div class="message-body">
-        <p>
-          This feature is only available in browsers that support <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_variables">CSS Variables</a>:
-        </p>
-      </div>
-    </div>
-
   </div>
 </section>

--- a/sass/grid/columns.sass
+++ b/sass/grid/columns.sass
@@ -464,13 +464,15 @@ $column-gap: 0.75rem !default
     &.is-desktop
       display: flex
 
-.columns.is-variable
-  --columnGap: 0.75rem
-  margin-left: calc(-1 * var(--columnGap))
-  margin-right: calc(-1 * var(--columnGap))
+@mixin columns-is-variable($columnGap: 0.75rem)
+  margin-left: #{-1 * $columnGap}
+  margin-right: #{-1 * $columnGap}
   .column
-    padding-left: var(--columnGap)
-    padding-right: var(--columnGap)
+    padding-left: $columnGap
+    padding-right: $columnGap
+
+.columns.is-variable
+  @include columns-is-variable
   @for $i from 0 through 8
     &.is-#{$i}
-      --columnGap: #{$i * 0.25rem}
+      @include columns-is-variable($i * 0.25rem)


### PR DESCRIPTION
This is a **improvement | bugfix | documentation fix**. _(all)_
- Improvement because, it drops the dependency on browser support for CSS variables. Depends purely on Sass pre-processing, so it will be compatible with browsers that don't have CSS variable support.
- Bugfix because of the referenced issue.
- Documentation fix because we can remove the warning about browser support in the `is-variable` docs.

### Proposed solution
Instead of depending on CSS variable browser support, use a Sass variable and a Sass mixin to generate regular CSS for the is-variable class. This should increase browser compatibility as well as fix #1190, #1355 and #1181 where warnings are emitted when using a CSS variable. It will also make the deprecation warning in #1283 and #1210 completely irrelevant since that only applies to CSS variables.

### Tradeoffs
I guess you have to learn how Sass variables and Sass mixins work? But other than that, I can't think of anything.

### Testing Done
Injected the generated CSS code into Bulma Docs. Confirmed working:

![bulma-is-variable-removed](https://user-images.githubusercontent.com/6047296/33250331-de6a3c4a-d355-11e7-8e5d-54f090abc67c.PNG)
![bulma-is-variable-new-css](https://user-images.githubusercontent.com/6047296/33250328-de0075ee-d355-11e7-861b-346d2d7834e6.PNG)