### PR TITLE
Replace deprecated elm-bulma-classes in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Browse the [online documentation here.](https://bulma.io/documentation/overview/
 | [BulmaJS](https://github.com/VizuaaLOG/BulmaJS)                                    | Javascript integration for Bulma. Written in ES6 with a data-* API |
 | [Bulma.styl](https://github.com/log1x/bulma.styl)                                  | 1:1 Stylus translation of Bulma                                    |
 | [elm-bulma](https://github.com/surprisetalk/elm-bulma)                             | Bulma + Elm                                                        |
-| [elm-bulma-classes](https://github.com/danielnarey/elm-bulma-classes)              | Bulma prepared for usage with ELM                                  |
+| [elm-bulma-classes](https://github.com/ahstro/elm-bulma-classes)                   | Bulma classes prepared for usage with Elm                          |
 | [Bulma Customizer](https://bulma-customizer.bstash.io/)                            | Bulma Customizer &#8211; Create your own **bespoke** Bulma build   |
 | [Fulma](https://mangelmaxime.github.io/Fulma/)                                     | Wrapper around Bulma for [fable-react](https://github.com/fable-compiler/fable-react)   |
 | [Laravel Enso](https://github.com/laravel-enso/enso)                               | SPA Admin Panel built with Bulma, VueJS and Laravel 			      |


### PR DESCRIPTION
Replace the deprecated [`danielnarey/elm-bulma-classes`](https://github.com/danielnarey/elm-bulma-classes) library with [`ahstro/elm-bulma-classes`](https://github.com/ahstro/elm-bulma-classes) in the "Related projects"-section of the `README.md`