### PR TITLE
Add .has-navbar-fixed-somewhere support to body tag (#1485)

### DIFF
--- a/docs/documentation/components/navbar.html
+++ b/docs/documentation/components/navbar.html
@@ -819,7 +819,7 @@ document.addEventListener('DOMContentLoaded', function () {
           {% highlight html %}<nav class="navbar is-fixed-top">{% endhighlight %}
         </li>
         <li>
-          Add the corresponding <code>has-navbar-fixed-top</code> or <code>has-navbar-fixed-bottom</code> modifier to the <code>&lt;html&gt;</code> element to provide the appropriate padding to the page
+          Add the corresponding <code>has-navbar-fixed-top</code> or <code>has-navbar-fixed-bottom</code> modifier to either <code>&lt;html&gt;</code> or <code>&lt;body&gt;</code> element to provide the appropriate padding to the page
           {% highlight html %}<html class="has-navbar-fixed-top">{% endhighlight %}
         </li>
       </ul>

--- a/sass/components/navbar.sass
+++ b/sass/components/navbar.sass
@@ -109,10 +109,12 @@ $navbar-divider-background-color: $border !default
   &.is-fixed-top
     top: 0
 
-html.has-navbar-fixed-top
+html.has-navbar-fixed-top,
+body.has-navbar-fixed-top
   padding-top: $navbar-height
 
-html.has-navbar-fixed-bottom
+html.has-navbar-fixed-bottom,
+body.has-navbar-fixed-bottom
   padding-bottom: $navbar-height
 
 .navbar-brand,


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **bugfix**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

html.has-navbar-fixed-top cannot use rem relative to html itself #1485

### Tradeoffs
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->

> Although it is a browser bug, move .has-navbar-fixed-top to body will be a workaround.

### Testing Done
<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

`npm run build` successfully and effectively.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Run `npm install` to install all Bulma dependencies -->
<!-- 3. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 4. Make sure your PR only affects `.sass` or documentation files -->

<!-- Thanks! -->