### PR TITLE
Fix documentation typo in responsiveness.html 

### DIFF
--- a/docs/documentation/overview/responsiveness.html
+++ b/docs/documentation/overview/responsiveness.html
@@ -216,7 +216,7 @@ $fullhd-enabled: false
 
 <div class="content">
   <p>
-    By default, the <code>$widecreen</code> and <code>$fullhd</code> breakpoints are <strong>enabled</strong>. You can disable them by setting the corresponding Sass boolean to <code>false</code>:
+    By default, the <code>$widescreen</code> and <code>$fullhd</code> breakpoints are <strong>enabled</strong>. You can disable them by setting the corresponding Sass boolean to <code>false</code>:
   </p>
 </div>
 


### PR DESCRIPTION
This is a **documentation fix**.

$widecreen -> $widescreen