### PR TITLE
add Accessibility section for Bootstrap

### DIFF
--- a/docs/alternative-to-bootstrap.html
+++ b/docs/alternative-to-bootstrap.html
@@ -50,6 +50,10 @@ bootstrap:
   icon: "list"
   title: "Additional elements"
   content: "Bootstrap has some **elements** like [list group](https://getbootstrap.com/components/#list-group), [wells](https://getbootstrap.com/components/#wells), or [page header](https://getbootstrap.com/components/#page-header) that Bulma doesn't have."
+- type: "bootstrap"
+  icon: "universal-access"
+  title: "Accessibility"
+  content: "Bulma has introduced some support for accessibility, but Bootstrap has strong and pervasive compatibility with **WCAG 2.0** guidelines."
 ---
 
 <div class="bd-bootstrap-message notification is-radiusless">


### PR DESCRIPTION
It looks like Bulma's accessibility profile is very slowly improving but will never match that of Bootstrap’s, short of an infinite timeline. For those of us that are legally required to meet a11y guidelines (US Government/Education), this is an important shortcoming that should be highlighted.

This is a **documentation change**.

### Proposed solution

The issues history seem to indicate that a11y is not a priority for Bulma. Highlighting Bootstrap as an alternative seems reasonable in the existing documentation section.

### Tradeoffs

People may not realize or notice that Bulma's a11y profile is non-compliant to standards until they've put work into adopting the framework.

### Testing Done

No testing done as this is only a documentation change.