### PR TITLE
[Fixes #1534] Hamburger Menu Height Now Dynamic

### DIFF
--- a/sass/utilities/mixins.sass
+++ b/sass/utilities/mixins.sass
@@ -109,7 +109,7 @@
 =hamburger($dimensions)
   cursor: pointer
   display: block
-  height: $dimensions
+  height: 100%
   position: relative
   width: $dimensions
   span

--- a/sass/utilities/mixins.sass
+++ b/sass/utilities/mixins.sass
@@ -109,7 +109,7 @@
 =hamburger($dimensions)
   cursor: pointer
   display: block
-  height: 100%
+  height: auto
   position: relative
   width: $dimensions
   span


### PR DESCRIPTION
This is a **bugfix**.
Fixes #1534 

### Proposed solution
Fixes the Hamburger fixed height by updated Mixin to make hamburger height value to auto instead of the dimension (which defaults to 3.25rem as of 0.6.1).

### Tradeoffs
The width is still static, which makes sense since a hamburger menu is typically a square, but by changing the height the element could appear closer to a rectangle depending on the developers styling. One way to remedy this is to make the hamburger menu consume a calculated height of the navbar so that it floats in the middle if the navbar is taller than a reasonable default such as the current.

Furthermore, this introduces the idea of dynamic sizing for the navigation elements, meaning they would have to be updated as well if the height doesn't match 3.25rem. 

Examples in testing.

### Testing Done
40px navbar height
![image](https://user-images.githubusercontent.com/14265337/34075204-4c0ff654-e28d-11e7-9ff4-204c0f1e2c22.png)

80px navbar height
![image](https://user-images.githubusercontent.com/14265337/34075209-68e1f62e-e28d-11e7-9b35-bc1d32ee1438.png)

Standard navbar height
![image](https://user-images.githubusercontent.com/14265337/34075231-3a1b6054-e28e-11e7-9c39-f7a8b15efb68.png)


<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Run `npm install` to install all Bulma dependencies -->
<!-- 3. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 4. Make sure your PR only affects `.sass` or documentation files -->

<!-- Thanks! -->
