### PR TITLE
# fixes issue 1583-button look like text link

### DIFF
--- a/css/bulma.css
+++ b/css/bulma.css
@@ -1930,11 +1930,7 @@ a.box:active {
   border-color: transparent;
   color: #fff;
 }
-.button.behave_like_text_link {
-  color:#0000EE;
-  border-style:none;
-  background-color:white;
-}
+
 .button.is-link:focus, .button.is-link.is-focused {
   border-color: transparent;
   color: #fff;

--- a/css/bulma.css
+++ b/css/bulma.css
@@ -1930,7 +1930,11 @@ a.box:active {
   border-color: transparent;
   color: #fff;
 }
-
+.button.behave_like_text_link {
+  color:#0000EE;
+  border-style:none;
+  background-color:white;
+}
 .button.is-link:focus, .button.is-link.is-focused {
   border-color: transparent;
   color: #fff;


### PR DESCRIPTION
added new class behave_like_text_link:-
changed background color of default HTML button, changed border style to none, and text color to blue

This is a new feature
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

### Tradeoffs
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->

### Testing Done
yes ,it removed the default groove style, changed the default background color to white and the text color to default color of a link i.e blue.
<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Run `npm install` to install all Bulma dependencies -->
<!-- 3. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 4. Make sure your PR only affects `.sass` or documentation files -->

<!-- Thanks! -->
