### PR TITLE
[Documentation Fix] Error: 10 Different Colors

### DIFF
--- a/docs/documentation/elements/tag.html
+++ b/docs/documentation/elements/tag.html
@@ -212,7 +212,7 @@ doc-subtab: tag
 
     <div class="columns">
       <div class="column is-4">
-        Like with buttons, there are <strong>9 different colors</strong> available.
+        Like with buttons, there are <strong>10 different colors</strong> available.
       </div>
       <div class="column is-2">
         <p class="field">


### PR DESCRIPTION
In your tags page (link: https://bulma.io/documentation/elements/tag/), it mentions the following: "Like with buttons, there are **9** different colors available," in the Colors section. There should be **10 different** colors, which are as followed:
1. is-black;
2. is-dark;
3. is-light;
4. is-white;
5. is-primary;
6. is-link;
7. is-info;
8. is-success;
9. is-warning;
10. is-danger;

Just a small mistake I caught, as I was playtesting the framework. :)

Best regards.