### PR TITLE
Add has-bg helpers for block background colors

### DIFF
--- a/sass/base/helpers.sass
+++ b/sass/base/helpers.sass
@@ -100,6 +100,8 @@ $alignments: ('centered': 'center', 'justified': 'justify', 'left': 'left', 'rig
     &:hover,
     &:focus
       color: darken($color, 10%) !important
+  .has-bg-#{$name}
+    background-color: $color !important
 
 @each $name, $shade in $shades
   .has-text-#{$name}


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is an improvement.  There has been no simple way to add background colors in an analogous way to the `.has-text` helpers for text color, and this PR adds `.has-bg` helpers to fix the gap.

The CHANGELOG.md has been updated.

### Proposed solution
This PR adds `.has-bg` helpers which parallel the `.has-text` helpers, in order to provide background colors for blocks.

### Tradeoffs
This is the simplest solution I could come up with, and one that tries to be in line with the
existing helpers for text color.

### Testing Done
I have confirmed that block items, such as grid cells, receive the background colors indicated by the helper class.