### PR TITLE
<button> can be used instead of <a> for improved accessibility

### DIFF
--- a/sass/base/helpers.sass
+++ b/sass/base/helpers.sass
@@ -98,7 +98,8 @@ $alignments: ('centered': 'center', 'justified': 'justify', 'left': 'left', 'rig
   $color: nth($pair, 1)
   .has-text-#{$name}
     color: $color !important
-  a.has-text-#{$name}
+  a.has-text-#{$name},
+  button.has-text-#{$name}
     &:hover,
     &:focus
       color: darken($color, 10%) !important

--- a/sass/components/breadcrumb.sass
+++ b/sass/components/breadcrumb.sass
@@ -12,7 +12,10 @@ $breadcrumb-item-separator-color: $grey-light !default
   +unselectable
   font-size: $size-normal
   white-space: nowrap
-  a
+  button
+    +reset-button
+  a,
+  button
     align-items: center
     color: $breadcrumb-item-color
     display: flex
@@ -23,10 +26,13 @@ $breadcrumb-item-separator-color: $grey-light !default
   li
     align-items: center
     display: flex
-    &:first-child a
-      padding-left: 0
+    &:first-child
+      a,
+      button
+        padding-left: 0
     &.is-active
-      a
+      a,
+      button
         color: $breadcrumb-item-active-color
         cursor: default
         pointer-events: none

--- a/sass/components/dropdown.sass
+++ b/sass/components/dropdown.sass
@@ -48,7 +48,11 @@ $dropdown-divider-background-color: $border !default
   padding-bottom: 0.5rem
   padding-top: 0.5rem
 
-.dropdown-item
+button.dropdown-item
+  +reset-button
+
+.dropdown-item,
+button.dropdown-item
   color: $dropdown-item-color
   display: block
   font-size: 0.875rem
@@ -56,9 +60,11 @@ $dropdown-divider-background-color: $border !default
   padding: 0.375rem 1rem
   position: relative
 
-a.dropdown-item
+a.dropdown-item,
+button.dropdown-item
   padding-right: 3rem
   white-space: nowrap
+  width: 100%
   &:hover
     background-color: $dropdown-item-hover-background-color
     color: $dropdown-item-hover-color

--- a/sass/components/menu.sass
+++ b/sass/components/menu.sass
@@ -21,11 +21,15 @@ $menu-label-color: $text-light !default
 
 .menu-list
   line-height: 1.25
-  a
+  button
+    +reset-button
+  a,
+  button
     border-radius: $menu-item-radius
     color: $menu-item-color
     display: block
     padding: 0.5em 0.75em
+    width: 100%
     &:hover
       background-color: $menu-item-hover-background-color
       color: $menu-item-hover-color

--- a/sass/components/navbar.sass
+++ b/sass/components/navbar.sass
@@ -66,6 +66,7 @@ $navbar-bottom-box-shadow-size: 0 -2px 0 0 !default
         .navbar-link
           color: $color-invert
         & > a.navbar-item,
+        & > button.navbar-item,
         .navbar-link
           &:hover,
           &.is-active
@@ -81,6 +82,7 @@ $navbar-bottom-box-shadow-size: 0 -2px 0 0 !default
           .navbar-link
             color: $color-invert
           & > a.navbar-item,
+          & > button.navbar-item,
           .navbar-link
             &:hover,
             &.is-active
@@ -94,7 +96,8 @@ $navbar-bottom-box-shadow-size: 0 -2px 0 0 !default
           background-color: darken($color, 5%)
           color: $color-invert
         .navbar-dropdown
-          a.navbar-item
+          a.navbar-item,
+          button.navbar-item
             &.is-active
               background-color: $color
               color: $color-invert
@@ -130,7 +133,8 @@ body
   min-height: $navbar-height
 
 .navbar-brand
-  a.navbar-item
+  a.navbar-item,
+  button.navbar-item
     &:hover
       background-color: transparent
 
@@ -140,7 +144,11 @@ body
   overflow-x: auto
   overflow-y: hidden
 
-.navbar-burger
+button.navbar-burger
+  +reset-button
+
+.navbar-burger,
+button.navbar-burger
   color: $navbar-burger-color
   +hamburger($navbar-height)
   margin-left: auto
@@ -148,8 +156,14 @@ body
 .navbar-menu
   display: none
 
+button.navbar-item,
+button.navbar-link
+  +reset-button
+
 .navbar-item,
-.navbar-link
+button.navbar-item,
+.navbar-link,
+button.navbar-link
   color: $navbar-item-color
   display: block
   line-height: 1.5
@@ -161,6 +175,7 @@ body
       margin-right: -0.25rem
 
 a.navbar-item,
+button.navbar-item,
 .navbar-link
   cursor: pointer
   &:hover,
@@ -276,10 +291,12 @@ a.navbar-item,
       .navbar-end
         align-items: center
       a.navbar-item,
+      button.navbar-item,
       .navbar-link
         border-radius: $radius
     &.is-transparent
       a.navbar-item,
+      button.navbar-item,
       .navbar-link
         &:hover,
         &.is-active
@@ -290,7 +307,8 @@ a.navbar-item,
           .navbar-link
             background-color: transparent !important
       .navbar-dropdown
-        a.navbar-item
+        a.navbar-item,
+        button.navbar-item
           &:hover
             background-color: $navbar-dropdown-item-hover-background-color
             color: $navbar-dropdown-item-hover-color
@@ -351,8 +369,10 @@ a.navbar-item,
     .navbar-item
       padding: 0.375rem 1rem
       white-space: nowrap
-    a.navbar-item
+    a.navbar-item,
+    button.navbar-item
       padding-right: 3rem
+      width: 100%
       &:hover
         background-color: $navbar-dropdown-item-hover-background-color
         color: $navbar-dropdown-item-hover-color
@@ -405,6 +425,7 @@ a.navbar-item,
       padding-bottom: $navbar-height + ($navbar-padding-vertical * 2)
   // Hover/Active states
   a.navbar-item,
+  button.navbar-item,
   .navbar-link
     &.is-active
       color: $navbar-item-active-color

--- a/sass/components/panel.sass
+++ b/sass/components/panel.sass
@@ -28,9 +28,13 @@ $panel-icon-color: $text-light !default
   &:not(:last-child)
     margin-bottom: 1.5rem
 
+button.panel-block
+  +reset-button
+
 .panel-heading,
 .panel-tabs,
-.panel-block
+.panel-block,
+button.panel-block
   border-bottom: $panel-item-border
   border-left: $panel-item-border
   border-right: $panel-item-border
@@ -51,27 +55,38 @@ $panel-icon-color: $text-light !default
   display: flex
   font-size: 0.875em
   justify-content: center
-  a
+  button
+    +reset-button
+  a,
+  button
+    color: $link
     border-bottom: $panel-tab-border-bottom
     margin-bottom: -1px
     padding: 0.5em
+    strong
+      color: currentColor
+    &:hover
+      color: $link-hover
     // Modifiers
     &.is-active
       border-bottom-color: $panel-tab-active-border-bottom-color
       color: $panel-tab-active-color
 
 .panel-list
-  a
+  a,
+  button
     color: $panel-list-item-color
     &:hover
       color: $panel-list-item-hover-color
 
-.panel-block
+.panel-block,
+button.panel-block
   align-items: center
   color: $panel-block-color
   display: flex
   justify-content: flex-start
   padding: 0.5em 0.75em
+  width: 100%
   input[type="checkbox"]
     margin-right: 0.75em
   & > .control
@@ -87,6 +102,7 @@ $panel-icon-color: $text-light !default
       color: $panel-block-active-icon-color
 
 a.panel-block,
+button.panel-block,
 label.panel-block
   cursor: pointer
   &:hover

--- a/sass/components/tabs.sass
+++ b/sass/components/tabs.sass
@@ -37,7 +37,10 @@ $tabs-toggle-link-active-color: $link-invert !default
   overflow: hidden
   overflow-x: auto
   white-space: nowrap
-  a
+  button
+    +reset-button
+  a,
+  button
     align-items: center
     border-bottom-color: $tabs-border-bottom-color
     border-bottom-style: $tabs-border-bottom-style
@@ -54,7 +57,8 @@ $tabs-toggle-link-active-color: $link-invert !default
   li
     display: block
     &.is-active
-      a
+      a,
+      button
         border-bottom-color: $tabs-link-active-border-bottom-color
         color: $tabs-link-active-color
   ul
@@ -90,7 +94,8 @@ $tabs-toggle-link-active-color: $link-invert !default
       justify-content: flex-end
   // Styles
   &.is-boxed
-    a
+    a,
+    button
       border: 1px solid transparent
       border-radius: $tabs-boxed-link-radius $tabs-boxed-link-radius 0 0
       &:hover
@@ -98,7 +103,8 @@ $tabs-toggle-link-active-color: $link-invert !default
         border-bottom-color: $tabs-boxed-link-hover-border-bottom-color
     li
       &.is-active
-        a
+        a,
+        button
           background-color: $tabs-boxed-link-active-background-color
           border-color: $tabs-boxed-link-active-border-color
           border-bottom-color: $tabs-boxed-link-active-border-bottom-color !important
@@ -107,7 +113,8 @@ $tabs-toggle-link-active-color: $link-invert !default
       flex-grow: 1
       flex-shrink: 0
   &.is-toggle
-    a
+    a,
+    button
       border-color: $tabs-toggle-link-border-color
       border-style: $tabs-toggle-link-border-style
       border-width: $tabs-toggle-link-border-width
@@ -120,12 +127,15 @@ $tabs-toggle-link-active-color: $link-invert !default
     li
       & + li
         margin-left: -#{$tabs-toggle-link-border-width}
-      &:first-child a
+      &:first-child a,
+      &:first-child button
         border-radius: $tabs-toggle-link-radius 0 0 $tabs-toggle-link-radius
-      &:last-child a
+      &:last-child a,
+      &:last-child button
         border-radius: 0 $tabs-toggle-link-radius $tabs-toggle-link-radius 0
       &.is-active
-        a
+        a,
+        button
           background-color: $tabs-toggle-link-active-background-color
           border-color: $tabs-toggle-link-active-border-color
           color: $tabs-toggle-link-active-color
@@ -134,14 +144,18 @@ $tabs-toggle-link-active-color: $link-invert !default
       border-bottom: none
     &.is-toggle-rounded
       li
-        &:first-child a
-          border-bottom-left-radius: $radius-rounded
-          border-top-left-radius: $radius-rounded
-          padding-left: 1.25em
-        &:last-child a
-          border-bottom-right-radius: $radius-rounded
-          border-top-right-radius: $radius-rounded
-          padding-right: 1.25em
+        &:first-child
+          a,
+          button
+            border-bottom-left-radius: $radius-rounded
+            border-top-left-radius: $radius-rounded
+            padding-left: 1.25em
+        &:last-child
+          a,
+          button
+            border-bottom-right-radius: $radius-rounded
+            border-top-right-radius: $radius-rounded
+            padding-right: 1.25em
   // Sizes
   &.is-small
     font-size: $size-small

--- a/sass/elements/box.sass
+++ b/sass/elements/box.sass
@@ -16,7 +16,11 @@ $box-link-active-shadow: inset 0 1px 2px rgba($black, 0.2), 0 0 0 1px $link !def
   display: block
   padding: $box-padding
 
-a.box
+button.box
+  +reset-button
+
+a.box,
+button.box
   &:hover,
   &:focus
     box-shadow: $box-link-hover-shadow

--- a/sass/layout/hero.sass
+++ b/sass/layout/hero.sass
@@ -34,13 +34,15 @@
       .navbar-link
         color: rgba($color-invert, 0.7)
       a.navbar-item,
+      button.navbar-item,
       .navbar-link
         &:hover,
         &.is-active
           background-color: darken($color, 5%)
           color: $color-invert
       .tabs
-        a
+        a,
+        button
           color: $color-invert
           opacity: 0.9
           &:hover
@@ -50,16 +52,19 @@
             opacity: 1
         &.is-boxed,
         &.is-toggle
-          a
+          a,
+          button
             color: $color-invert
             &:hover
               background-color: rgba($black, 0.1)
-          li.is-active a
-            &,
-            &:hover
-              background-color: $color-invert
-              border-color: $color-invert
-              color: $color
+          li.is-active
+            a,
+            button
+              &,
+              &:hover
+                background-color: $color-invert
+                border-color: $color-invert
+                color: $color
       // Modifiers
       &.is-bold
         $gradient-top-left: darken(saturate(adjust-hue($color, -10deg), 10%), 10%)

--- a/sass/utilities/mixins.sass
+++ b/sass/utilities/mixins.sass
@@ -68,6 +68,22 @@
     &:#{$placeholder}-placeholder
       @content
 
+%reset-button
+  -webkit-appearance: none
+  background: transparent
+  border: none
+  color: inherit
+  cursor: pointer
+  font: inherit
+  line-height: inherit
+  margin: 0
+  overflow: visible
+  padding: 0
+  text-align: inherit
+
+=reset-button
+  @extend %reset-button
+
 // Responsiveness
 
 =from($device)


### PR DESCRIPTION
PR to address #2001
I've added `button` to every `a` selector that a `<button>` tag is appropriate for.  
There is also a `.link` class. In panels, `<button>` in the tabs would look different since the color isn't being set explicitly, this will help `<button>` blend in.  
Also I've added 100% to some places since `<button>` unlike `<a>` doesn't match its parent width by default.

closes #2001 