### PR TITLE
Added indeterminate progress bar, fixes #372

### DIFF
--- a/docs/documentation/elements/progress.html
+++ b/docs/documentation/elements/progress.html
@@ -34,6 +34,13 @@ meta:
 <progress class="progress is-large" value="60" max="100">60%</progress>
 {% endcapture %}
 
+{% capture progress_indeterminate %}
+<progress class="progress is-small is-primary" max="100">15%</progress>
+<progress class="progress is-danger" max="100">30%</progress>
+<progress class="progress is-medium is-dark" max="100">45%</progress>
+<progress class="progress is-large is-info" max="100">60%</progress>
+{% endcapture %}
+
 {% include elements/snippet.html content=progress %}
 
 {% include elements/anchor.html name="Colors" %}
@@ -43,5 +50,9 @@ meta:
 {% include elements/anchor.html name="Sizes" %}
 
 {% include elements/snippet.html content=progress_sizes %}
+
+{% include elements/anchor.html name="Indeterminate" %}
+
+{% include elements/snippet.html content=progress_indeterminate %}
 
 {% include elements/variables.html type='element' %}

--- a/sass/elements/progress.sass
+++ b/sass/elements/progress.sass
@@ -31,6 +31,21 @@ $progress-value-background-color: $text !default
         background-color: $color
       &::-ms-fill
         background-color: $color
+
+  &:indeterminate
+    &::-webkit-progress-bar
+      background-color: transparent
+    &::-moz-progress-bar
+      background-color: transparent
+
+    animation: progress-indeterminate 1.5s linear infinite
+    background: $progress-bar-background-color linear-gradient(to right, $text 30%, $progress-bar-background-color 30%) top left / 150% 150% no-repeat
+
+    @each $name, $pair in $colors
+      $color: nth($pair, 1)
+      &.is-#{$name}
+        background: $progress-bar-background-color linear-gradient(to right, $color 30%, $progress-bar-background-color 30%) top left / 150% 150% no-repeat
+
   // Sizes
   &.is-small
     height: $size-small
@@ -38,3 +53,9 @@ $progress-value-background-color: $text !default
     height: $size-medium
   &.is-large
     height: $size-large
+
+@keyframes progress-indeterminate
+  0%
+    background-position: 200% 0
+  100%
+    background-position: -200% 0


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is an improvement, fixing #372. It allows the use of indeterminate progress bars, as seen below:

![](https://user-images.githubusercontent.com/1048949/31696492-c7dbb2ce-b37f-11e7-9387-b15544a1746f.gif)

You can do this by skipping the `value` attribute in your `progress` tag.

### Proposed solution
It's an adaptation to @scottwernervt's code on the issue #372. Many other big frameworks support indeterminate progress bar styles, so why shouldn't Bulma? :smile: 

### Testing Done

Tested on Chrome and Firefox on Linux, their latest versions. I consider it should work on the recent versions of any major browser, as this solution was proposed a year ago.