### PR TITLE
Fix position of delete button on class 'tag'

### DIFF
--- a/sass/elements/tag.sass
+++ b/sass/elements/tag.sass
@@ -52,8 +52,8 @@ $tag-delete-margin: 1px !default
   padding-right: 0.75em
   white-space: nowrap
   .delete
-    margin-left: 0.25em
-    margin-right: -0.375em
+    margin-left: 0.25rem
+    margin-right: -0.375rem
   // Colors
   @each $name, $pair in $colors
     $color: nth($pair, 1)


### PR DESCRIPTION
Bugfix.
The same way as #1518 ,  the delete button is incorrectly positioned on 'tag' classes.

Using 'rem' instead of 'em' fix the issue.

(There is no related issue created)