### PR TITLE
Add border + box-shadow to .delete on focus

### DIFF
--- a/sass/utilities/mixins.sass
+++ b/sass/utilities/mixins.sass
@@ -1,5 +1,9 @@
 @import "initial-variables"
 
+$delete-focus-border-color: $link !default
+$delete-focus-box-shadow-size: 0 0 0 0.125rem !default
+$delete-focus-box-shadow-color: rgba($link, 0.25) !default
+
 =arrow($color)
   border: 1px solid $color
   border-right: 0
@@ -37,7 +41,7 @@
   -moz-appearance: none
   -webkit-appearance: none
   background-color: rgba($black, 0.2)
-  border: none
+  border: 1px solid transparent
   border-radius: $radius-rounded
   cursor: pointer
   display: inline-block
@@ -65,13 +69,16 @@
     transform-origin: center center
   &:before
     height: 2px
-    width: 50%
+    width: 55%
   &:after
-    height: 50%
+    height: 55%
     width: 2px
   &:hover,
   &:focus
     background-color: rgba($black, 0.3)
+  &:focus
+    border: 1px solid $delete-focus-border-color
+    box-shadow: $delete-focus-box-shadow-size $delete-focus-box-shadow-color
   &:active
     background-color: rgba($black, 0.4)
   // Sizes


### PR DESCRIPTION
This is an **improvement**. It makes focused `.delete`-elements more visibly focused, using a similar style as focused inputs.


### Proposed solution
Currently, a focused `.delete` looks like this:
![focused_old](https://user-images.githubusercontent.com/3090888/35674229-43a6ae82-0744-11e8-8d53-7efd58c84757.png)

With this code, it would look like this:
![focused_new](https://user-images.githubusercontent.com/3090888/35674228-4389ed56-0744-11e8-99eb-e5c3a8a0fa0b.png)

### Tradeoffs
Since `.delete`'s `font-size` is set to `0`, I could not use `em`s to calculate the `box-shadow`. I tried setting different `box-shadow`s for `.is-small`, normal, `.is-medium`, and `.is-large` - setting it to width / 10 - but settled on just setting it to `0.125rem` instead, which looked fine for all sizes.

I also had to set a `1px` border on regular `.delete` and compensate by making the `:before` and `:after`'s `width` and `height` respectively larger, to not break the current look.

### Testing Done
I've tested using the built css with all aforementioned sizes of `.delete`-elements. I'm not sure if this would affect any other elements though.