### PR TITLE
Add breakpoint based column gaps

### DIFF
--- a/sass/grid/columns.sass
+++ b/sass/grid/columns.sass
@@ -475,39 +475,30 @@ $column-gap: 0.75rem !default
     @for $i from 0 through 8
       &.is-#{$i}
         --columnGap: #{$i * 0.25rem}
-    +mobile
-      @for $i from 0 through 8
+      +mobile
         &.is-#{$i}-mobile
           --columnGap: #{$i * 0.25rem}
-    +tablet
-      @for $i from 0 through 8
+      +tablet
         &.is-#{$i}-tablet
           --columnGap: #{$i * 0.25rem}
-    +tablet-only
-      @for $i from 0 through 8
+      +tablet-only
         &.is-#{$i}-tablet-only
           --columnGap: #{$i * 0.25rem}
-    +touch
-      @for $i from 0 through 8
+      +touch
         &.is-#{$i}-touch
           --columnGap: #{$i * 0.25rem}
-    +desktop
-      @for $i from 0 through 8
+      +desktop
         &.is-#{$i}-desktop
           --columnGap: #{$i * 0.25rem}
-    +desktop-only
-      @for $i from 0 through 8
+      +desktop-only
         &.is-#{$i}-desktop-only
           --columnGap: #{$i * 0.25rem}
-    +widescreen
-      @for $i from 0 through 8
+      +widescreen
         &.is-#{$i}-widescreen
           --columnGap: #{$i * 0.25rem}
-    +widescreen-only
-      @for $i from 0 through 8
+      +widescreen-only
         &.is-#{$i}-widescreen-only
           --columnGap: #{$i * 0.25rem}
-    +fullhd
-      @for $i from 0 through 8
+      +fullhd
         &.is-#{$i}-fullhd
           --columnGap: #{$i * 0.25rem}

--- a/sass/grid/columns.sass
+++ b/sass/grid/columns.sass
@@ -475,3 +475,39 @@ $column-gap: 0.75rem !default
     @for $i from 0 through 8
       &.is-#{$i}
         --columnGap: #{$i * 0.25rem}
+    +mobile
+      @for $i from 0 through 8
+        &.is-#{$i}-mobile
+          --columnGap: #{$i * 0.25rem}
+    +tablet
+      @for $i from 0 through 8
+        &.is-#{$i}-tablet
+          --columnGap: #{$i * 0.25rem}
+    +tablet-only
+      @for $i from 0 through 8
+        &.is-#{$i}-tablet-only
+          --columnGap: #{$i * 0.25rem}
+    +touch
+      @for $i from 0 through 8
+        &.is-#{$i}-touch
+          --columnGap: #{$i * 0.25rem}
+    +desktop
+      @for $i from 0 through 8
+        &.is-#{$i}-desktop
+          --columnGap: #{$i * 0.25rem}
+    +desktop-only
+      @for $i from 0 through 8
+        &.is-#{$i}-desktop-only
+          --columnGap: #{$i * 0.25rem}
+    +widescreen
+      @for $i from 0 through 8
+        &.is-#{$i}-widescreen
+          --columnGap: #{$i * 0.25rem}
+    +widescreen-only
+      @for $i from 0 through 8
+        &.is-#{$i}-widescreen-only
+          --columnGap: #{$i * 0.25rem}
+    +fullhd
+      @for $i from 0 through 8
+        &.is-#{$i}-fullhd
+          --columnGap: #{$i * 0.25rem}


### PR DESCRIPTION
This is a **new feature** adding breakpoint based column gap classes i.e. `is-variable is-8-desktop`

```html
<div class="columns is-variable is-mobile is-0-mobile is-8-tablet is-0-desktop is-8-widescreen">
```

### Proposed solution

Allow different column gaps at different screen widths. I needed this in my current project and thought I'd PR to see if it would be worthwhile in the core.

I believe I've implemented this to match how you've used the mixins - but please let me know if its done incorrectly - would be happy to adjust as needed.

### Tradeoffs

Generates a fair few classes.

### Testing Done

You can see it in action and play [in this codepen](https://codepen.io/timacdonald/pen/ddePWK)