### PR TITLE
Make feed entries show full content

### DIFF
--- a/docs/atom.xml
+++ b/docs/atom.xml
@@ -19,11 +19,7 @@
         {% if post.author.name %}
           <dc:creator>{{ post.author.name | xml_escape }}</dc:creator>
         {% endif %}
-        {% if post.introduction %}
-          <description>{{ post.introduction | xml_escape }}</description>
-        {% else %}
-          <description>{{ post.content | xml_escape }}</description>
-        {% endif %}
+        <description>{{ post.content | xml_escape }}</description>
         <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
         <link>{{ site.url }}{{ post.url }}</link>
         <guid isPermaLink="true">{{ site.url }}{{ post.url }}</guid>


### PR DESCRIPTION
Feed is configured to show introduction text rather than the full content of each post. Now it will always show the full content for each entry.

Fixes #1545.