### PR TITLE
Add Gutter Class Modifiers (Margins & Paddings)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,10 @@
 ## 0.6.4
 
 ### New features
-* Add margin and padding (gutter) modifiers.
+* Add margin and padding (gap) modifiers.
 * `has-margin-top-bottom`, `has-margin-left-right`, `has-padding-top-bottom`, `has-padding-left-right`.
-* `has-margin-sm`, `has-padding-sm` decreased gutter size in half.
-* Default gutter spacing is $gap (32px). The small gutter spacing is $gap / 2 (16px)
-
+* Use `has-margin-sm`, `has-padding-sm` to decrease gap size in half.
+* Default gap spacing is $gap (32px). Small gap spacing is $gap / 2 (16px).
 
 ## 0.6.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Bulma Changelog
 
+## 0.6.4
+
+### New features
+* Add margin and padding (gutter) modifiers.
+* `has-margin-top-bottom`, `has-margin-left-right`, `has-padding-top-bottom`, `has-padding-left-right`.
+* `has-margin-sm`, `has-padding-sm` decreased gutter size in half.
+* Default gutter spacing is $gap (32px). The small gutter spacing is $gap / 2 (16px)
+
+
 ## 0.6.3
 
 ### Bug fixes

--- a/sass/base/helpers.sass
+++ b/sass/base/helpers.sass
@@ -1,3 +1,5 @@
+@import "../utilities/initial-variables.sass"
+
 // Float
 
 .is-clearfix
@@ -228,6 +230,33 @@ $displays: 'block' 'flex' 'inline' 'inline-block' 'inline-flex'
     visibility: hidden !important
 
 // Other
+.has-margin-top-bottom
+  margin-top: $gap !important
+  margin-bottom: $gap !important
+  &.has-margin-sm
+    margin-top: $gap / 2 !important
+    margin-bottom: $gap / 2 !important
+
+.has-margin-left-right
+  margin-left: $gap !important
+  margin-right: $gap !important
+  &.has-margin-sm
+    margin-left: $gap / 2 !important
+    margin-right: $gap / 2 !important
+
+.has-padding-top-bottom
+  padding-top: $gap !important
+  padding-bottom: $gap !important
+  &.has-padding-sm
+    padding-top: $gap / 2 !important
+    padding-bottom: $gap / 2 !important
+
+.has-padding-left-right
+  padding-left: $gap !important
+  padding-right: $gap !important
+  &.has-padding-sm
+    padding-left: $gap / 2 !important
+    padding-right: $gap / 2 !important
 
 .is-marginless
   margin: 0 !important

--- a/sass/base/helpers.sass
+++ b/sass/base/helpers.sass
@@ -1,3 +1,4 @@
+// Importing variables to access $gap
 @import "../utilities/initial-variables.sass"
 
 // Float


### PR DESCRIPTION
<!-- Choose one of the following: -->
This is a **new feature**.

This new feature adds the `.has-(margin | padding)-left-right`, `.has-(margin | padding)-top-bottom`, `.has-(margin | padding)-sm` classes. CHANGELOG.md is updated.

### Proposed solution
This solution offers an easy way to space any element or add gaps (gutters) to a row or column (Ex: `.container` | `.container-fluid`). The `$gap` variable is used for consistent spacing.

### Tradeoffs
May be considered a long class name. Users could put `.has-magin-right-left` _instead_ of `.has-margin-left-right`.

### Testing Done
I have tested these classes on a local project with Bulma as a dependency.