### PR TITLE
fix link to the ribbon extension

### DIFF
--- a/docs/extensions.html
+++ b/docs/extensions.html
@@ -89,7 +89,7 @@ extensions:
   width: 245
   height: 139
 - name: bulma-ribbon
-  url: https://wikiki.github.io/elements/ribbon
+  url: https://github.com/Wikiki/bulma-ribbon
   slug: bulma-ribbon
   width: 323
   height: 87


### PR DESCRIPTION
This is a **documentation fix**.

The ribbon extension is not linked in the https://wikiki.github.io/ website, so the link is pointing to the GitHub repository.
