### PR TITLE
Fix margin typo for .button in .buttons

### DIFF
--- a/sass/elements/button.sass
+++ b/sass/elements/button.sass
@@ -213,10 +213,10 @@ $button-static-border-color: $grey-lighter !default
     margin-bottom: 0.5rem
     &:not(:last-child)
       margin-right: 0.5rem
-  &:last-child
-    margin-bottom: -0.5rem
-  &:not(:last-child)
-    margin-bottom: 1rem
+    &:last-child
+      margin-bottom: -0.5rem
+    &:not(:last-child)
+      margin-bottom: 1rem
   &.has-addons
     .button
       &:not(:first-child)


### PR DESCRIPTION
This is a **bugfix**.

### Proposed solution
Fix the tab spacing issue `.button` inside `.buttons` for sass

### Tradeoffs
none

### Testing Done
Yes, `.button` inside `.buttons` container have expected margins now. 