### PR TITLE
Remove clip-path from .is-sr-only

### DIFF
--- a/sass/base/helpers.sass
+++ b/sass/base/helpers.sass
@@ -160,7 +160,6 @@ $displays: 'block' 'flex' 'inline' 'inline-block' 'inline-flex'
 
 .is-sr-only
   border: none !important
-  clip-path: inset(50%) !important
   clip: rect(0, 0, 0, 0) !important
   height: 0.01em !important
   overflow: hidden !important


### PR DESCRIPTION
see https://github.com/zurb/foundation-sites/commit/6bad0f84f4fad1cb8c71f06182d317763a83366f

There is still the clip-path property in the file bulma/docs/css/bulma-docs.css

This is a **improvement | bugfix**.

### Testing Done

None
