### PR TITLE
negative margin issue

### DIFF
--- a/sass/components/navbar.sass
+++ b/sass/components/navbar.sass
@@ -376,9 +376,9 @@ a.navbar-item,
   .navbar > .container,
   .container > .navbar
     .navbar-brand
-      margin-left: -1rem
+      margin-left: -.75rem
     .navbar-menu
-      margin-right: -1rem
+      margin-right: -.75rem
   // Fixed navbar
   .navbar
     &.is-fixed-bottom-desktop,


### PR DESCRIPTION

![screenshot_651](https://user-images.githubusercontent.com/31360927/39451621-f0ca1f80-4cd7-11e8-8b08-6cef0229c064.png)

The negative margin for pixel perfection should be ``0.75rem`` for ``.navbar-brand`` and ``.navbar-menu``
