### PR TITLE
bulma-start better 'getting started'

### DIFF
--- a/docs/bulma-start.html
+++ b/docs/bulma-start.html
@@ -30,24 +30,16 @@ breadcrumb:
 
 {% include elements/anchor.html name="Install" %}
 
-{% highlight bash %}
-cd your-projects-folder  
-git clone https://github.com/jgthms/bulma-start
-mv bulma-start my-new-bulma-site
-rm -rf my-new-bulma-site/.git       # remove original git settings
-{% endhighlight %}
-
-<p class="block"><em>or</em> <a href="https://github.com/jgthms/bulma-start/archive/master.zip" rel="nofollow noopener">download .zip</a></p>
-
-Now that you prepared the groundwork for your project, set up Bulma and run the watchers:
+<a href="https://github.com/jgthms/bulma-start/archive/master.zip" rel="nofollow noopener">Download bulma-start (.zip)</a>, rename to your project's name (i.e. `my-new-bulma-site`) and:
 
 {% highlight bash %}
 cd my-new-bulma-site
+rm -rf .git        # remove original git settings
 npm install
 npm start
 {% endhighlight %}
 
-For more, visit <a href="https://github.com/jgthms/bulma-start#get-your-feet-wet">project's README on Github.</a>
+For more, visit <a href="https://github.com/jgthms/bulma-start#get-your-feet-wet">bulma-start README on Github.</a>
 
 {% include elements/anchor.html name="What’s included" %}
 

--- a/docs/bulma-start.html
+++ b/docs/bulma-start.html
@@ -34,7 +34,6 @@ breadcrumb:
 
 {% highlight bash %}
 cd my-new-bulma-site
-rm -rf .git        # remove original git settings
 npm install
 npm start
 {% endhighlight %}

--- a/docs/bulma-start.html
+++ b/docs/bulma-start.html
@@ -30,11 +30,24 @@ breadcrumb:
 
 {% include elements/anchor.html name="Install" %}
 
-{% highlight bash %}npm install bulma-start{% endhighlight %}
+{% highlight bash %}
+cd your-projects-folder  
+git clone https://github.com/jgthms/bulma-start
+mv bulma-start my-new-bulma-site
+rm -rf my-new-bulma-site/.git       # remove original git settings
+{% endhighlight %}
 
-<p class="block"><em>or</em></p>
+<p class="block"><em>or</em> <a href="https://github.com/jgthms/bulma-start/archive/master.zip" rel="nofollow noopener">download .zip</a></p>
 
-{% highlight bash %}yarn add bulma-start{% endhighlight %}
+Now that you prepared the groundwork for your project, set up Bulma and run the watchers:
+
+{% highlight bash %}
+cd my-new-bulma-site
+npm install
+npm start
+{% endhighlight %}
+
+For more, visit <a href="https://github.com/jgthms/bulma-start#get-your-feet-wet">project's README on Github.</a>
 
 {% include elements/anchor.html name="What’s included" %}
 


### PR DESCRIPTION
This is a **documentation fix.**

Instructions are confused because `bulma-start` it's not an extension or component – it's a template. This way, using `npm` and copying files from `node_modules` is NOT intuitive.

`git clone` gives a better understanding of how to get started, since it's obvious that you are copying files and not adding components to your project (as usual with `npm`).

<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->




### Proposed solution
Using `git clone` instead of `npm` or `yarn`.

### Tradeoffs
User should have `git` installed – but I don't think this may be a problem, since `npm` is not native either.

_Ps: sorry for the typo on "best"_