### PR TITLE
[Closes #1325] Documentation Search

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -18,3 +18,9 @@ download:      https://github.com/jgthms/bulma/releases/download/0.6.2/bulma-0.6
 github:        https://github.com/jgthms/bulma
 twitter:       https://twitter.com/jgthms
 version:       0.6.2
+
+# Search
+
+algolia:
+  key:         a58d77bf81d5eb18853fcd332d997f8e
+  index:       bulma

--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -18,6 +18,9 @@
   {% if page.mdi %}
     <link rel="stylesheet" href="{{ site.data.icons.mdi }}">
   {% endif %}
+  {% if page.layout == 'documentation' %}
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css">
+  {% endif %}
   <link rel="stylesheet" href="{{ site.url }}/css/bulma-docs.css?v={{ site.time | date: "%Y%m%d%H%M" }}">
 
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.url }}">
@@ -32,7 +35,6 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@jgthms">
   <meta name="twitter:creator" content="@jgthms">
-
 
   <!-- Shared social media -->
   {% if page.share_title %}
@@ -76,6 +78,8 @@
   <link rel="shortcut icon" href="{{ site.url }}/favicons/favicon.ico?v=201701041855">
   <meta name="msapplication-config" content="{{ site.url }}/favicons/browserconfig.xml?v=201701041855">
   <meta name="theme-color" content="#00d1b2">
+
+  {% include javascript-settings.html %}
 
   <script defer src="{{ site.data.icons.fontawesome5 }}"></script>
 </head>

--- a/docs/_includes/javascript-settings.html
+++ b/docs/_includes/javascript-settings.html
@@ -1,0 +1,11 @@
+<script>
+  var bdSettings = {
+    version: '{{ site.version }}',
+    deprecated: {% if site.deprecated %}true{% else %}false{% endif %},
+    algolia: {
+      {% if site.algolia.app %}app: '{{ site.algolia.app }}',{% endif %}
+      key: '{{ site.algolia.key }}',
+      index: '{{ site.algolia.index }}'
+    }
+  };
+</script>

--- a/docs/_includes/scripts.html
+++ b/docs/_includes/scripts.html
@@ -9,6 +9,11 @@
   <script type="text/javascript" src="{{ site.url }}/lib/navbar.js?v={{ site.time | date: '%Y%m%d%H%M' }}"></script>
 {% endif %}
 
