### PR TITLE
Native upload button visible in latest Google Chrome

### DIFF
--- a/sass/elements/form.sass
+++ b/sass/elements/form.sass
@@ -352,12 +352,8 @@ $help-size: $size-small !default
       border-color: darken($file-name-border-color, 5%)
 
 .file-input
-  height: 0.01em
-  left: 0
-  outline: none
+  opacity: 0
   position: absolute
-  top: 0
-  width: 0.01em
 
 .file-cta,
 .file-name


### PR DESCRIPTION
This is a **bugfix**.

### Proposed solution
The recent Google Chrome on Windows and Mac seams to make the native file upload button visible, even though it should be hidden (which it is in Firefox and IE). I've managed to narrow it down to css `height` and `width` has no effect on the button itself, but only the text-field on the right. This solves #1969 and #1904.

### Tradeoffs
The `.file-input` can't be set to `display: none` or `visibility: hidden`, since third-party plugins (like jQuery Validate) can't focus on the element. Twitter Bootstrap uses `opacity: 0`, and this works very well with third-party plugins.

### Testing Done
Has tested on Windows 10 with Google Chrome, Firefox, Internet Explorer, Microsoft Edge and Safari (iOS).