### PR TITLE
Fixes #1514: Fix spacing of the delete button in notification element

### DIFF
--- a/sass/elements/notification.sass
+++ b/sass/elements/notification.sass
@@ -20,8 +20,8 @@ $notification-padding: 1.25rem 2.5rem 1.25rem 1.5rem !default
     background: transparent
   & > .delete
     position: absolute
-    right: 0.5em
-    top: 0.5em
+    right: 0.5rem
+    top: 0.5rem
   .title,
   .subtitle,
   .content


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **bugfix**. Fixes #1514.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->
This fixes the spacing of the `.delete` button inside the notification element. `em` doesn't work in that context, so even if you have `10em` it won't move the delete button and will keep it at the top right corner; replacing the positioning with `rem` works as expected.

