### PR TITLE
Add $family-secondary, $family-tertiary, and 6 font family helpers

### DIFF
--- a/docs/documentation/modifiers/typography-helpers.html
+++ b/docs/documentation/modifiers/typography-helpers.html
@@ -417,7 +417,7 @@ breadcrumb:
 
 <div class="content">
   <p>
-    You can change the font family with the use of one of <strong>5 font family helpers</strong>:
+    You can change the font family with the use of one of <strong>6 font family helpers</strong>:
   </p>
 </div>
 

--- a/docs/documentation/modifiers/typography-helpers.html
+++ b/docs/documentation/modifiers/typography-helpers.html
@@ -396,7 +396,7 @@ breadcrumb:
   <tbody>
   <tr>
     <td><code>has-text-weight-light</code></td>
-    <td>Transforms  text weight to <strong>light</strong></td>
+    <td>Transforms text weight to <strong>light</strong></td>
   </tr>
   <tr>
     <td><code>has-text-weight-normal</code></td>
@@ -412,3 +412,51 @@ breadcrumb:
   </tr>
   </tbody>
 </table>
+
+{% include elements/anchor.html name="Font family" %}
+
+<div class="content">
+  <p>
+    You can change the font family with the use of one of <strong>5 font family helpers</strong>:
+  </p>
+</div>
+
+<table class="table is-bordered">
+  <thead>
+  <tr>
+    <th>
+      Class
+    </th>
+    <th>
+      Family
+    </th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td><code>has-font-primary</code></td>
+    <td>Changes font family to <strong>$family-primary</strong></td>
+  </tr>
+  <tr>
+    <td><code>has-font-secondary</code></td>
+    <td>Changes font family to <strong>$family-secondary</strong></td>
+  </tr>
+  <tr>
+    <td><code>has-font-tertiary</code></td>
+    <td>Changes font family to <strong>$family-tertiary</strong></td>
+  </tr>
+  <tr>
+    <td><code>has-font-sans-serif</code></td>
+    <td>Changes font family to <strong>$family-sans-serif</strong></td>
+  </tr>
+  <tr>
+    <td><code>has-font-monospace</code></td>
+    <td>Changes font family to <strong>$family-monospace</strong></td>
+  </tr>
+  <tr>
+    <td><code>has-font-code</code></td>
+    <td>Changes font family to <strong>$family-code</strong></td>
+  </tr>
+  </tbody>
+</table>
+

--- a/docs/documentation/modifiers/typography-helpers.html
+++ b/docs/documentation/modifiers/typography-helpers.html
@@ -417,7 +417,8 @@ breadcrumb:
 
 <div class="content">
   <p>
-    You can change the font family with the use of one of <strong>6 font family helpers</strong>:
+    You can change the font family with the use of one of <strong>5 font family
+    helpers</strong>:
   </p>
 </div>
 
@@ -434,27 +435,23 @@ breadcrumb:
   </thead>
   <tbody>
   <tr>
-    <td><code>has-font-primary</code></td>
+    <td><code>is-family-primary</code></td>
     <td>Changes font family to <strong>$family-primary</strong></td>
   </tr>
   <tr>
-    <td><code>has-font-secondary</code></td>
+    <td><code>is-family-secondary</code></td>
     <td>Changes font family to <strong>$family-secondary</strong></td>
   </tr>
   <tr>
-    <td><code>has-font-tertiary</code></td>
-    <td>Changes font family to <strong>$family-tertiary</strong></td>
-  </tr>
-  <tr>
-    <td><code>has-font-sans-serif</code></td>
+    <td><code>is-family-sans-serif</code></td>
     <td>Changes font family to <strong>$family-sans-serif</strong></td>
   </tr>
   <tr>
-    <td><code>has-font-monospace</code></td>
+    <td><code>is-family-monospace</code></td>
     <td>Changes font family to <strong>$family-monospace</strong></td>
   </tr>
   <tr>
-    <td><code>has-font-code</code></td>
+    <td><code>is-family-code</code></td>
     <td>Changes font family to <strong>$family-code</strong></td>
   </tr>
   </tbody>

--- a/sass/base/helpers.sass
+++ b/sass/base/helpers.sass
@@ -119,18 +119,20 @@ $alignments: ('centered': 'center', 'justified': 'justify', 'left': 'left', 'rig
   font-weight: $weight-semibold !important
 .has-text-weight-bold
   font-weight: $weight-bold !important
-  
-.has-font-primary
+
+.is-family-primary
   font-family: $family-primary !important
-.has-font-secondary
+
+.is-family-secondary
   font-family: $family-secondary !important
-.has-font-tertiary
-  font-family: $family-tertiary !important
-.has-font-sans-serif
+
+.is-family-sans-serif
   font-family: $family-sans-serif !important
-.has-font-monospace
+
+.is-family-monospace
   font-family: $family-monospace !important
-.has-font-code
+
+.is-family-code
   font-family: $family-code !important
 
 // Visibility

--- a/sass/base/helpers.sass
+++ b/sass/base/helpers.sass
@@ -119,6 +119,19 @@ $alignments: ('centered': 'center', 'justified': 'justify', 'left': 'left', 'rig
   font-weight: $weight-semibold !important
 .has-text-weight-bold
   font-weight: $weight-bold !important
+  
+.has-font-primary
+  font-family: $family-primary !important
+.has-font-secondary
+  font-family: $family-secondary !important
+.has-font-tertiary
+  font-family: $family-tertiary !important
+.has-font-sans-serif
+  font-family: $family-sans-serif !important
+.has-font-monospace
+  font-family: $family-monospace !important
+.has-font-code
+  font-family: $family-code !important
 
 // Visibility
 

--- a/sass/utilities/derived-variables.sass
+++ b/sass/utilities/derived-variables.sass
@@ -68,7 +68,6 @@ $link-active-border: $grey-dark !default
 
 $family-primary: $family-sans-serif !default
 $family-secondary: $family-sans-serif !default
-$family-tertiary: $family-sans-serif !default
 $family-code: $family-monospace !default
 
 $size-small: $size-7 !default

--- a/sass/utilities/derived-variables.sass
+++ b/sass/utilities/derived-variables.sass
@@ -67,6 +67,8 @@ $link-active-border: $grey-dark !default
 // Typography
 
 $family-primary: $family-sans-serif !default
+$family-secondary: $family-sans-serif !default
+$family-tertiary: $family-sans-serif !default
 $family-code: $family-monospace !default
 
 $size-small: $size-7 !default


### PR DESCRIPTION
This is a **improvement**.

This adds a 2 new font family variables and 6 font family helpers.

I believe these variables and helpers will solve a lot of the talk that was going around in #349.

The 2 new variables $family-secondary and $family-tertiary will give people a few more semantic options for setting custom fonts and are set by default to $family-sans-serif just like $family-primary.

The 6 new helpers make it very easy to customize the text of any element:

.has-font-primary
.has-font-secondary
.has-font-tertiary
.has-font-sans-serif
.has-font-monospace
.has-font-code

These improvements work as expected,  are straightforward, and as far as I can tell should require little to practically no maintenance. The footprint of these improvements is also very light as far as size is concerned.

I personally use these improvements with Bulma, find them extremely useful and think most, if not all,  Bulma users would appreciate and use them as well (#349). Doc updates included in this PR.

Thank you for making such an amazing framework!!!






