### PR TITLE
Change color of loading bar on inverted button

### DIFF
--- a/sass/elements/button.sass
+++ b/sass/elements/button.sass
@@ -145,9 +145,12 @@ $button-static-border-color: $grey-lighter !default
           border-color: transparent
           box-shadow: none
           color: $color
+        &.is-loading
+          &::after
+            border-color: transparent transparent $color $color
       &.is-loading
         &::after
-          border-color: transparent transparent $color-invert $color-invert !important
+          border-color: transparent transparent $color-invert $color-invert
       &.is-outlined
         background-color: transparent
         border-color: $color


### PR DESCRIPTION
Inverted and loading button i.e. ```<button class="button is-inverted is-loading">Loading</button>``` looks something like 
![capture1](https://user-images.githubusercontent.com/13885706/41664926-688328fa-74c4-11e8-8cf2-cbd070280989.PNG)
But this will change the same button to
![image](https://user-images.githubusercontent.com/13885706/41664980-8bc18f14-74c4-11e8-967a-96af7fba8ccf.png)
