### PR TITLE
Update bulma toast extension link

### DIFF
--- a/docs/extensions.html
+++ b/docs/extensions.html
@@ -119,7 +119,7 @@ extensions:
   width: 634
   height: 469
 - name: bulma-toast
-  url: https://rafaelfran.co/bulma-toast/
+  url: https://rfoel.com/bulma-toast/
   slug: bulma-toast
   width: 208
   height: 173


### PR DESCRIPTION
The link for bulma toast extension was broken.

This is a **documentation fix**.

