### PR TITLE
Fixed docs when Vimeo fails to load

### DIFF
--- a/docs/_javascript/index.js
+++ b/docs/_javascript/index.js
@@ -4,12 +4,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const introVideo = document.getElementById('introVideo');
   const introIframe = document.getElementById('introIframe');
-  const introPlayer = new Vimeo.Player(introIframe);
   const npmClipboard = new Clipboard('#npmCopy');
 
-  introPlayer.ready().then(function() {
-    introVideo.classList.add('has-loaded');
-  });
+  if (Vimeo) {
+    const introPlayer = new Vimeo.Player(introIframe);
+    introPlayer.ready().then(function() {
+      introVideo.classList.add('has-loaded');
+    });
+  }
 
   npmClipboard.on('success', function(e) {
     e.trigger.innerText = 'copied!';


### PR DESCRIPTION
All javascript breaks if Vimeo fails to load or is blocked. Checking for `Vimeo` before accessing it should fix it. This can easily be reproduced using [uMatrix](https://github.com/gorhill/uMatrix).

<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **improvement**.
All JavaScript breaks on the docs if Vimeo fails to load - such as 'add column'. Checking for Vimeo before trying to use it should fix it

### Proposed solution

Check for Vimeo before using it.

### Tradeoffs

Code doesn't look as pretty

### Testing Done

Block Vimeo using [uMatrix](https://github.com/gorhill/uMatrix) browser plugin, but I have not tested the fix. I figured this visual would still be more useful then a bug ticket though.
