### PR TITLE
Fix some typos for arrowless dropdowns in docs

### DIFF
--- a/docs/documentation/components/navbar.html
+++ b/docs/documentation/components/navbar.html
@@ -1072,7 +1072,7 @@ $(document).ready(function() {
 
 <div class="content">
   <p>
-    You can remove the arrow in the items of the Navbar by addind the <code>navbar-dropdown</code> class to them.
+    You can remove the arrow in the items of the navbar by adding the <code>is-arrowless</code> modifier to them.
   </p>
 </div>
 


### PR DESCRIPTION
Found some typos for the `is-arrowless` modifier and changed the wording a bit so it's more consistent with the rest of the documentation.

This is a **documentation fix**.
