### PR TITLE
Small panel docs fix, FA 5 icon classes

### DIFF
--- a/docs/documentation/components/panel.html
+++ b/docs/documentation/components/panel.html
@@ -60,13 +60,13 @@ meta:
   </a>
   <a class="panel-block">
     <span class="panel-icon">
-      <i class="fas fa-code-fork" aria-hidden="true"></i>
+      <i class="fas fa-code-branch" aria-hidden="true"></i>
     </span>
     daniellowtw/infboard
   </a>
   <a class="panel-block">
     <span class="panel-icon">
-      <i class="fas fa-code-fork" aria-hidden="true"></i>
+      <i class="fas fa-code-branch" aria-hidden="true"></i>
     </span>
     mojs
   </a>


### PR DESCRIPTION
This is a **documentation fix**.

On [documentation panel](https://bulma.io/documentation/components/panel/) site, where panel demo is, last two icons are not showing, only placeholder is visible, which indicates that there is no such icon.
As FontAwesome 5 site states, `fa-code-branch` icon replaces Font Awesome 4's `fa-code-fork`.
Just updated two lines, where old class wasn't replaced.

### Proposed solution
Replace `fa-code-fork` class with proposed on FontAwesome 5 page `fa-code-branch`

### Tradeoffs
FontAwesome 5 has only one icon, which represents branch - in 3 different style variants.

### Testing Done
Tested on browser's inspector, works as expected - shows branch icon.
