### PR TITLE
Add "unpkg" field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "Jeremy Thomas <bbxdesign@gmail.com> (https://jgthms.com)",
   "description": "Modern CSS framework based on Flexbox",
   "main": "bulma.sass",
+  "unpkg": "css/bulma.css",
   "style": "bulma/css/bulma.min.css",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This makes <https://unpkg.com/bulma> CDN redirect to the CSS file,
not "bulma.sass" as the fallback "main" field.
