### PR TITLE
Fix documentation: Missing word 'is-hoverable'

### DIFF
--- a/docs/documentation/elements/table.html
+++ b/docs/documentation/elements/table.html
@@ -556,7 +556,7 @@ doc-subtab: table
         <p>You can <strong>combine</strong> all four modifiers.</p>
       </div>
       <div class="column">
-        <code>table is-bordered is-striped is-narrow is-fullwidth</code>
+        <code>table is-bordered is-striped is-narrow is-hoverable is-fullwidth</code>
       </div>
       <div class="column is-half">
         <table class="table is-bordered is-striped is-narrow is-hoverable is-fullwidth">


### PR DESCRIPTION
This is a **documentation fix**.

Bulma is really useful!
I appreciate all you do.
