### PR TITLE
Fixed responsive breakpoints

### DIFF
--- a/sass/utilities/initial-variables.sass
+++ b/sass/utilities/initial-variables.sass
@@ -50,12 +50,12 @@ $gap: 64px !default
 // 960, 1152, and 1344 have been chosen because they are divisible by both 12 and 16
 $tablet: 769px !default
 // 960px container + 4rem
-$desktop: 960px + (2 * $gap) !default
+$desktop: 960px + $gap !default
 // 1152px container + 4rem
-$widescreen: 1152px + (2 * $gap) !default
+$widescreen: 1152px + $gap !default
 $widescreen-enabled: true !default
 // 1344px container + 4rem
-$fullhd: 1344px + (2 * $gap) !default
+$fullhd: 1344px + $gap !default
 $fullhd-enabled: true !default
 
 // Miscellaneous


### PR DESCRIPTION
Documentation suggests breakpoints for desktop, widescreen and fullhd are from: 1024px, 1216px and 1408px respectively. Comments in sass/utilities/initial-variables.sass corroborate this (container base width + 4 rem i.e. 64px). Also, real life agrees too (e.g. desktop width traditionally starts at 1024px). Prior to this commit; desktop, widescreen and fullhd breakpoints were wrongly: 1088px, 1280px and 1472px (because $gap was multiplied twice - a hang over from when $gap was 32px rather than 64px?).

<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **new feature | improvement | bugfix | documentation fix**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

### Tradeoffs
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->

### Testing Done

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

<!-- Thanks! -->
