### PR TITLE
Fix documentation: Colors of `File`

### DIFF
--- a/docs/documentation/form/file.html
+++ b/docs/documentation/form/file.html
@@ -669,12 +669,12 @@ variables_keys:
 
     <div class="content">
       <p>
-        You can style the file element by appending one of the <strong>9 color modifiers</strong>:
+        You can style the file element by appending one of the <strong>{{ site.data.colors.derived | size }} color modifiers</strong>:
       </p>
       <ul>
-        {% for color in site.colors %}
+        {% for color in site.data.colors.derived %}
           <li>
-            <code>is-{{ color }}</code>
+            <code>is-{{ color.id }}</code>
           </li>
         {% endfor %}
       </ul>


### PR DESCRIPTION
This is a **documentation fix**:

- Fix all possible colors of `File`
- Fix count number of colors

To include all colors of `.file` as found in generated CSS https://github.com/jgthms/bulma/blob/master/css/bulma.css#L3443-L3691

