### PR TITLE
Add .is-expanded modifier to .buttons.has-addons

### DIFF
--- a/sass/elements/button.sass
+++ b/sass/elements/button.sass
@@ -239,6 +239,8 @@ $button-static-border-color: $grey-lighter !default
         z-index: 3
         &:hover
           z-index: 4
+      &.is-expanded
+        flex-grow: 1
   &.is-centered
     justify-content: center
   &.is-right


### PR DESCRIPTION
This is a **new feature**.

Added `is-expanded` to `.buttons.has-addons` to match other expanded button functionality available in controls.

### Proposed solution

Add a `is-expanded modifier`.

### Tradeoffs
None come to mind.

### Testing Done
[See this codepen](https://codepen.io/timacdonald/pen/vdpQRz) for a quick demo.