### PR TITLE
 Add without-arrow class for navbar items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * #1884 New `$navbar-burger-color` variable
 * #1679 Add breakpoint based column gaps
 * #1905 Fix `modal` for IE11 #1902
+* #1919 New `is-arrowless` class for navbar items
 
 ### Bug fixes
 

--- a/docs/documentation/components/navbar.html
+++ b/docs/documentation/components/navbar.html
@@ -952,6 +952,68 @@ document.addEventListener('DOMContentLoaded', function () {
   </div>
 </div>
 
+
+{% assign vernum = site.data.meta.version | downcase | remove: "." | plus: 0 %}
+
+{% if vernum >= 72 %}
+
+<h4 class="title is-4">
+  Dropdown without arrow
+</h4>
+
+<div class="content">
+  <p>
+    You can remove the arrow in the items of the Navbar by addind the <code>navbar-dropdown</code> class to them.
+  </p>
+</div>
+
+{% highlight html %}
+<div class="navbar-item has-dropdown is-hoverable">
+  <a class="navbar-link is-arrowless">
+    Docs
+  </a>
+  <!-- navbar-dropdowns -->
+</div>
+{% endhighlight %}
+
+{% capture navbar_dropup_without_arrow_example %}
+<div class="navbar-item has-dropdown is-hoverable">
+  <a class="navbar-link is-arrowless">
+    Link without arrow
+  </a>
+  <div class="navbar-dropdown">
+    <a class="navbar-item">
+      Overview
+    </a>
+    <a class="navbar-item">
+      Elements
+    </a>
+    <a class="navbar-item">
+      Components
+    </a>
+    <hr class="navbar-divider">
+    <div class="navbar-item">
+      Version {{ site.data.meta.version }}
+    </div>
+  </div>
+</div>
+{% endcapture %}
+
+<div class="columns">
+  <div class="column">
+    <div class="bd-example is-paddingless">
+      {{ navbar_dropup_without_arrow_example }}
+    </div>
+  </div>
+
+  <div class="column">
+    {% highlight html %}{{ navbar_dropup_without_arrow_example }}{% endhighlight %}
+  </div>
+</div>
+
+{% endif %}
+
+
 <h4 class="title is-4">
   Styles for the dropdown menu
 </h4>

--- a/sass/components/navbar.sass
+++ b/sass/components/navbar.sass
@@ -198,7 +198,7 @@ a.navbar-item,
   flex-grow: 1
   flex-shrink: 1
 
-.navbar-link
+.navbar-link:not(.is-arrowless)
   padding-right: 2.5em
   &::after
     +arrow($navbar-dropdown-arrow)


### PR DESCRIPTION
It removes the arrow in the items of the Navbar.

![image](https://user-images.githubusercontent.com/16052290/41005860-7e2630a4-691f-11e8-9fc4-5c8a40a30116.png)

Closes #1833.

I have rebuilt the css and updated the documentation and the changelog. However the documentation generated css doesn't seem to include the changes:

Am I missing something? Is it maybe fixed to the current released version and is it ok like that? :thinking: 

![image](https://user-images.githubusercontent.com/16052290/41005988-f0d28f30-691f-11e8-8cdd-51c8e313e594.png)
