### PR TITLE
Add word-break

### DIFF
--- a/sass/components/panel.sass
+++ b/sass/components/panel.sass
@@ -72,6 +72,7 @@ $panel-icon-color: $text-light !default
   display: flex
   justify-content: flex-start
   padding: 0.5em 0.75em
+  word-break: break-word
   input[type="checkbox"]
     margin-right: 0.75em
   & > .control


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **improvement**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->
Text is being overflowed from a `.panel-box` if it is long enough. So this `word-break` style is needed and especially `break-word` is the best I think.

### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->
#### Before
![before](https://i.imgur.com/8wrxwpj.png)
#### Improved
![improved](https://i.imgur.com/lWiSoQW.png)

As you can see, long file name _(left panel box)_ is overflowed but now, in the improved version, it's pretty good and has no side effect on well-broken words _(right panel box)_.

### Tradeoffs
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->
Not at all.

### Testing Done
<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->
I built it and applied to my private project. Of curse no error found.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Run `npm install` to install all Bulma dependencies -->
<!-- 3. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 4. Make sure your PR only affects `.sass` or documentation files -->

<!-- Thanks! -->
