### PR TITLE
proper aligning for tabs

### DIFF
--- a/sass/components/tabs.sass
+++ b/sass/components/tabs.sass
@@ -58,7 +58,7 @@ $tabs-toggle-link-active-color: $link-invert !default
         border-bottom-color: $tabs-link-active-border-bottom-color
         color: $tabs-link-active-color
   ul
-    align-items: center
+    align-items: baseline
     border-bottom-color: $tabs-border-bottom-color
     border-bottom-style: $tabs-border-bottom-style
     border-bottom-width: $tabs-border-bottom-width

--- a/sass/components/tabs.sass
+++ b/sass/components/tabs.sass
@@ -58,7 +58,7 @@ $tabs-toggle-link-active-color: $link-invert !default
         border-bottom-color: $tabs-link-active-border-bottom-color
         color: $tabs-link-active-color
   ul
-    align-items: baseline
+    align-items: center
     border-bottom-color: $tabs-border-bottom-color
     border-bottom-style: $tabs-border-bottom-style
     border-bottom-width: $tabs-border-bottom-width

--- a/sass/elements/content.sass
+++ b/sass/elements/content.sass
@@ -22,6 +22,8 @@ $content-table-foot-cell-color: $text-strong !default
   // Inline
   li + li
     margin-top: 0.25em
+  .tabs li + li 
+    margin-top: 0  
   // Block
   p,
   dl,

--- a/sass/elements/content.sass
+++ b/sass/elements/content.sass
@@ -145,6 +145,9 @@ $content-table-foot-cell-color: $text-strong !default
           td,
           th
             border-bottom-width: 0
+    .tabs
+      li + li
+        margin-top: 0          
   // Sizes
   &.is-small
     font-size: $size-small

--- a/sass/elements/content.sass
+++ b/sass/elements/content.sass
@@ -22,8 +22,8 @@ $content-table-foot-cell-color: $text-strong !default
   // Inline
   li + li
     margin-top: 0.25em
-  .tabs li + li 
-    margin-top: 0  
+    &:not(.tabs)
+      margin-top: 0
   // Block
   p,
   dl,

--- a/sass/elements/content.sass
+++ b/sass/elements/content.sass
@@ -22,8 +22,6 @@ $content-table-foot-cell-color: $text-strong !default
   // Inline
   li + li
     margin-top: 0.25em
-    &:not(.tabs)
-      margin-top: 0
   // Block
   p,
   dl,
@@ -89,11 +87,14 @@ $content-table-foot-cell-color: $text-strong !default
     list-style: disc outside
     margin-left: 2em
     margin-top: 1em
+    &:not(.tabs)
+      margin-top: 0
+    
     ul
       list-style-type: circle
       margin-top: 0.5em
       ul
-        list-style-type: square
+        list-style-type: square    
   dd
     margin-left: 2em
   figure

--- a/sass/elements/content.sass
+++ b/sass/elements/content.sass
@@ -87,8 +87,6 @@ $content-table-foot-cell-color: $text-strong !default
     list-style: disc outside
     margin-left: 2em
     margin-top: 1em
-    &:not(.tabs)
-      margin-top: 0
     
     ul
       list-style-type: circle
@@ -145,9 +143,9 @@ $content-table-foot-cell-color: $text-strong !default
           td,
           th
             border-bottom-width: 0
-    .tabs
-      li + li
-        margin-top: 0          
+  .tabs
+    li + li
+      margin-top: 0 
   // Sizes
   &.is-small
     font-size: $size-small


### PR DESCRIPTION
# This is a  bugfix.


### Proposed solution
[x] fix for #2172

replaces center with baseline, so all tabs are properly aligned.
