### PR TITLE
Update version and download link in meta.json file

### DIFF
--- a/docs/_data/meta.json
+++ b/docs/_data/meta.json
@@ -2,10 +2,10 @@
   "title": "Bulma: a modern CSS framework based on Flexbox",
   "description": "Bulma is an open source CSS framework based on Flexbox and built with Sass. It's 100% responsive, fully modular, and available for free.",
   "documentation": "/documentation",
-  "download": "https://github.com/jgthms/bulma/releases/download/0.7.0/bulma-0.7.0.zip",
+  "download": "https://github.com/jgthms/bulma/releases/download/0.7.1/bulma-0.7.1.zip",
   "github": "https://github.com/jgthms/bulma",
   "twitter": "https://twitter.com/jgthms",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "book_url": "https://bleedingedgepress.com/creating-interfaces-bulma/",
   "book_amazon": "https://www.amazon.com/Creating-Interfaces-Bulma-Jeremy-Thomas-ebook/dp/B079M1BJG4/",
   "book_sample": "http://www.bleedingedgepress.com/book_excerpts/01E9D1/creating_interfaces_with_bulma_sample.pdf"


### PR DESCRIPTION
Similar to #1792

0.7.1 was released 7 days ago in https://github.com/jgthms/bulma/commit/6d831a7c96e3f1737b7fbdbdcd2e985964995553

This is a documentation fix.