### PR TITLE
Add content ol types - fixes #1940

### DIFF
--- a/sass/elements/content.sass
+++ b/sass/elements/content.sass
@@ -73,6 +73,15 @@ $content-table-foot-cell-color: $text-strong !default
     list-style: decimal outside
     margin-left: 2em
     margin-top: 1em
+    // list style modifiers emulating ol[type] attribute values different then decimal
+    &.is-lower-roman
+      list-style-type: lower-roman
+    &.is-upper-roman
+      list-style-type: upper-roman
+    &.is-lower-alpha
+      list-style-type: lower-alpha
+    &.is-upper-alpha
+      list-style-type: upper-alpha
   ul
     list-style: disc outside
     margin-left: 2em


### PR DESCRIPTION
Add list style modifiers emulating type attribute values different then decimal to ol element in content class - fixes #1940

This is an improvement.
Currently bulma content doesn't support any way of adding semantic ol types in HTML. ol type attribute added in HTML is ignored.

### Proposed solution
Add the following modifiers to content ol element:
- is-lower-roman
- is-upper-roman
- is-lower-alpha
- is-upper-alpha

### Tradeoffs
This solutions is easy to use and not coupled to any other element.
It increases build time and complexity minimally.
The performance penalty should also be negligible.

### Testing Done
I have created a simple content div with embedded ol element. I tried all classes and the display was correct. Example below.

```
<!DOCTYPE html>
<html>
  <head>
    <meta charset="utf-8">
    <meta name="viewport" content="width=device-width, initial-scale=1">
    <title>Hello Bulma!</title>
    <link rel="stylesheet" href="css/bulma.min.css">
  </head>
  <body>
  <section class="section">
    <div class="content">
      <ol class="is-upper-alpha">
        <li>ala</li>
        <li>ela</li>
      </ol>
    </div>
  </section>
  </body>
</html>
```
