### PR TITLE
Fixes #1789

### DIFF
--- a/sass/base/helpers.sass
+++ b/sass/base/helpers.sass
@@ -108,6 +108,8 @@ $alignments: ('centered': 'center', 'justified': 'justify', 'left': 'left', 'rig
 @each $name, $shade in $shades
   .has-text-#{$name}
     color: $shade !important
+  .has-background-#{$name}
+    background-color: $shade !important
 
 .has-text-weight-light
   font-weight: $weight-light !important


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **bugfix**.
<!-- Bugfix? Reference that issue as well. -->
Fix #1789 

### Testing Done
Added class `.has-backgound-grey` (and all other shades) to an element, and correct background color was applyed.
