### PR TITLE
bugfix: issues/1902 fix for ie11

### DIFF
--- a/sass/components/modal.sass
+++ b/sass/components/modal.sass
@@ -32,6 +32,7 @@ $modal-card-body-padding: 20px !default
   +overlay
   align-items: center
   display: none
+  flex-direction: column
   justify-content: center
   overflow: hidden
   position: fixed


### PR DESCRIPTION
https://github.com/jgthms/bulma/issues/1902

<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

This is a bugfix

### Proposed solution
Fixes modal not being centered on IE11

### Tradeoffs
Drawbacks: none

### Testing Done
Yes. Works in IE11, works in Chrome.
