### PR TITLE
Update Bulma version and download link variables in meta.json file

### DIFF
--- a/docs/_data/meta.json
+++ b/docs/_data/meta.json
@@ -2,10 +2,10 @@
   "title": "Bulma: a modern CSS framework based on Flexbox",
   "description": "Bulma is an open source CSS framework based on Flexbox and built with Sass. It's 100% responsive, fully modular, and available for free.",
   "documentation": "/documentation",
-  "download": "https://github.com/jgthms/bulma/releases/download/0.6.2/bulma-0.6.2.zip",
+  "download": "https://github.com/jgthms/bulma/releases/download/0.7.0/bulma-0.7.0.zip",
   "github": "https://github.com/jgthms/bulma",
   "twitter": "https://twitter.com/jgthms",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "book_url": "https://bleedingedgepress.com/creating-interfaces-bulma/",
   "book_amazon": "https://www.amazon.com/Creating-Interfaces-Bulma-Jeremy-Thomas-ebook/dp/B079M1BJG4/",
   "book_sample": "http://www.bleedingedgepress.com/book_excerpts/01E9D1/creating_interfaces_with_bulma_sample.pdf"


### PR DESCRIPTION
This pull request updates Bulma version and download link variables in the homepage of bulma website.

<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a documentation fix.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->
Bulma website shows and provides a link for the older version 0.6.2, I just updated the version in the link in "meta.json" file that holds the variables.
