### PR TITLE
Fixes #1992 - Disabled form elements hover state is overlapping, if control has add-ons elements

### DIFF
--- a/sass/elements/form.sass
+++ b/sass/elements/form.sass
@@ -449,16 +449,17 @@ $help-size: $size-small !default
       .button,
       .input,
       .select select
-        &:hover,
-        &.is-hovered
-          z-index: 2
-        &:focus,
-        &.is-focused,
-        &:active,
-        &.is-active
-          z-index: 3
-          &:hover
-            z-index: 4
+        &:not([disabled])
+          &:hover,
+          &.is-hovered
+            z-index: 2
+          &:focus,
+          &.is-focused,
+          &:active,
+          &.is-active
+            z-index: 3
+            &:hover
+              z-index: 4
       &.is-expanded
         flex-grow: 1
     &.has-addons-centered

--- a/sass/elements/form.sass
+++ b/sass/elements/form.sass
@@ -449,17 +449,16 @@ $help-size: $size-small !default
       .button,
       .input,
       .select select
-        &:not([disabled])
-          &:hover,
-          &.is-hovered
-            z-index: 2
-          &:focus,
-          &.is-focused,
-          &:active,
-          &.is-active
-            z-index: 3
-            &:hover
-              z-index: 4
+        &:hover,
+        &.is-hovered
+          z-index: 2
+        &:focus,
+        &.is-focused,
+        &:active,
+        &.is-active
+          z-index: 3
+          &:hover
+            z-index: 4
       &.is-expanded
         flex-grow: 1
     &.has-addons-centered


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a bugfix
<!-- New feature? Update the CHANGELOG.MD too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->
Disabled form elements hover state is overlapping if a control has add-ons elements

### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->
This solution excludes disabled form elements hover state which is used within has-addons fields wrapper
Fixes #1992

### Tradeoffs
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->
No tradeoffs.

### Testing Done
I checkout out master and changed the lines. Please see attached files

#### .fields.has-addons > .control > input : hover bug
![field-has-addons-disabled-input-hover-bug](https://user-images.githubusercontent.com/1259609/42712260-d6974a26-86e2-11e8-8b7a-978968090849.gif)

#### .fields.has-addons > .control > input : hover fixes
![field-has-addons-disabled-input-hover-fixed](https://user-images.githubusercontent.com/1259609/42712265-def03188-86e2-11e8-9a41-b5d1452b305c.gif)

#### example html structure
```html
<div class="field has-addons">
  <p class="control">
    <input class="input" type="text" placeholder="Your email" disabled>
  </p>
  <p class="control">
    <a class="button is-static">
      @gmail.com
    </a>
  </p>
</div>
```

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

<!-- Thanks! -->