### PR TITLE
Modal card broken on IE11 fix

### DIFF
--- a/sass/components/modal.sass
+++ b/sass/components/modal.sass
@@ -72,6 +72,7 @@ $modal-card-body-padding: 20px !default
   flex-direction: column
   max-height: calc(100vh - #{$modal-card-spacing})
   overflow: hidden
+  -ms-overflow-y: visible
 
 .modal-card-head,
 .modal-card-foot


### PR DESCRIPTION
This is a bugfix

How it should be:

![image](https://user-images.githubusercontent.com/26086545/40840368-a807ac08-65a6-11e8-879d-c256be8111d9.png)

How it is:

![image](https://user-images.githubusercontent.com/26086545/40840375-aff28686-65a6-11e8-9640-f0108f4ee953.png)

Adding -ms-overflow-y: visible will only affect IE11.

Tested in IE11 in a real project and the Bulma homepage.
