### PR TITLE
Fixes #1366 - $breadcrumb-item-separator-color not inverted

### DIFF
--- a/sass/components/breadcrumb.sass
+++ b/sass/components/breadcrumb.sass
@@ -5,8 +5,6 @@ $breadcrumb-item-active-color: $text-strong !default
 $breadcrumb-item-padding-vertical: 0 !default
 $breadcrumb-item-padding-horizontal: 0.75em !default
 
-$breadcrumb-item-separator-color: $grey-light !default
-
 .breadcrumb
   +block
   +unselectable
@@ -31,8 +29,7 @@ $breadcrumb-item-separator-color: $grey-light !default
         cursor: default
         pointer-events: none
     & + li::before
-      color: $breadcrumb-item-separator-color
-      content: "\0002f"
+        content: "\0002f"
   ul,
   ol
     align-items: flex-start


### PR DESCRIPTION
This is a bugfix.

Fixes #1366.

### Proposed solution
Fix issue that prevents breadcrumb separator from being inverted based on the background (i.e. breadcrumb that is a child of hero is-dark). 

### Tradeoffs
Removes default breadcrumb separator color of #b5b5b5.

### Testing Done
Tested the breadcrumb component with different parents with classes such as is-primary and is-dark.
