### PR TITLE
Add is-small section modifier

### DIFF
--- a/docs/documentation/layout/section.html
+++ b/docs/documentation/layout/section.html
@@ -34,7 +34,7 @@ doc-subtab: section
 {% endhighlight %}
 
     <div class="content">
-      <p>You can use the modifiers <code>is-medium</code> and <code>is-large</code> to change the <strong>spacing</strong>.</p>
+      <p>You can use the modifiers <code>is-small</code>, <code>is-medium</code> and <code>is-large</code> to change the <strong>spacing</strong>.</p>
     </div>
 
     {% include variables.html %}


### PR DESCRIPTION
.is-small for section works for me. Why it wasn't listed here?

<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **documentation fix**.

### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

### Tradeoffs
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->

### Testing Done
<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Run `npm install` to install all Bulma dependencies -->
<!-- 3. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 4. Make sure your PR only affects `.sass` or documentation files -->

<!-- Thanks! -->
