### PR TITLE
Add clarification in docs for navbar-burger, Fixes #2107

### DIFF
--- a/docs/documentation/components/navbar.html
+++ b/docs/documentation/components/navbar.html
@@ -634,7 +634,7 @@ $(document).ready(function() {
 
 <div class="content">
   <p>
-    The <code>navbar-burger</code> is a hamburger menu that only appears on <strong>mobile</strong>. It has to appear as the last child of <code>navbar-brand</code>.
+    The <code>navbar-burger</code> is a hamburger menu that only appears on <strong>mobile</strong>. It has to appear as the last child of <code>navbar-brand</code>. It has to contain three empty <code>span</code> tags in order to visualize the hamburger lines or the cross (when active).
   </p>
 </div>
 


### PR DESCRIPTION
It was not clear in the documentation that you **need** to have the 3 empty spans or otherwise the lines (and the cross) won't show up.

<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **documentation fix** for #2107 .
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

