### PR TITLE
Add documentation for img.is-rounded (closes #1609)

### DIFF
--- a/docs/documentation/elements/image.html
+++ b/docs/documentation/elements/image.html
@@ -28,6 +28,12 @@ meta:
 </figure>
 {% endcapture %}
 
+{% capture rounded_image %}
+<figure class="image is-128x128">
+  <img class="is-rounded" src="{{site.url}}/images/placeholders/128x128.png">
+</figure>
+{% endcapture %}
+
 {% capture retina_image %}
 <figure class="image is-128x128">
   <img src="{{site.url}}/images/placeholders/256x256.png">
@@ -57,6 +63,14 @@ meta:
     {% endfor %}
   </tbody>
 </table>
+
+{% include elements/anchor.html name="Rounded images" %}
+
+<div class="content">
+  <p>You can also make rounded images, using <code>.is-rounded</code> class:</p>
+</div>
+
+{% include elements/snippet.html content=rounded_image %}
 
 {% include elements/anchor.html name="Retina images" %}
 


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **documentation fix**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

The issue #1609 asks for a rounded image, which already exists but is undocumented. This PR documents this feature.

### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->
This PR solves the problem of developers not being able to find the `.is-rounded` class.