### PR TITLE
Remove unnecessary right margin from last level-item (level.is-mobile)

### DIFF
--- a/sass/components/level.sass
+++ b/sass/components/level.sass
@@ -18,9 +18,9 @@
     .level-item
       &:not(:last-child)
         margin-bottom: 0
+        margin-right: 0.75rem
       &:not(.is-narrow)
         flex-grow: 1
-      margin-right: 0.75rem
   // Responsiveness
   +tablet
     display: flex


### PR DESCRIPTION
This is a bugfix.

In a mobile level (`level.is-mobile`), the last level-item has unnecessary right-margin:

<img width="770" alt="2018-08-19 18 15 40" src="https://user-images.githubusercontent.com/5351911/44308564-f7d2ca80-a3f2-11e8-8e32-cda2f0f1e39d.png">

### Proposed solution

Just wrap with `&:not(:last-child)`

### Tradeoffs

None

### Testing Done

I tested with my webapp. It looks good.