### PR TITLE
ie11 doesn't listen to size="" if it's given initial

### DIFF
--- a/sass/elements/form.sass
+++ b/sass/elements/form.sass
@@ -172,7 +172,7 @@ $help-size: $size-small !default
     &:not([multiple])
       padding-right: 2.5em
     &[multiple]
-      height: initial
+      height: auto
       padding: 0
       option
         padding: 0.5em 1em


### PR DESCRIPTION
bugfix

ie11 doesn't listen to height:initial for selectbox multiple, height:auto works on all browsers

tested in chrome, ff, ie11, edge

issue in ie11
<img width="1554" src="https://user-images.githubusercontent.com/26086545/40834570-83ec1864-6591-11e8-8851-5474660b8409.png">

fix in all browsers
<img width="2304" alt="schermafbeelding 2018-06-01 om 11 39 01" src="https://user-images.githubusercontent.com/26086545/40834595-92873d22-6591-11e8-9fae-4a18ad13717f.png">

<img width="800" alt="schermafbeelding 2018-06-01 om 11 36 32" src="https://user-images.githubusercontent.com/26086545/40834596-92a3a5d4-6591-11e8-81bb-49b798020c2f.png">

with some stuff removed, still same size="8"
<img width="1452" alt="schermafbeelding 2018-06-01 om 11 35 23" src="https://user-images.githubusercontent.com/26086545/40834598-92bef6ea-6591-11e8-9afb-0b3086b776d7.png">


