### PR TITLE
Replace hard-coded footer padding with new footer-padding variable (Fixes #1878)

### DIFF
--- a/sass/layout/footer.sass
+++ b/sass/layout/footer.sass
@@ -1,5 +1,6 @@
 $footer-background-color: $white-bis !default
+$footer-padding: 3rem 1.5rem 6rem !default
 
 .footer
   background-color: $footer-background-color
-  padding: 3rem 1.5rem 6rem
+  padding: $footer-padding


### PR DESCRIPTION
This change addresses the problem of having hard-coded padding in the footer. It is an improvement to make the footer more flexible.

### Proposed solution
This small change adds a new `$footer-padding` variable. If the variable is not overridden the previously hard-coded default value is used.

Fixes #1878.

### Tradeoffs
None - works the same as it did previously if the variable isn't overridden.

### Testing Done
I tested with the variable enabled and disabled and it works as expected in my local project that utilizes node-sass for compilation. I also searched for any collisions with an existing `$footer-padding` variable and did not find any.

This is a tiny change. My only question would be about the consistency of padding customization. Some items have individual variables for vertical and horizontal padding, while others (like this one) have a single padding variable. I don't see an advantage of one over the other besides consistency, but maybe someone else does. An easy change regardless.

Thank you!
