### PR TITLE
"flex-grow" change so "is-flexible" level item modifier works

### DIFF
--- a/sass/components/level.sass
+++ b/sass/components/level.sass
@@ -46,7 +46,7 @@
 .level-left,
 .level-right
   flex-basis: auto
-  flex-grow: 0
+  flex-grow: 1
   flex-shrink: 0
   .level-item
     // Modifiers


### PR DESCRIPTION
This is a bugfix

By default, the "is-flexible" modifier for "level-item" class does not change anything visually, that specific "level item" does not take up the majority of the parent (as I assume the modifier was meant to do?)

This has been fixed by changing the "flex-grow" property to "1" so that the modifier works.

Also, if the modifier is meant to expand the "level-item", would this be better to named "is-expanded" so that it's consistent with modifiers that do the same thing for other components e.g. navbar item?