### PR TITLE
Fix icons floating out of input area

### DIFF
--- a/sass/elements/form.sass
+++ b/sass/elements/form.sass
@@ -538,6 +538,7 @@ $help-size: $size-small !default
   font-size: $size-normal
   position: relative
   text-align: left
+  clear: both //fixes the icon floating out of the input when help text is floated right
   // Modifiers
   // DEPRECATED
   &.has-icon


### PR DESCRIPTION
Fix the problem of the `control has-icon-*` icons floating out of the input area when a `.help` element `is-pulled-right` of a preceding field.

<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **imporvement / bugfix**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->
There are no similar problems as I don't think anyone has done the layout I used to get the layout error.


### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

Add `clear: both` to the `.control` class to account for `help` elements being pulled to the right when there are no labels between individual inputs. This sort of layout may be preferred when a minimal form is used. But when the help text is made visible everything goes out of whack.

#### Examples of the problem

<img width="1181" alt="screen shot 2018-03-23 at 21 56 34" src="https://user-images.githubusercontent.com/2767904/37853462-85a9c1d4-2eef-11e8-8e52-c1494de2de4f.png">

#### Fix Applied

Adding `clear: both`

<img width="1147" alt="screen shot 2018-03-23 at 21 56 59" src="https://user-images.githubusercontent.com/2767904/37853469-89acc010-2eef-11e8-87fc-b818a3dea1ec.png">


### Tradeoffs
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->
There are no draw backs from what I can tell. The function is supported since CSS 2.1.

### Testing Done
<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->
The feature is confirmed to be working across the browsers I have access too.
Latest Safari on Mac, Chrome Mobile, Firefox dev. and Firefox 
[Can work across all though...](https://caniuse.com/#search=clear%3A%20both)

I used the default examples from Bulma documentation to do tests on for creating the error and fixing it. Has been built on the latest release and tested in a development app.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Run `npm install` to install all Bulma dependencies -->
<!-- 3. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 4. Make sure your PR only affects `.sass` or documentation files -->

<!-- Thanks! -->