### PR TITLE
Add cyan text-modifier (Fix #1711)

### DIFF
--- a/docs/_includes/color/cyan.html
+++ b/docs/_includes/color/cyan.html
@@ -1,0 +1,2 @@
+<span class="bd-color" style="background: hsl(204, 86%, 53%);"></span>
+<code>hsl(204, 86%, 53%)</code>

--- a/docs/documentation/modifiers/typography-helpers.html
+++ b/docs/documentation/modifiers/typography-helpers.html
@@ -184,7 +184,8 @@ doc-subtab: typography-helpers
         <tr><td><code>has-text-light</code></td><td>{% include color/white-ter.html %}</td></tr>
         <tr><td><code>has-text-dark</code></td><td>{% include color/grey-darker.html %}</td></tr>
         <tr><td><code>has-text-primary</code></td><td>{% include color/turquoise.html %}</td></tr>
-        <tr><td><code>has-text-info</code></td><td>{% include color/blue.html %}</td></tr>
+        <tr><td><code>has-text-info</code></td><td>{% include color/cyan.html %}</td></tr>
+        <tr><td><code>has-text-link</code></td><td>{% include color/blue.html %}</td></tr>
         <tr><td><code>has-text-success</code></td><td>{% include color/green.html %}</td></tr>
         <tr><td><code>has-text-warning</code></td><td>{% include color/yellow.html %}</td></tr>
         <tr><td><code>has-text-danger</code></td><td>{% include color/red.html %}</td></tr>


### PR DESCRIPTION
This is a **documentation fix**.

There is a typo in docs with the text-modifiers.  (#1711)

It says that `.has-text-info` is using  `$blue` `hsl(217, 71%, 53%)`. This is wrong and should be `$cyan` `hsl(204, 86%, 53%)`.

Also the `.has-text-link` modifier is missing from docs, this is the modifier that is using `$blue` `hsl(217, 71%, 53%)`.

This PR fixes both issues.

### Before
![Before](https://i.imgur.com/owxJ142.png)

### After
![After](https://i.imgur.com/ZyNxcfW.png)
