### PR TITLE
Add $animation-duration to initial-variables

### DIFF
--- a/sass/utilities/initial-variables.sass
+++ b/sass/utilities/initial-variables.sass
@@ -64,6 +64,7 @@ $radius: 3px !default
 $radius-large: 5px !default
 $radius-rounded: 290486px !default
 $speed: 86ms !default
+$animation-duration: 500ms !default
 
 // Flags
 

--- a/sass/utilities/mixins.sass
+++ b/sass/utilities/mixins.sass
@@ -142,7 +142,7 @@
         transform: translateY(-5px) rotate(-45deg)
 
 =loader
-  animation: spinAround 500ms infinite linear
+  animation: spinAround $animation-duration infinite linear
   border: 2px solid $border
   border-radius: $radius-rounded
   border-right-color: transparent


### PR DESCRIPTION
This is an **improvement** related to #1649.

### Proposed solution

Add $animation-duration to initial-variables and use it in the loader mixin.

### Testing Done

Ran `npm run build` and tested that the correct value is present in the generated files.