### PR TITLE
Add is-12 and is-full to column documentation

### DIFF
--- a/docs/documentation/columns/sizes.html
+++ b/docs/documentation/columns/sizes.html
@@ -118,6 +118,9 @@ breadcrumb:
     <li>
       <code>is-one-quarter</code>
     </li>
+    <li>
+      <code>is-full</code>
+    </li>
   </ul>
   <p>The <em>other</em> columns will fill up the <strong>remaining</strong> space automatically.</p>
 </div>
@@ -140,6 +143,14 @@ breadcrumb:
       <code>is-one-fifth</code>
     </li>
   </ul>
+</div>
+
+<div class="columns">
+  <div class="column is-full">
+    <p class="bd-notification is-primary">
+      <code class="html">is-full</code>
+    </p>
+  </div>
 </div>
 
 <div class="columns">
@@ -287,6 +298,7 @@ breadcrumb:
     <li><code>is-9</code></li>
     <li><code>is-10</code></li>
     <li><code>is-11</code></li>
+    <li><code>is-12</code></li>
   </ul>
 </div>
 
@@ -508,6 +520,11 @@ breadcrumb:
   </div>
   <div class="column">
     <p class="bd-notification is-fojeisj has-text-centered">1</p>
+  </div>
+</div>
+<div class="columns">
+  <div class="column is-12">
+    <p class="bd-notification is-primary"><code>is-12</code></p>
   </div>
 </div>
 


### PR DESCRIPTION
Add missing css-classes to the documentation.

This is a documentation fix

### Testing Done
Run with jekyll and oculary verified the result.

E.g.
![skarmbild fran 2018-09-27 23-17-09](https://user-images.githubusercontent.com/29211472/46175375-0b076e80-c2ac-11e8-99e8-ab4bde9adb12.png)