### PR TITLE
[Docs] Bump version of examples in customize bulma section

### DIFF
--- a/docs/_data/meta.json
+++ b/docs/_data/meta.json
@@ -5,7 +5,7 @@
   "download": "https://github.com/jgthms/bulma/releases/download/0.7.1/bulma-0.7.1.zip",
   "github": "https://github.com/jgthms/bulma",
   "twitter": "https://twitter.com/jgthms",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "book_url": "https://bleedingedgepress.com/creating-interfaces-bulma/",
   "book_amazon": "https://www.amazon.com/Creating-Interfaces-Bulma-Jeremy-Thomas-ebook/dp/B079M1BJG4/",
   "book_sample": "http://www.bleedingedgepress.com/book_excerpts/01E9D1/creating_interfaces_with_bulma_sample.pdf",

--- a/docs/_data/meta.json
+++ b/docs/_data/meta.json
@@ -2,7 +2,7 @@
   "title": "Bulma: a modern CSS framework based on Flexbox",
   "description": "Bulma is an open source CSS framework based on Flexbox and built with Sass. It's 100% responsive, fully modular, and available for free.",
   "documentation": "/documentation",
-  "download": "https://github.com/jgthms/bulma/releases/download/0.7.1/bulma-0.7.1.zip",
+  "download": "https://github.com/jgthms/bulma/releases/download/0.7.2/bulma-0.7.2.zip",
   "github": "https://github.com/jgthms/bulma",
   "twitter": "https://twitter.com/jgthms",
   "version": "0.7.2",

--- a/docs/documentation/customize/with-node-sass.html
+++ b/docs/documentation/customize/with-node-sass.html
@@ -22,7 +22,7 @@ npm install bulma --save-dev
   "main": "sass/mystyles.scss",
   "license": "MIT",
   "devDependencies": {
-    "bulma": "^0.7.1",
+    "bulma": "^0.7.2",
     "node-sass": "^4.9.2"
   }
 }

--- a/docs/documentation/customize/with-webpack.html
+++ b/docs/documentation/customize/with-webpack.html
@@ -28,7 +28,7 @@ npm install webpack-cli --save-dev
   "main": "webpack.config.js",
   "license": "MIT",
   "devDependencies": {
-    "bulma": "^0.7.1",
+    "bulma": "^0.7.2",
     "css-loader": "^1.0.0",
     "extract-text-webpack-plugin": "^4.0.0-beta.0",
     "node-sass": "^4.9.2",


### PR DESCRIPTION
This pr updates the versions of examples in all the pages of [customize](https://bulma.io/documentation/customize/) section to 0.7.2