### PR TITLE
Change dropdown icon to use pure CSS, Fixes #2118

### DIFF
--- a/docs/_data/variables/components/dropdown.json
+++ b/docs/_data/variables/components/dropdown.json
@@ -9,10 +9,10 @@
     },
     "$dropdown-content-arrow": {
       "name": "$dropdown-content-arrow",
-      "value": "$link",
+      "value": "$black",
       "type": "variable",
       "computed_type": "color",
-      "computed_value": "hsl(217, 71%,  53%)"
+      "computed_value": "hsl(0, 0%, 4%)"
     },
     "$dropdown-content-offset": {
       "name": "$dropdown-content-offset",

--- a/docs/documentation/components/dropdown.html
+++ b/docs/documentation/components/dropdown.html
@@ -19,9 +19,6 @@ meta:
   <div class="dropdown-trigger">
     <button class="button" aria-haspopup="true" aria-controls="dropdown-menu">
       <span>Dropdown button</span>
-      <span class="icon is-small">
-        <i class="fas fa-angle-down" aria-hidden="true"></i>
-      </span>
     </button>
   </div>
   <div class="dropdown-menu" id="dropdown-menu" role="menu">
@@ -52,9 +49,6 @@ meta:
   <div class="dropdown-trigger">
     <button class="button" aria-haspopup="true" aria-controls="dropdown-menu2">
       <span>Content</span>
-      <span class="icon is-small">
-        <i class="fas fa-angle-down" aria-hidden="true"></i>
-      </span>
     </button>
   </div>
   <div class="dropdown-menu" id="dropdown-menu2" role="menu">
@@ -80,9 +74,6 @@ meta:
   <div class="dropdown-trigger">
     <button class="button" aria-haspopup="true" aria-controls="dropdown-menu3">
       <span>Click me</span>
-      <span class="icon is-small">
-        <i class="fas fa-angle-down" aria-hidden="true"></i>
-      </span>
     </button>
   </div>
   <div class="dropdown-menu" id="dropdown-menu3" role="menu">
@@ -122,9 +113,6 @@ meta:
   <div class="dropdown-trigger">
     <button class="button" aria-haspopup="true" aria-controls="dropdown-menu4">
       <span>Hover me</span>
-      <span class="icon is-small">
-        <i class="fas fa-angle-down" aria-hidden="true"></i>
-      </span>
     </button>
   </div>
   <div class="dropdown-menu" id="dropdown-menu4" role="menu">
@@ -142,9 +130,6 @@ meta:
   <div class="dropdown-trigger">
     <button class="button" aria-haspopup="true" aria-controls="dropdown-menu5">
       <span>Left aligned</span>
-      <span class="icon is-small">
-        <i class="fas fa-angle-down" aria-hidden="true"></i>
-      </span>
     </button>
   </div>
   <div class="dropdown-menu" id="dropdown-menu5" role="menu">
@@ -162,9 +147,6 @@ meta:
   <div class="dropdown-trigger">
     <button class="button" aria-haspopup="true" aria-controls="dropdown-menu6">
       <span>Right aligned</span>
-      <span class="icon is-small">
-        <i class="fas fa-angle-down" aria-hidden="true"></i>
-      </span>
     </button>
   </div>
   <div class="dropdown-menu" id="dropdown-menu6" role="menu">
@@ -182,9 +164,6 @@ meta:
   <div class="dropdown-trigger">
     <button class="button" aria-haspopup="true" aria-controls="dropdown-menu7">
       <span>Dropup button</span>
-      <span class="icon is-small">
-        <i class="fas fa-angle-up" aria-hidden="true"></i>
-      </span>
     </button>
   </div>
   <div class="dropdown-menu" id="dropdown-menu7" role="menu">

--- a/sass/components/dropdown.sass
+++ b/sass/components/dropdown.sass
@@ -1,5 +1,5 @@
 $dropdown-content-background-color: $white !default
-$dropdown-content-arrow: $link !default
+$dropdown-content-arrow: $black !default
 $dropdown-content-offset: 4px !default
 $dropdown-content-radius: $radius !default
 $dropdown-content-shadow: 0 2px 3px rgba($black, 0.1), 0 0 0 1px rgba($black, 0.1) !default
@@ -17,6 +17,11 @@ $dropdown-divider-background-color: $border !default
   display: inline-flex
   position: relative
   vertical-align: top
+  &::after
+    @extend %arrow
+    border-color: $dropdown-content-arrow
+    right: 1.125em
+    z-index: 4
   &.is-active,
   &.is-hoverable:hover
     .dropdown-menu
@@ -26,6 +31,9 @@ $dropdown-divider-background-color: $border !default
       left: auto
       right: 0
   &.is-up
+    &::after
+      transform: rotate(135deg)
+      top: 1.4em
     .dropdown-menu
       bottom: 100%
       padding-bottom: $dropdown-content-offset
@@ -72,3 +80,7 @@ a.dropdown-item
   display: block
   height: 1px
   margin: 0.5rem 0
+
+.dropdown-trigger
+  button
+    padding-right: 2.3em;


### PR DESCRIPTION
As in the issue #2118, Dropdown component uses fontawesome icons to display arrow. I changed so that it uses the pure CSS arrow used in for example `select` elements.

Also updated the docs to match this new markup, ´<i>´ is no longer needed in Dropdowns.