### PR TITLE
add .is-spaced for .has-navbar-fixed-top/bottom in navbar

### DIFF
--- a/sass/components/navbar.sass
+++ b/sass/components/navbar.sass
@@ -403,6 +403,10 @@ a.navbar-item,
       padding-top: $navbar-height + ($navbar-padding-vertical * 2)
     &.has-spaced-navbar-fixed-bottom
       padding-bottom: $navbar-height + ($navbar-padding-vertical * 2)
+    &.has-navbar-fixed-top.is-spaced
+      padding-top: $navbar-height + ($navbar-padding-vertical * 2)
+    &.has-navbar-fixed-bottom.is-spaced
+      padding-bottom: $navbar-height + ($navbar-padding-vertical * 2)
   // Hover/Active states
   a.navbar-item,
   .navbar-link


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **improvement**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
From the design concept of Bulma, has-navbar-fixed-top/bottom classes would be better to have "is-spaced" class.
Users cannot notice has-spaced-navbar-fixed-top/bottom classes,  because they are not written in docs.

<!-- Bugfix? Reference that issue as well. -->

### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

### Tradeoffs
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->

### Testing Done

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

<!-- Thanks! -->
