### PR TITLE
Fix webpack to lowercase

### DIFF
--- a/docs/_data/links.json
+++ b/docs/_data/links.json
@@ -118,8 +118,8 @@
       "path": "/documentation/customize/with-sass-cli"
     },
     "customize-webpack": {
-      "name": "With Webpack",
-      "subtitle": "Use Bulma with Webpack",
+      "name": "With webpack",
+      "subtitle": "Use Bulma with webpack",
       "color": "warning",
       "icon_brand": "true",
       "icon": "js",

--- a/docs/documentation/customize/concepts.html
+++ b/docs/documentation/customize/concepts.html
@@ -76,7 +76,7 @@ breadcrumb:
       with the <a href="{{ site.url }}{{ sass_cli_link.path }}">Sass CLI</a>
     </li>
     <li>
-      with <a href="{{ site.url }}{{ webpack_link.path }}">Webpack</a>
+      with <a href="{{ site.url }}{{ webpack_link.path }}">webpack</a>
     </li>
   </ul>
 </div>


### PR DESCRIPTION
This is a **documentation fix**. Use `webpack` instead of `Webpack`.
