### PR TITLE
bugfix - added missing semicolon in docs

### DIFF
--- a/docs/_includes/steps/add-custom-styles.html
+++ b/docs/_includes/steps/add-custom-styles.html
@@ -33,7 +33,7 @@ $input-shadow: none;
 @import "../node_modules/bulma/sass/elements/container.sass";
 @import "../node_modules/bulma/sass/elements/form.sass";
 @import "../node_modules/bulma/sass/elements/title.sass";
-@import "../node_modules/bulma/sass/components/navbar.sass"
+@import "../node_modules/bulma/sass/components/navbar.sass";
 @import "../node_modules/bulma/sass/layout/hero.sass";
 @import "../node_modules/bulma/sass/layout/section.sass";
 {% endcapture %}


### PR DESCRIPTION
added in a missing semicolon that breaks imports when using sass-loader with webpack if the code is copied directly into a .SCSS file.