### PR TITLE
Allow <button> as .dropdown-item

### DIFF
--- a/sass/components/dropdown.sass
+++ b/sass/components/dropdown.sass
@@ -56,9 +56,12 @@ $dropdown-divider-background-color: $border !default
   padding: 0.375rem 1rem
   position: relative
 
-a.dropdown-item
+a.dropdown-item,
+button.dropdown-item
   padding-right: 3rem
   white-space: nowrap
+  width: 100%
+  text-align: left
   &:hover
     background-color: $dropdown-item-hover-background-color
     color: $dropdown-item-hover-color


### PR DESCRIPTION
### Improvement

Allow a `<button>` to be a `.dropdown-item`:

```html
<div class="dropdown-menu" role="menu">
    <button type="button" class="dropdown-item">
        <i class="fas fa-fw fa-edit"></i> Edit
    </button>
</div>
```
### Proposed solution

Just style `button.dropdown-item` in addition to `a.dropdown-item`.

It needs two extra properties to work properly:

- `width: 100%` (button is not full width by default, despite `display: block`, not sure why?)
- `text-align: left` (buttons are aligned center by default)

Adding these properties to `a.dropdown-item` as well does not affect appearance, and saves a few bytes in the output, compared to creating another rule.

### Tradeoffs

None I can think of.

### Testing Done

`npm run build` compiles alright. Button looks nice inside the dropdown.
