### PR TITLE
Makes adding colors easier

### DIFF
--- a/sass/utilities/derived-variables.sass
+++ b/sass/utilities/derived-variables.sass
@@ -75,8 +75,9 @@ $size-medium: $size-5 !default
 $size-large: $size-4 !default
 
 // Lists and maps
+$custom-colors: null !default
 
-$colors: ("white": ($white, $black), "black": ($black, $white), "light": ($light, $light-invert), "dark": ($dark, $dark-invert), "primary": ($primary, $primary-invert), "link": ($link, $link-invert), "info": ($info, $info-invert), "success": ($success, $success-invert), "warning": ($warning, $warning-invert), "danger": ($danger, $danger-invert)) !default
+$colors: colorMap(("white": ($white, $black), "black": ($black, $white), "light": ($light, $light-invert), "dark": ($dark, $dark-invert), "primary": ($primary, $primary-invert), "link": ($link, $link-invert), "info": ($info, $info-invert), "success": ($success, $success-invert), "warning": ($warning, $warning-invert), "danger": ($danger, $danger-invert)), $custom-colors) !default
 $shades: ("black-bis": $black-bis, "black-ter": $black-ter, "grey-darker": $grey-darker, "grey-dark": $grey-dark, "grey": $grey, "grey-light": $grey-light, "grey-lighter": $grey-lighter, "white-ter": $white-ter, "white-bis": $white-bis) !default
 
 $sizes: $size-1 $size-2 $size-3 $size-4 $size-5 $size-6 $size-7 !default

--- a/sass/utilities/functions.sass
+++ b/sass/utilities/functions.sass
@@ -1,3 +1,25 @@
+@function colorMap($bulma-colors, $custom-colors)
+  // we return at least bulma hardcoded colors
+  $merged-colors: $bulma-colors
+  // we want a map as input
+  @if type-of($custom-colors) == 'map'
+    @each $name, $components in $custom-colors
+      // color name should be a string and colors pair a list with at least one element
+      @if type-of($name) == 'string' and (type-of($components) == 'list' or type-of($components) == 'color') and length($components) >= 1
+        $color-base: nth($components, 1)
+        $color-invert: null
+        // is an inverted color provided ?
+        @if length($components) > 1
+          $color-invert: nth($components, 2)
+        // we only want a color as base color
+        @if type-of($color-base) == 'color'
+          // if inverted color is not provided or is not a color we compute it
+          @if type-of($color-invert) != 'color'
+            $color-invert: findColorInvert($color-base)
+          // we merge this colors elements as map with bulma colors (we can override them this way, no multiple definition for the same name)
+          $merged-colors: map_merge($merged-colors, ($name: ($color-base, $color-invert)))
+  @return $merged-colors
+
 @function powerNumber($number, $exp)
   $value: 1
   @if $exp > 0


### PR DESCRIPTION
This is a **improvement**.
As bulma colors are kind hard-coded into a map, which wrap colors and functions (findColorInvert), to extend them you have to import variables and functions then customize your style, then import derived variables and reassing colors to a merged map. Damn this is heavy. I've come to solution where you set you customizations to $custom-colors variable, the way bulma does, and then you import bulma, done.

### Proposed solution
Add a function in `utilities/functions.sass` that handle `$custom-colors` to merge it with bulma's `$colors` droping malformated elements. Assing it to `$colors` in `utilities/derived-variables.sass` so it can be overriden and is backward compatible with 'old' integrations.

### Tradeoffs
Can't see anyone... 1 call over whole project, with relatively small maps

### Testing Done
Customized through `$custom-colors` with malformated elements, then compiled and used in html page. All custom (proper) and base colors where accessible with `.is-#{name}` classes dependent of colors.