### PR TITLE
Remove level-item:last-child right margin on level.is-mobile

### DIFF
--- a/sass/components/level.sass
+++ b/sass/components/level.sass
@@ -20,7 +20,8 @@
         margin-bottom: 0
       &:not(.is-narrow)
         flex-grow: 1
-      margin-right: 0.75rem
+      &:not(:last-child)
+        margin-right: 0.75rem
   // Responsiveness
   +tablet
     display: flex


### PR DESCRIPTION
This is a **bugfix**.

Issue: https://github.com/jgthms/bulma/issues/1606

### Proposed solution

Scope the margin while using `is-mobile` the same as when not using `is-mobile`.

```css
.level.is-mobile .level-item:not(:last-child) {
  margin-right: 0.75rem;
}
```

### Tradeoffs

None I can think of.

### Testing Done

See [this codepen](https://codepen.io/timacdonald/pen/GyLKOz) with the implemented fix. Comment it out to see the margin on each of the variations. 