### PR TITLE
Fixes #1580: Remove border radius from 'navbar-burger'

### DIFF
--- a/sass/components/navbar.sass
+++ b/sass/components/navbar.sass
@@ -131,6 +131,7 @@ html.has-navbar-fixed-bottom
 .navbar-burger
   +hamburger($navbar-height)
   margin-left: auto
+  border-radius: 0px
 
 .navbar-menu
   display: none


### PR DESCRIPTION
This is a **bugfix** for #1580.

### Proposed solution
Currently, button elements with the class combination of 'button' and 'navbar-burger' have border radius. A solution is to remove the border-radius from 'navbar-burger', so it can be safely used in combination with 'button'.