### PR TITLE
Fixes issue #753

### DIFF
--- a/docs/_data/variables/components/navbar.json
+++ b/docs/_data/variables/components/navbar.json
@@ -46,6 +46,11 @@
       "name": "$navbar-item-img-max-height",
       "value": "1.75rem"
     },
+    "navbar-hamburger-color": {
+      "id": "navbar-hamburger-color",
+      "name": "$navbar-hamburger-color",
+      "value": "$navbar-item-color"
+    },
     "navbar-tab-hover-background-color": {
       "id": "navbar-tab-hover-background-color",
       "name": "$navbar-tab-hover-background-color",

--- a/sass/components/navbar.sass
+++ b/sass/components/navbar.sass
@@ -14,6 +14,8 @@ $navbar-item-active-color: $black !default
 $navbar-item-active-background-color: transparent !default
 $navbar-item-img-max-height: 1.75rem !default
 
+$navbar-hamburger-color: $navbar-item-color !default
+
 $navbar-tab-hover-background-color: transparent !default
 $navbar-tab-hover-border-bottom-color: $link !default
 $navbar-tab-active-color: $link !default
@@ -141,6 +143,7 @@ body
 .navbar-burger
   +hamburger($navbar-height)
   margin-left: auto
+  color: $navbar-hamburger-color
 
 .navbar-menu
   display: none

--- a/sass/components/navbar.sass
+++ b/sass/components/navbar.sass
@@ -141,9 +141,9 @@ body
   overflow-y: hidden
 
 .navbar-burger
+  color: $navbar-hamburger-color
   +hamburger($navbar-height)
   margin-left: auto
-  color: $navbar-hamburger-color
 
 .navbar-menu
   display: none


### PR DESCRIPTION
## Set navbar hamburger color to match items and allow manual setting

This is a **improvement** and/or **bugfix**.

### Proposed solution
This patch is a bugfix for #753 and a general improvement to the Navbar. The issue in that PR essentially highlights a gap in the current variables provided with in the Navbar.sass file. This solves that by adding a Sass variable to cover the use case.

In the docs customizing the Navbar color doesn't have this issue as it uses helper classes to set both background-color and color. When you choose to configure the Navbar color via Sass variables though you don't have this ability. Lacking this variable could require extra unnecessary lines of code in comparison to the ease provided by using the variable.

### Tradeoffs
Initially I added the variable as a copy-pasta of navbar-item-color. This could be suboptimal though because ideally navbar items and the hamburger should be similar. For example, if you set the navbar-background-color to a dark navyblue and items to to a off white then a black hamburger wouldn't be very visible.

Setting this new variable to default to the navbar-item-color allows for that potential trade-off to be negated. Also, by adding the new variable - instead of simply reusing navbar-item-color - it allows the flexibility set the uniquely if need.

### Testing Done
I have tested this feature locally within my own project I'm building with Bulma right now.