### PR TITLE
Add ability to customize container width

### DIFF
--- a/sass/elements/container.sass
+++ b/sass/elements/container.sass
@@ -1,9 +1,13 @@
+$container-gap-factor-desktop: 2 !default
+$container-gap-factor-widescreen: $container-gap-factor-desktop !default
+$container-gap-factor-fullhd: $container-gap-factor-desktop !default
+
 .container
   margin: 0 auto
   position: relative
   +from($desktop)
-    max-width: $desktop - (2 * $gap)
-    width: $desktop - (2 * $gap)
+    max-width: $desktop - ($container-gap-factor-desktop * $gap)
+    width: $desktop - ($container-gap-factor-desktop * $gap)
     &.is-fluid
       margin-left: $gap
       margin-right: $gap
@@ -11,15 +15,15 @@
       width: auto
   +until($widescreen)
     &.is-widescreen
-      max-width: $widescreen - (2 * $gap)
+      max-width: $widescreen - ($container-gap-factor-widescreen * $gap)
       width: auto
   +until($fullhd)
     &.is-fullhd
-      max-width: $fullhd - (2 * $gap)
+      max-width: $fullhd - ($container-gap-factor-fullhd * $gap)
       width: auto
   +from($widescreen)
-    max-width: $widescreen - (2 * $gap)
-    width: $widescreen - (2 * $gap)
+    max-width: $widescreen - ($container-gap-factor-widescreen * $gap)
+    width: $widescreen - ($container-gap-factor-widescreen * $gap)
   +from($fullhd)
-    max-width: $fullhd - (2 * $gap)
-    width: $fullhd - (2 * $gap)
+    max-width: $fullhd - ($container-gap-factor-fullhd * $gap)
+    width: $fullhd - ($container-gap-factor-fullhd * $gap)


### PR DESCRIPTION
Container width can be tweaked using a gap "factor" or multiplier

This is an **improvement**.
It is a bit hacky (a variables for each responsive breakpoints) but enables further customization.

### Proposed solution
Using variables for `$gap` multiplier in container.sass

### Tradeoffs
None of my knowledge.

### Testing Done
Tested locally. Pretty basic stuff, I don't think further testing is needed.

### Note
Sorry, my commit message breaks the guidelines, I didn't use the present tense :/
I can git reset and recommit if you really want to.

Thank you !