### PR TITLE
Add "has-fixed-size" to docs

### DIFF
--- a/docs/documentation/form/textarea.html
+++ b/docs/documentation/form/textarea.html
@@ -134,6 +134,12 @@ meta:
 
 {% include elements/snippet.html content=textarea_example %}
 
+{% capture fixedsize_example %}
+<div class="control">
+  <textarea class="textarea has-fixed-size" type="text" placeholder="Fixed size textarea"></textarea>
+</div>
+{% endcapture %}
+
 <div class="content">
   <p>
     You can set the height of the textarea using the `rows` HTML attribute.
@@ -200,3 +206,7 @@ meta:
 </div>
 
 {% include elements/snippet.html content=readonly_example %}
+
+<h4 class="subtitle">Fixed Size</h4>
+
+{% include elements/snippet.html content=fixedsize_example %}


### PR DESCRIPTION
This is an improvement.

The textarea `has-fixed-size` modifier is in Bulma's SASS files but not in the docs.