### PR TITLE
Add docs for is-fullwidth modifier for buttons

### DIFF
--- a/docs/documentation/elements/button.html
+++ b/docs/documentation/elements/button.html
@@ -49,6 +49,13 @@ meta:
 <a class="button is-large">Large</a>
 {% endcapture %}
 
+{% capture button_displays_example %}
+<a class="button is-small is-fullwidth">Small</a>
+<a class="button is-fullwidth">Normal</a>
+<a class="button is-medium is-fullwidth">Medium</a>
+<a class="button is-large is-fullwidth">Large</a>
+{% endcapture %}
+
 {% capture button_outlined_example %}
 <a class="button is-outlined">Outlined</a>
 <a class="button is-primary is-outlined">Outlined</a>
@@ -496,6 +503,10 @@ meta:
 {% include elements/anchor.html name="Sizes" %}
 
 {% include elements/snippet.html wrapper="buttons" content=button_sizes_example %}
+
+{% include elements/anchor.html name="Displays" %}
+
+{% include elements/snippet.html wrapper="buttons" content=button_displays_example %}
 
 {% include elements/anchor.html name="Styles" %}
 


### PR DESCRIPTION
This is a **documentation fix**.

### Proposed solution
Add docs for is-fullwidth modified for buttons. Make it to fully fill the row.

Fixes #1897 