### PR TITLE
Introduce mulitline button modifier

### DIFF
--- a/sass/elements/button.sass
+++ b/sass/elements/button.sass
@@ -46,7 +46,18 @@ $button-static-border-color: $grey-lighter !default
   padding-left: 0.75em
   padding-right: 0.75em
   text-align: center
-  white-space: nowrap
+  &:not(.is-multiline)
+    white-space: nowrap
+    .icon
+      &:first-child:not(:last-child)
+        margin-left: calc(-0.375em - 1px)
+        margin-right: 0.1875em
+      &:last-child:not(:first-child)
+        margin-left: 0.1875em
+        margin-right: calc(-0.375em - 1px)
+      &:first-child:last-child
+        margin-left: calc(-0.375em - 1px)
+        margin-right: calc(-0.375em - 1px)
   strong
     color: inherit
   .icon
@@ -56,15 +67,6 @@ $button-static-border-color: $grey-lighter !default
     &.is-large
       height: 1.5em
       width: 1.5em
-    &:first-child:not(:last-child)
-      margin-left: calc(-0.375em - 1px)
-      margin-right: 0.1875em
-    &:last-child:not(:first-child)
-      margin-left: 0.1875em
-      margin-right: calc(-0.375em - 1px)
-    &:first-child:last-child
-      margin-left: calc(-0.375em - 1px)
-      margin-right: calc(-0.375em - 1px)
   // States
   &:hover,
   &.is-hovered
@@ -193,6 +195,10 @@ $button-static-border-color: $grey-lighter !default
       +loader
       +center(1em)
       position: absolute !important
+  &.is-multiline
+    flex-direction: column
+    height: auto
+    min-height: 2.25em
   &.is-static
     background-color: $button-static-background-color
     border-color: $button-static-border-color


### PR DESCRIPTION
This is a **new feature**.

```html
<a href="#" class="button is-mulitline">
    My long text that I expect will be multiline on mobile
</a>
```

## Multiline Buttons

I often find I need a button that is long and I know on mobile it is going to overflow. With the current buttons in Bulma - only single lines are possible. In the past I've used notifications with the text linked for multiline style links - but thought I'd throw this out there and see if there is any interest.

### Proposed solution

Basically - ditch the `white-space` and `height`. Use the `height` as the `min-height` instead to keep consistency.

### Tradeoffs

I mean...long buttons look horrible when to long...but that is up the the dev to weigh that one up I guess 😅

### Testing Done

Checkout [this codepen](https://codepen.io/timacdonald/pen/EQmQbL). Might need to resize the preview window to see the multiline in action.

The first few examples are just a side by side to ensure that the new modifier doesn't change the general styling of the button. The later examples show what would happen if the text was to long.