### PR TITLE
Correct a typo in docs

### DIFF
--- a/docs/_posts/2018-01-18-bulma-supports-font-awesome-5.md
+++ b/docs/_posts/2018-01-18-bulma-supports-font-awesome-5.md
@@ -14,7 +14,7 @@ As a result, **Bulma already supports Font Awesome 5**! 😃
 
 Since the `icon` element is simply a **container** for any icon font *allowing the layout to reserve a spot for the icon while it loads), it supports any size of Font Awesome 4 and 5.
 
-For the sake of being in sync with Bulima users, I've recently updated the website to actually use Font Awesome 5! The process of **migrating** from Font Awesome 4 to 5 is straightforward. You simply need to:
+For the sake of being in sync with Bulma users, I've recently updated the website to actually use Font Awesome 5! The process of **migrating** from Font Awesome 4 to 5 is straightforward. You simply need to:
 
 1. include Font Awesome 5 instead, [using the script tag](https://fontawesome.com/get-started)
 2. replace `fa` classes with their `fas` and `fab` equivalents


### PR DESCRIPTION

This is a documentation fix.

Correct "Bulima" to "Bulma"

