### PR TITLE
fixes delete [pointer-events]

### DIFF
--- a/sass/utilities/mixins.sass
+++ b/sass/utilities/mixins.sass
@@ -175,6 +175,7 @@
   border: none
   border-radius: $radius-rounded
   cursor: pointer
+  pointer-events: auto
   display: inline-block
   flex-grow: 0
   flex-shrink: 0


### PR DESCRIPTION
<!-- Bugfix? Reference that issue as well. -->
this is bugfix, because without it, delete icon, when placed in searchbox, displays, 
but doesn't work upon click.