+{% if page.layout == 'documentation' %}
+  <script src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+  <script src="{{ site.url }}/lib/search.js?v={{ site.time | date: '%Y%m%d%H%M' }}"></script>
+{% endif %}
+
 <div id="fb-root"></div>
 
 <script async defer type="text/javascript">(function(d, s, id) {

--- a/docs/_includes/search.html
+++ b/docs/_includes/search.html
@@ -1,0 +1,10 @@
+<div class="columns">
+  <div class="column is-three-quarters is-half-desktop">
+    <div id="documentionSearchWrapper" class="control has-icons-left">
+      <input id="documentionSearch" class="input is-medium" type="text" placeholder="Search…" autocomplete="off">
+      <span class="icon is-left">
+        <i class="fas fa-search"></i>
+      </span>
+    </div>
+  </div>
+</div>

--- a/docs/_layouts/documentation.html
+++ b/docs/_layouts/documentation.html
@@ -16,7 +16,7 @@ route: documentation
           <p class="subtitle">
             Everything you need to <strong>create a website</strong> with Bulma
           </p>
-          <input type="text" id="documention-search">
+          {% include search.html %}
         </div>
         <div class="column is-narrow">
           {% include carbon.html %}

--- a/docs/_layouts/documentation.html
+++ b/docs/_layouts/documentation.html
@@ -16,6 +16,7 @@ route: documentation
           <p class="subtitle">
             Everything you need to <strong>create a website</strong> with Bulma
           </p>
+          <input type="text" id="documention-search">
         </div>
         <div class="column is-narrow">
           {% include carbon.html %}
@@ -72,4 +73,3 @@ route: documentation
     </p>
   </div>
 </section>
-

--- a/docs/lib/search.js
+++ b/docs/lib/search.js
@@ -1,0 +1,36 @@
+'use strict';
+
+document.addEventListener('DOMContentLoaded', function () {
+
+  // Toggle search between current, and deprecated documentation versions
+  var algoliaOptions = {};
+  if(bdSettings.deprecated) {
+    algoliaOptions.facetFilters = ['version:' + bdSettings.version];
+  } else {
+    algoliaOptions.facetFilters = ['tags:current'];
+  }
+
+  // Configure DocSearch
+  var options = {
+    apiKey: bdSettings.algolia.key,
+    indexName: bdSettings.algolia.index,
+    inputSelector: '#documention-search',
+    algoliaOptions: algoliaOptions,
+    transformData: function (hits) {
+      return hits.map(function (hit) {
+        hit.url = hit.url
+          .replace('https://bulma.io/', '/')
+          .replace('https://versions.bulma.io/', '/');
+        return hit;
+      });
+    }
+  };
+
+  // Add an optional appId (used for development and testing)
+  if(bdSettings.algolia.app) {
+    options.appId = bdSettings.algolia.app;
+  }
+
+  docsearch(options);
+
+});

--- a/docs/lib/search.js
+++ b/docs/lib/search.js
@@ -12,10 +12,14 @@ document.addEventListener('DOMContentLoaded', function () {
 
   // Configure DocSearch
   var options = {
+    algoliaOptions: algoliaOptions,
     apiKey: bdSettings.algolia.key,
     indexName: bdSettings.algolia.index,
-    inputSelector: '#documention-search',
-    algoliaOptions: algoliaOptions,
+    inputSelector: '#documentionSearch',
+    autocompleteOptions: {
+      appendTo: "#documentionSearchWrapper",
+      hint: false
+    },
     transformData: function (hits) {
       return hits.map(function (hit) {
         hit.url = hit.url


### PR DESCRIPTION
This is a **documentation fix**.

### Proposed solution
Using Algolia's [DocSearch](https://community.algolia.com/docsearch/) for scraping, indexing, understanding the documentation’s hierarchy, and displaying search results. It would close #1325.

The scraper indexes the latest/current documentation hosted on https://bulma.io/. It also indexes previous versions of the documentation hosted on https://versions.bulma.io/ starting at version 0.6.2 (since there was no search before this version).

### Tradeoffs
The solution relies on a third-party (Algolia) to scrape and index new content. DocSearch is however used by many reputable projects such as [Bootstrap](https://getbootstrap.com/docs/4.0/getting-started/introduction/), [Vue.js](https://vuejs.org/v2/guide/), [React](https://reactjs.org/), and [many others](https://github.com/algolia/docsearch-configs/tree/master/configs).

The alternative is to use something like [jekyll-algolia](https://community.algolia.com/jekyll-algolia/) which would rebuild a new index before deploying a new documentation version. It however requires more development, and configuration. Mainly it would require custom hooks written in Ruby to reorganize the content before sending it to Algolia.

### Testing Done
Most of the solution relies on the DocSearch JavaScript and styles. Not much custom code was written. Initial testing is done using the [docsearch-scraper](https://github.com/algolia/docsearch-scraper).

For testing locally, [append the Algolia testing app to your Jekyll configuration](https://github.com/patrickdaze/bulma/commit/b5363482ef7b71018bde2b0684a10cb3cf229afb#comments).

![2018-01-23 22_04_47](https://user-images.githubusercontent.com/250287/35313654-8c914794-008f-11e8-87b7-1dab570c2e91.gif)

### Launch Requirements
- [x] Create initial DocSearch frontend implementation
- [x] Create the [DocSearch configuration](https://github.com/patrickdaze/docsearch-configs/tree/bulma-configuration)
- [ ] Collaborate with Algolia to implement the DocSearch configuration ([comment about this below](https://github.com/jgthms/bulma/pull/1622#issuecomment-360015138))
- [ ] Finalize frontend design (this PR / discussion at #1325)
- [ ] Update `_config.yml` with key and index provided by Algolia
- [ ] Update repo's documentation (if required)