### PR TITLE
Remove unnecessary use of @extend inside mixins

### DIFF
--- a/sass/utilities/mixins.sass
+++ b/sass/utilities/mixins.sass
@@ -130,12 +130,15 @@
 
 // Placeholders
 
-=unselectable
+%unselectable
   -webkit-touch-callout: none
   -webkit-user-select: none
   -moz-user-select: none
   -ms-user-select: none
   user-select: none
+  
+=unselectable
+  @extend %unselectable
 
 =arrow($color: transparent)
   border: 3px solid $color
@@ -157,8 +160,8 @@
   &:not(:last-child)
     margin-bottom: 1.5rem
 
-=delete
-  +unselectable
+%delete
+  @extend %unselectable
   -moz-appearance: none
   -webkit-appearance: none
   background-color: rgba($black, 0.2)
@@ -222,8 +225,11 @@
     min-height: 32px
     min-width: 32px
     width: 32px
+    
+=delete
+  @extend %delete
 
-=loader
+%loader
   animation: spinAround 500ms infinite linear
   border: 2px solid $grey-lighter
   border-radius: $radius-rounded
@@ -234,6 +240,9 @@
   height: 1em
   position: relative
   width: 1em
+
+=loader
+  @extend %loader
 
 =overlay($offset: 0)
   bottom: 0

--- a/sass/utilities/mixins.sass
+++ b/sass/utilities/mixins.sass
@@ -130,15 +130,15 @@
 
 // Placeholders
 
-%unselectable
+=unselectable
   -webkit-touch-callout: none
   -webkit-user-select: none
   -moz-user-select: none
   -ms-user-select: none
   user-select: none
-  
-=unselectable
-  @extend %unselectable
+
+%unselectable
+  +unselectable
 
 =arrow($color: transparent)
   border: 3px solid $color
@@ -156,11 +156,17 @@
   transform-origin: center
   width: 0.625em
 
+%arrow
+  +arrow
+
 =block
   &:not(:last-child)
     margin-bottom: 1.5rem
 
-%delete
+%block
+  +block
+
+=delete
   @extend %unselectable
   -moz-appearance: none
   -webkit-appearance: none
@@ -225,11 +231,11 @@
     min-height: 32px
     min-width: 32px
     width: 32px
-    
-=delete
-  @extend %delete
 
-%loader
+%delete
+  +delete
+
+=loader
   animation: spinAround 500ms infinite linear
   border: 2px solid $grey-lighter
   border-radius: $radius-rounded
@@ -241,8 +247,8 @@
   position: relative
   width: 1em
 
-=loader
-  @extend %loader
+%loader
+  +loader
 
 =overlay($offset: 0)
   bottom: 0
@@ -255,3 +261,6 @@
     left: $offset
     right: $offset
     top: $offset
+
+%overlay
+  +overlay

--- a/sass/utilities/mixins.sass
+++ b/sass/utilities/mixins.sass
@@ -130,18 +130,15 @@
 
 // Placeholders
 
-%unselectable
+=unselectable
   -webkit-touch-callout: none
   -webkit-user-select: none
   -moz-user-select: none
   -ms-user-select: none
   user-select: none
 
-=unselectable
-  @extend %unselectable
-
-%arrow
-  border: 3px solid transparent
+=arrow($color: transparent)
+  border: 3px solid $color
   border-radius: 2px
   border-right: 0
   border-top: 0
@@ -156,19 +153,12 @@
   transform-origin: center
   width: 0.625em
 
-=arrow($color)
-  @extend %arrow
-  border-color: $color
-
-%block
+=block
   &:not(:last-child)
     margin-bottom: 1.5rem
 
-=block
-  @extend %block
-
-%delete
-  @extend %unselectable
+=delete
+  +unselectable
   -moz-appearance: none
   -webkit-appearance: none
   background-color: rgba($black, 0.2)
@@ -233,12 +223,9 @@
     min-width: 32px
     width: 32px
 
-=delete
-  @extend %delete
-
-%loader
+=loader
   animation: spinAround 500ms infinite linear
-  border: 2px solid $border
+  border: 2px solid $grey-lighter
   border-radius: $radius-rounded
   border-right-color: transparent
   border-top-color: transparent
@@ -248,18 +235,12 @@
   position: relative
   width: 1em
 
-=loader
-  @extend %loader
-
-%overlay
+=overlay($offset: 0)
   bottom: 0
   left: 0
   position: absolute
   right: 0
   top: 0
-
-=overlay($offset: 0)
-  @extend %overlay
   @if $offset != 0
     bottom: $offset
     left: $offset


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **improvement/bugfix**. In the current implementation of `mixins.sass`, it is relying heavily on the use of `@extend` which are not being used elsewhere throughout Bulma causing otherwise useful mixins to fail upon compilation when attempting to use them inside of media queries.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution
Move the CSS of these various selectors inside of the mixins themselves. 
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

### Tradeoffs
None that I can find. Everything compiles as intended and none of these inheritance selectors are being used anywhere else within' Bulma or the docs.
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->

### Testing Done
Everything compiles and builds as intended. I am now able to make use of mixins such as `+arrow()` from within' media queries and the responsive mixin helpers shipped with Bulma.

The only mixins that had to be slightly modified were `+arrow()` with setting `$color` to default to `transparent` and removing the need for `border-color` since we can just set it on our initial `border` rule and `+delete()` with changing its `@extend` of `%unselectable` to use the `+unselectable` mixin instead.
<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

<!-- Thanks! -->
