### PR TITLE
[docs] Update Related Projects on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ Browse the [online documentation here.](https://bulma.io/documentation/overview/
 | [Goldfish](https://github.com/Caiyeon/goldfish)                                    | Vault UI with Bulma, Golang, and Vue Admin                         |
 | [ember-bulma](https://github.com/open-tux/ember-bulma)                             | Ember addon providing a collection of UI components for Bulma      |
 | [Bloomer](https://bloomer.js.org)                                                  | A set of React components for Bulma                                |
-| [Re-bulma](https://github.com/bokuweb/re-bulma)                                    | Bulma components build with React                                  |
 | [React-bulma](https://github.com/kulakowka/react-bulma)                            | React.js components for Bulma                                      |
 | [Buefy](https://buefy.github.io)                                                   | Lightweight UI components for Vue.js based on Bulma                |
 | [vue-bulma-components](https://github.com/vouill/vue-bulma-components)             | Bulma components for Vue.js with straightforward syntax            |


### PR DESCRIPTION
Re-Bulma is no longer maintained and should probably be removed from the README.

See here: https://github.com/bokuweb/re-bulma/blob/master/README.md

<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **documentation fix**.
