### PR TITLE
Update table.sass, fix color hover on striped rows [Fix #1710]

### DIFF
--- a/sass/elements/table.sass
+++ b/sass/elements/table.sass
@@ -98,7 +98,9 @@ $table-striped-row-even-hover-background-color: $white-ter !default
       tbody
         tr:not(.is-selected)
           &:hover
-            background-color: $table-striped-row-even-hover-background-color
+            background-color: $table-row-hover-background-color
+            &:nth-child(even)
+              background-color: $table-striped-row-even-hover-background-color
   &.is-narrow
     td,
     th


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a bugfix for #1710.

### Proposed solution
This is a very simple change to fix hover color on striped tables.
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

### Tradeoffs
N/A

### Testing Done
Result in screenshot:
![image](https://user-images.githubusercontent.com/15874076/37721688-2ff9a2c0-2cf8-11e8-9e10-1e9757c9de00.png)
![image](https://user-images.githubusercontent.com/15874076/37721694-3425006a-2cf8-11e8-8b00-79b2546ff89c.png)

