### PR TITLE
Add and use $navbar-breakpoint variable; Fixes #1042

### DIFF
--- a/sass/components/navbar.sass
+++ b/sass/components/navbar.sass
@@ -44,6 +44,8 @@ $navbar-divider-height: 2px !default
 
 $navbar-bottom-box-shadow-size: 0 -2px 0 0 !default
 
+$navbar-breakpoint: $desktop !default
+
 =navbar-fixed
   left: 0
   position: fixed

--- a/sass/components/navbar.sass
+++ b/sass/components/navbar.sass
@@ -76,7 +76,7 @@ $navbar-breakpoint: $desktop !default
         .navbar-link
           &::after
             border-color: $color-invert
-      +desktop
+      +from($navbar-breakpoint)
         .navbar-start,
         .navbar-end
           & > .navbar-item,
@@ -223,7 +223,7 @@ a.navbar-item,
   height: $navbar-divider-height
   margin: 0.5rem 0
 
-+touch
++until($navbar-breakpoint)
   .navbar > .container
     display: block
   .navbar-brand,
@@ -264,7 +264,7 @@ a.navbar-item,
     &.has-navbar-fixed-bottom-touch
       padding-bottom: $navbar-height
 
-+desktop
++from($navbar-breakpoint)
   .navbar,
   .navbar-menu,
   .navbar-start,


### PR DESCRIPTION
This fixes the problem of a hard-coded breakpoint for when the hamburger menu becomes a full menu.

This is an improvement; it gives Bulma users needed flexibility without requiring hacking, workarounds like redefining breakpoints that may have unwanted side effects, or code duplication.

### Proposed solution

Replace hard-coded desktop/touch mixins with from/until mixins that take a new $navbar-breakpoint variable.

Fixes  #1042

Now people bringing in Bulma with Sass or SCSS can do something like the following; in their main .scss file in this example:

```
// Update Bulma's derived variables
@import "../../node_modules/bulma/sass/utilities/initial-variables.sass";
$navbar-breakpoint: $tablet;
```

### Tradeoffs

None; it continues to work identically as before if no-one sets this variable.

### Testing Done

I replaced Bulma in node_modules with a clone of my forked repository that has only this change, and it worked exactly as intended.  Bulma provided all the tools to make this an easy modification; now everyone can have access to it.

Thanks!
