### PR TITLE
Disable table hover in .content by default [Fixes #1295]

### DIFF
--- a/docs/_data/variables/elements/content.json
+++ b/docs/_data/variables/elements/content.json
@@ -61,11 +61,6 @@
       "name": "$content-table-cell-heading-color",
       "value": "$text-strong"
     },
-    "content-table-row-hover-background-color": {
-      "id": "content-table-row-hover-background-color",
-      "name": "$content-table-row-hover-background-color",
-      "value": "$background"
-    },
     "content-table-head-cell-border-width": {
       "id": "content-table-head-cell-border-width",
       "name": "$content-table-head-cell-border-width",

--- a/sass/elements/content.sass
+++ b/sass/elements/content.sass
@@ -12,7 +12,6 @@ $content-table-cell-border: 1px solid $border !default
 $content-table-cell-border-width: 0 0 1px !default
 $content-table-cell-padding: 0.5em 0.75em !default
 $content-table-cell-heading-color: $text-strong !default
-$content-table-row-hover-background-color: $background !default
 $content-table-head-cell-border-width: 0 0 2px !default
 $content-table-head-cell-color: $text-strong !default
 $content-table-foot-cell-border-width: 2px 0 0 !default

--- a/sass/elements/content.sass
+++ b/sass/elements/content.sass
@@ -117,9 +117,6 @@ $content-table-foot-cell-color: $text-strong !default
     th
       color: $content-table-cell-heading-color
       text-align: left
-    tr
-      &:hover
-        background-color: $content-table-row-hover-background-color
     thead
       td,
       th


### PR DESCRIPTION
This is a duplicate of PR #1296, which is a **bugfix** to #1295. Same commits, only now I've rebased @admench's changes as requested. 

### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->
Uses @admench's changes, which removes the table's hover background as the default background on hover. Again, fixes #1295.

### Tradeoffs
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->
The downside is needing to explicitly mark `.content` tables as `.is-hoverable`, but the previous behavior was undocumented and had no way to disable within the framework.

### Testing Done
<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->
Used in a project I'm working on, hover effects went away. 

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Run `npm install` to install all Bulma dependencies -->
<!-- 3. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 4. Make sure your PR only affects `.sass` or documentation files -->

<!-- Thanks! -->

### Docs Update
It looks like the docs changed to uses JSON content files since this change was originally suggested, let me know if I've made a mistake in updating the docs.
