### PR TITLE
Fixes #1493: Add z-index to `is-loading` class

### DIFF
--- a/sass/elements/form.sass
+++ b/sass/elements/form.sass
@@ -611,6 +611,7 @@ $help-size: $size-small !default
       position: absolute !important
       right: 0.625em
       top: 0.625em
+      z-index: 4
     &.is-small:after
       font-size: $size-small
     &.is-medium:after


### PR DESCRIPTION
The `has-addons` class for a field can hide the loader of its children
if they have the `is-loading` class when the field is hovered or active.

<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **bugfix** for #1493.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->
Adding a `z-index` of 4 make the loader (or `::after` pseudo-element of the `is-loading` class) to be positioned at the same stack order of the `has-addons` field when hovered/focused/active.

The lines that are causing this behaviour is: [https://github.com/jgthms/bulma/blob/6176c2c9f515766a0df39db5e2a8da4207097cad/sass/elements/form.sass#L444-L456](https://github.com/jgthms/bulma/blob/6176c2c9f515766a0df39db5e2a8da4207097cad/sass/elements/form.sass#L444-L456)

Here you can see the `z-index` property when the field changes the "state", causing the loader to be hidden when the control has the `is-loading` class.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Run `npm install` to install all Bulma dependencies -->
<!-- 3. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 4. Make sure your PR only affects `.sass` or documentation files -->

<!-- Thanks! -->
