### PR TITLE
fix error message for required file fix #1137

### DIFF
--- a/sass/elements/form.sass
+++ b/sass/elements/form.sass
@@ -352,12 +352,12 @@ $help-size: $size-small !default
       border-color: darken($file-name-border-color, 5%)
 
 .file-input
-  height: 0.01em
+  height: 100%
   left: 0
   outline: none
   position: absolute
   top: 0
-  width: 0.01em
+  width: 100%
 
 .file-cta,
 .file-name


### PR DESCRIPTION
This is a bugfix

If a file input is required we dont get browser error, for that I change the with and height 

![image](https://user-images.githubusercontent.com/1175584/39115358-5a26b0ce-46d9-11e8-8274-b0cd7e9077fa.png)
