### PR TITLE
Implement colours for dropdown component

### DIFF
--- a/docs/documentation/components/dropdown.html
+++ b/docs/documentation/components/dropdown.html
@@ -38,6 +38,152 @@ doc-subtab: dropdown
 </div>
 {% endcapture %}
 
+{% capture dropdown_colors_example %}
+<div class="dropdown is-active is-primary">
+  <div class="dropdown-trigger">
+    <button class="button" aria-haspopup="true" aria-controls="dropdown-menu">
+      <span>Primary</span>
+      <span class="icon is-small">
+        <i class="fa fa-angle-down" aria-hidden="true"></i>
+      </span>
+    </button>
+  </div>
+  <div class="dropdown-menu" id="dropdown-menu" role="menu">
+    <div class="dropdown-content">
+      <a href="#" class="dropdown-item">
+        Dropdown item
+      </a>
+      <a href="#" class="dropdown-item is-active">
+        Active dropdown item
+      </a>
+      <a href="#" class="dropdown-item">
+        Other dropdown item
+      </a>
+    </div>
+  </div>
+</div>
+
+<div class="dropdown is-hoverable is-link">
+  <div class="dropdown-trigger">
+    <button class="button" aria-haspopup="true" aria-controls="dropdown-menu">
+      <span>Link</span>
+      <span class="icon is-small">
+        <i class="fa fa-angle-down" aria-hidden="true"></i>
+      </span>
+    </button>
+  </div>
+  <div class="dropdown-menu" id="dropdown-menu" role="menu">
+    <div class="dropdown-content">
+      <a href="#" class="dropdown-item">
+        Dropdown item
+      </a>
+      <a href="#" class="dropdown-item is-active">
+        Active dropdown item
+      </a>
+      <a href="#" class="dropdown-item">
+        Other dropdown item
+      </a>
+    </div>
+  </div>
+</div>
+
+<div class="dropdown is-hoverable is-info">
+  <div class="dropdown-trigger">
+    <button class="button" aria-haspopup="true" aria-controls="dropdown-menu">
+      <span>Link</span>
+      <span class="icon is-small">
+        <i class="fa fa-angle-down" aria-hidden="true"></i>
+      </span>
+    </button>
+  </div>
+  <div class="dropdown-menu" id="dropdown-menu" role="menu">
+    <div class="dropdown-content">
+      <a href="#" class="dropdown-item">
+        Dropdown item
+      </a>
+      <a href="#" class="dropdown-item is-active">
+        Active dropdown item
+      </a>
+      <a href="#" class="dropdown-item">
+        Other dropdown item
+      </a>
+    </div>
+  </div>
+</div>
+
+<div class="dropdown is-hoverable is-success">
+  <div class="dropdown-trigger">
+    <button class="button" aria-haspopup="true" aria-controls="dropdown-menu">
+      <span>Link</span>
+      <span class="icon is-small">
+        <i class="fa fa-angle-down" aria-hidden="true"></i>
+      </span>
+    </button>
+  </div>
+  <div class="dropdown-menu" id="dropdown-menu" role="menu">
+    <div class="dropdown-content">
+      <a href="#" class="dropdown-item">
+        Dropdown item
+      </a>
+      <a href="#" class="dropdown-item is-active">
+        Active dropdown item
+      </a>
+      <a href="#" class="dropdown-item">
+        Other dropdown item
+      </a>
+    </div>
+  </div>
+</div>
+
+<div class="dropdown is-hoverable is-warning">
+  <div class="dropdown-trigger">
+    <button class="button" aria-haspopup="true" aria-controls="dropdown-menu">
+      <span>Link</span>
+      <span class="icon is-small">
+        <i class="fa fa-angle-down" aria-hidden="true"></i>
+      </span>
+    </button>
+  </div>
+  <div class="dropdown-menu" id="dropdown-menu" role="menu">
+    <div class="dropdown-content">
+      <a href="#" class="dropdown-item">
+        Dropdown item
+      </a>
+      <a href="#" class="dropdown-item is-active">
+        Active dropdown item
+      </a>
+      <a href="#" class="dropdown-item">
+        Other dropdown item
+      </a>
+    </div>
+  </div>
+</div>
+
+<div class="dropdown is-hoverable is-danger">
+  <div class="dropdown-trigger">
+    <button class="button" aria-haspopup="true" aria-controls="dropdown-menu">
+      <span>Link</span>
+      <span class="icon is-small">
+        <i class="fa fa-angle-down" aria-hidden="true"></i>
+      </span>
+    </button>
+  </div>
+  <div class="dropdown-menu" id="dropdown-menu" role="menu">
+    <div class="dropdown-content">
+      <a href="#" class="dropdown-item">
+        Dropdown item
+      </a>
+      <a href="#" class="dropdown-item is-active">
+        Active dropdown item
+      </a>
+      <a href="#" class="dropdown-item">
+        Other dropdown item
+      </a>
+    </div>
+  </div>
+</div>
+{% endcapture %}
+
 {% capture dropdown_content_example %}
 <div class="dropdown is-active">
   <div class="dropdown-trigger">
@@ -201,7 +347,7 @@ doc-subtab: dropdown
       include meta.html
       new=true
       since="0.4.4"
-      colors=false
+      colors=true
       sizes=false
       variables=true
     %}
@@ -294,6 +440,23 @@ doc-subtab: dropdown
       </div>
       <div class="column is-half">
         {% highlight html %}{{dropdown_click_example}}{{dropdown_info_example}}{% endhighlight %}
+      </div>
+    </div>
+
+    {% include anchor.html name="Colors" %}
+
+    <div class="content">
+      <p>
+        You can provide a color to the main container, i.e., the <code>dropdown</code> element, and it will add the color to the <code>button</code> inside the <code>dropdown-trigger</code> element and to the <code>dropdown-item</code> anchor link with the <code>is-active</code> class.
+      </p>
+    </div>
+
+    <div class="columns">
+      <div class="column is-half">
+        {{dropdown_colors_example}}
+      </div>
+      <div class="column is-half">
+        {% highlight html %}{{dropdown_colors_example}}{% endhighlight %}
       </div>
     </div>
 

--- a/sass/components/dropdown.sass
+++ b/sass/components/dropdown.sass
@@ -31,6 +31,18 @@ $dropdown-divider-background-color: $border !default
       padding-bottom: $dropdown-content-offset
       padding-top: unset
       top: auto
+  // Colors
+  @each $name, $pair in $colors
+    $color: nth($pair, 1)
+    $color-invert: nth($pair, 2)
+    &.is-#{$name}
+      .dropdown-trigger
+        .button
+          @extend .is-#{$name}
+      a.dropdown-item
+        &.is-active
+          background-color: $color
+          color: $color-invert
 
 .dropdown-menu
   display: none


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **new feature/improvement**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->
This PR adds the colours implementation to the dropdown component in a simple way: just adding the desired colour to the `dropdown` element as if it were a button -like `is-primary`-, and it will add the colour to both the dropdown button and the active item inside the dropdown menu.

### Tradeoffs
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->
Maybe something with the usage of `@extend` for the button, but for now I think there are no tradeoffs.

### Testing Done
<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->
Built with `npm run build` and `npm run docs`, and looked at the local documentation (with `jekyll`) to see the results.

![2017-12-07-160044_1262x499_scrot](https://user-images.githubusercontent.com/15493430/33736635-bc5dc218-db69-11e7-90b5-a4e93174a099.png)


<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Run `npm install` to install all Bulma dependencies -->
<!-- 3. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 4. Make sure your PR only affects `.sass` or documentation files -->

<!-- Thanks! -->
