### PR TITLE
Fix missing use of $pagination-color variable

### DIFF
--- a/sass/components/pagination.sass
+++ b/sass/components/pagination.sass
@@ -65,6 +65,7 @@ $pagination-shadow-inset: inset 0 1px 2px rgba($black, 0.2)
 .pagination-previous,
 .pagination-next,
 .pagination-link
+  color: $pagination-color
   border-color: $pagination-border-color
   min-width: 2.25em
   &:hover


### PR DESCRIPTION
This is an **improvement/bugfix**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

The pagination-color variable is not being used anywhere, so setting it
to something else doesn't do anything. This should change the colour of
pagination-previous, pagination-next, and pagination-link classes.

### Proposed solution
`$pagination-color` should be used in `.pagination-previous`, `.pagination-next`, and `.pagination-link`.

### Testing Done
Ran `npm run build-css` and saw the results changing the desired variable.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Run `npm install` to install all Bulma dependencies -->
<!-- 3. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 4. Make sure your PR only affects `.sass` or documentation files -->

<!-- Thanks! -->
