### PR TITLE
Changed "scroll" to "auto" in html overflow-y

### DIFF
--- a/sass/base/generic.sass
+++ b/sass/base/generic.sass
@@ -25,7 +25,7 @@ html
   -webkit-font-smoothing: antialiased
   min-width: 300px
   overflow-x: hidden
-  overflow-y: scroll
+  overflow-y: auto
   text-rendering: $body-rendering
   text-size-adjust: 100%
 


### PR DESCRIPTION
This fixes the shown scrollbar by hiding it in a page with just "is-fullHeight" hero or 100vh and 100vw.

<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **new feature | improvement | bugfix | documentation fix**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

### Tradeoffs
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->

### Testing Done
<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Run `npm install` to install all Bulma dependencies -->
<!-- 3. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 4. Make sure your PR only affects `.sass` or documentation files -->

<!-- Thanks! -->
