### PR TITLE
fixiing bad default value for background color of card header, content and footer

### DIFF
--- a/docs/_data/variables/components/card.json
+++ b/docs/_data/variables/components/card.json
@@ -39,12 +39,12 @@
     "card-header-background-color": {
       "id": "card-header-background-color",
       "name": "$card-header-background-color",
-      "value": "none"
+      "value": "transparent"
     },
     "card-content-background-color": {
       "id": "card-content-background-color",
       "name": "$card-content-background-color",
-      "value": "none"
+      "value": "transparent"
     },
     "card-footer-border-top": {
       "id": "card-footer-border-top",
@@ -54,7 +54,7 @@
     "card-footer-background-color": {
       "id": "card-footer-background-color",
       "name": "$card-footer-background-color",
-      "value": "none"
+      "value": "transparent"
     }
   }
 }

--- a/sass/components/card.sass
+++ b/sass/components/card.sass
@@ -2,14 +2,14 @@ $card-color: $text !default
 $card-background-color: $white !default
 $card-shadow: 0 2px 3px rgba($black, 0.1), 0 0 0 1px rgba($black, 0.1) !default
 
-$card-header-background-color: none !default
+$card-header-background-color: transparent !default
 $card-header-color: $text-strong !default
 $card-header-shadow: 0 1px 2px rgba($black, 0.1) !default
 $card-header-weight: $weight-bold !default
 
-$card-content-background-color: none !default
+$card-content-background-color: transparent !default
 
-$card-footer-background-color: none !default
+$card-footer-background-color: transparent !default
 $card-footer-border-top: 1px solid $border !default
 
 .card


### PR DESCRIPTION
Following good https://github.com/jgthms/bulma/pull/1619#issuecomment-384550482 from @oppenheimer-, the default value for:

- card-header-background-color
- card-content-background-color
- card-footer-background-color

is moved from none (not CSS3 valid) to transparent (default CSS3 value for background-color).
