### PR TITLE
Fix #1473 unset > initial

### DIFF
--- a/sass/components/dropdown.sass
+++ b/sass/components/dropdown.sass
@@ -29,7 +29,7 @@ $dropdown-divider-background-color: $border !default
     .dropdown-menu
       bottom: 100%
       padding-bottom: $dropdown-content-offset
-      padding-top: unset
+      padding-top: initial
       top: auto
 
 .dropdown-menu

--- a/sass/elements/form.sass
+++ b/sass/elements/form.sass
@@ -119,7 +119,7 @@ $help-size: $size-small !default
     max-height: 600px
     min-height: 120px
   &[rows]
-    height: unset
+    height: initial
   // Modifiers
   &.has-fixed-size
     resize: none
@@ -173,7 +173,7 @@ $help-size: $size-small !default
     &:not([multiple])
       padding-right: 2.5em
     &[multiple]
-      height: unset
+      height: initial
       padding: 0
       option
         padding: 0.5em 1em


### PR DESCRIPTION
This is a **bugfix**.

This is a fix for #1473 

### Proposed solution
Elements using the css `unset` value are not getting their value reset in IE. According to [caniuse](https://caniuse.com/#search=unset) the `unset` value is not supported at all in IE browsers.

This PR replaces css values of `unset` with its `initial` value.

#### MDN references

[Initial](https://developer.mozilla.org/en-US/docs/Web/CSS/initial)
> The initial CSS keyword applies the initial value of a property to an element. It can be applied to any CSS property, including the CSS shorthand all.

[Unset](https://developer.mozilla.org/en-US/docs/Web/CSS/unset)
> The unset CSS keyword resets a property to its inherited value if it inherits from its parent, and to its initial value if not. In other words, it behaves like the inherit keyword in the first case, and like the initial keyword in the second case. It can be applied to any CSS property, including the CSS shorthand all.