### PR TITLE
Corrected pricing table typo in extensions docs

### DIFF
--- a/docs/extensions.html
+++ b/docs/extensions.html
@@ -28,7 +28,7 @@ extensions:
   slug: bulma-tagsinput
   width: 423
   height: 50
-- name: bulma-princigtable
+- name: bulma-pricingtable
   url: https://wikiki.github.io/components/pricingtable
   slug: bulma-pricingtable
   width: 1301


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **documentation fix**.

I just noticed the title on the extensions page, the pricing table title was misspelled.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->


<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Run `npm install` to install all Bulma dependencies -->
<!-- 3. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 4. Make sure your PR only affects `.sass` or documentation files -->

<!-- Thanks! -->
