### PR TITLE
WIP: Add footer buttons to .card

### DIFF
--- a/sass/components/card.sass
+++ b/sass/components/card.sass
@@ -65,3 +65,105 @@ $card-footer-border-top: 1px solid $border !default
 .card
   .media:not(:last-child)
     margin-bottom: 0.75rem
+
+.card-footer-button
+  align-items: center
+  background-color: $button-background-color
+  color: $button-color
+  cursor: pointer
+  display: flex
+  flex-basis: 0
+  flex-grow: 1
+  flex-shrink: 0
+  justify-content: center
+  padding: 0.75rem
+  strong
+    color: inherit
+  .icon
+    &,
+    &.is-small,
+    &.is-medium,
+    &.is-large
+      height: 1.5em
+      width: 1.5em
+    &:first-child:not(:last-child)
+      margin-left: calc(-0.375em - 1px)
+      margin-right: 0.1875em
+    &:last-child:not(:first-child)
+      margin-left: 0.1875em
+      margin-right: calc(-0.375em - 1px)
+    &:first-child:last-child
+      margin-left: calc(-0.375em - 1px)
+      margin-right: calc(-0.375em - 1px)
+  // States
+  &:hover,
+  &.is-hovered
+    color: $button-hover-color
+  &:focus,
+  &.is-focused
+    color: $button-focus-color
+  &:active,
+  &.is-active
+    color: $button-active-color
+  // Colors
+  &.is-text
+    background-color: transparent
+    color: $button-text-color
+    text-decoration: underline
+    &:hover,
+    &.is-hovered,
+    &:focus,
+    &.is-focused
+      background-color: $button-text-hover-background-color
+      color: $button-text-hover-color
+    &:active,
+    &.is-active
+      background-color: darken($button-text-hover-background-color, 5%)
+      color: $button-text-hover-color
+    &[disabled]
+      background-color: transparent
+  @each $name, $pair in $colors
+    $color: nth($pair, 1)
+    $color-invert: nth($pair, 2)
+    &.is-#{$name}
+      background-color: $color
+      color: $color-invert
+      &:hover,
+      &.is-hovered
+        background-color: darken($color, 2.5%)
+        color: $color-invert
+      &:focus,
+      &.is-focused
+        color: $color-invert
+      &:active,
+      &.is-active
+        background-color: darken($color, 5%)
+        color: $color-invert
+      &[disabled]
+        background-color: $color
+      &.is-inverted
+        background-color: $color-invert
+        color: $color
+        &:hover
+          background-color: darken($color-invert, 5%)
+        &[disabled]
+          background-color: $color-invert
+          color: $color
+      &.is-loading
+        &:after
+          border-color: transparent transparent $color-invert $color-invert !important
+  // Modifiers
+  &[disabled]
+    background-color: $button-disabled-background-color
+    opacity: $button-disabled-opacity
+  &.is-loading
+    color: transparent !important
+    pointer-events: none
+    &:after
+      +loader
+      +center(1em)
+      position: absolute !important
+  &.is-static
+    background-color: $button-static-background-color
+    color: $button-static-color
+    pointer-events: none


### PR DESCRIPTION
This is a **new feature**. Here's what we are doing:

<img width="514" alt="screen shot 2018-01-30 at 7 21 01 pm" src="https://user-images.githubusercontent.com/24803032/35555274-bf98974c-05f2-11e8-9a01-188cac71b326.png">

Currently the `.card` footer only allows `.card-footer-item`. I always want to be able to use `.button` elements in the footer instead of just plain links. This PR is a **WIP** and is more of just a suggestions of a possibility. I'm not a CSS ninja - so there could be things wrong here.

Suggestions and feedback welcomed.

### Proposed solution

Here is what I've done to achieve the current SASS...

Duplicated `.button` and then...

- Removed `+control`.
- Removed `+unselectable` (although perhaps this should be retained).
- Removed `border:` stuff.
- Removed `box-shadow:` stuff.
- Removed `.is-outlined` stuff.
- Removed **sizes**.
- Removed `.is-fullwidth`.
- Removed `.is-rounded`.
- Adjusted to match `.card-footer-item`.

### Tradeoffs

This would create a kind of `.card-footer-*` pattern which is perhaps not the best solution. Perhaps a more element agnostic solution would be better for the `.card-footer`. Going forward with this pattern would mean a (possibly substantial) increase in CSS with each new element that is added to the pattern.

@nedjo suggested this here: https://github.com/jgthms/bulma/issues/1376

### Testing Done

I've created [this codepen](https://codepen.io/timacdonald/pen/bLGXxd) with the current built css with a few examples to look at.

## Need input from Jeremy

- [ ] Can we use the button variables so we don't double up on existing rules?
- [ ] The `.card-footer-item` right border when mixing. Check out the blue, white, yellow example. I feel the white buttons right border looks weird?
- [ ] Codepen created with all possible variations to check for possible issues.
- [ ] Individual `card-footer-*` items or a more element agnostic approach.
- [ ] Ensure all existing button variations work, such as loading icon, disabled etc.

### Related

https://github.com/jgthms/bulma/issues/948
https://github.com/jgthms/bulma/issues/673