### PR TITLE
Add an extra prerequisite - ruby2.x-dev in docs/README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,8 +3,9 @@
 The documentation HTML is produced with the Ruby-based `jekyll` tool.
 
 1. Make sure Ruby 2.x is installed.
-2  Make sure ruby2.x-dev is installed
-3. `gem install jekyll`
+2. `gem install jekyll`
+
+> **Note**: If you are an ```Ubuntu user``` Make sure ruby2.x-dev is installed
 
 ## Viewing the documentation locally
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,8 @@
 The documentation HTML is produced with the Ruby-based `jekyll` tool.
 
 1. Make sure Ruby 2.x is installed.
-2. `gem install jekyll`
+2  Make sure ruby2.x-dev is installed
+3. `gem install jekyll`
 
 ## Viewing the documentation locally
 


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **documentation fix**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution
Tell users to have ```ruby2.x-dev``` installed before attempting to build the docs. Installing Jekyll on Linux (Ubuntu 16.04) machine failed because ```ruby 2.x``` was installed and ```ruby2.x-dev``` was not.
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

### Tradeoffs
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->

### Testing Done
Yes it works :smiley:.
<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Run `npm install` to install all Bulma dependencies -->
<!-- 3. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 4. Make sure your PR only affects `.sass` or documentation files -->

<!-- Thanks! -->
