### PR TITLE
`Type` removed from textarea

### DIFF
--- a/docs/documentation/form/textarea.html
+++ b/docs/documentation/form/textarea.html
@@ -25,27 +25,27 @@ meta:
 {% capture colors_example %}
 <div class="field">
   <div class="control">
-    <textarea class="textarea is-primary" type="text" placeholder="Primary textarea"></textarea>
+    <textarea class="textarea is-primary" placeholder="Primary textarea"></textarea>
   </div>
 </div>
 <div class="field">
   <div class="control">
-    <textarea class="textarea is-info" type="text" placeholder="Info textarea"></textarea>
+    <textarea class="textarea is-info" placeholder="Info textarea"></textarea>
   </div>
 </div>
 <div class="field">
   <div class="control">
-    <textarea class="textarea is-success" type="text" placeholder="Success textarea"></textarea>
+    <textarea class="textarea is-success" placeholder="Success textarea"></textarea>
   </div>
 </div>
 <div class="field">
   <div class="control">
-    <textarea class="textarea is-warning" type="text" placeholder="Warning textarea"></textarea>
+    <textarea class="textarea is-warning" placeholder="Warning textarea"></textarea>
   </div>
 </div>
 <div class="field">
   <div class="control">
-    <textarea class="textarea is-danger" type="text" placeholder="Danger textarea"></textarea>
+    <textarea class="textarea is-danger" placeholder="Danger textarea"></textarea>
   </div>
 </div>
 {% endcapture %}
@@ -53,82 +53,82 @@ meta:
 {% capture sizes_example %}
 <div class="field">
   <div class="control">
-    <textarea class="textarea is-small" type="text" placeholder="Small textarea"></textarea>
+    <textarea class="textarea is-small" placeholder="Small textarea"></textarea>
   </div>
 </div>
 <div class="field">
   <div class="control">
-    <textarea class="textarea" type="text" placeholder="Normal textarea"></textarea>
+    <textarea class="textarea" placeholder="Normal textarea"></textarea>
   </div>
 </div>
 <div class="field">
   <div class="control">
-    <textarea class="textarea is-medium" type="text" placeholder="Medium textarea"></textarea>
+    <textarea class="textarea is-medium" placeholder="Medium textarea"></textarea>
   </div>
 </div>
 <div class="field">
   <div class="control">
-    <textarea class="textarea is-large" type="text" placeholder="Large textarea"></textarea>
+    <textarea class="textarea is-large" placeholder="Large textarea"></textarea>
   </div>
 </div>
 {% endcapture %}
 
 {% capture normal_example %}
 <div class="control">
-  <textarea class="textarea" type="text" placeholder="Normal textarea"></textarea>
+  <textarea class="textarea" placeholder="Normal textarea"></textarea>
 </div>
 {% endcapture %}
 
 {% capture hover_example %}
 <div class="control">
-  <textarea class="textarea is-hovered" type="text" placeholder="Hovered textarea"></textarea>
+  <textarea class="textarea is-hovered" placeholder="Hovered textarea"></textarea>
 </div>
 {% endcapture %}
 
 {% capture focus_example %}
 <div class="control">
-  <textarea class="textarea is-focused" type="text" placeholder="Focused textarea"></textarea>
+  <textarea class="textarea is-focused" placeholder="Focused textarea"></textarea>
 </div>
 {% endcapture %}
 
 {% capture loading_example %}
 <div class="control is-loading">
-  <textarea class="textarea" type="text" placeholder="Loading textarea"></textarea>
+  <textarea class="textarea" placeholder="Loading textarea"></textarea>
 </div>
 {% endcapture %}
 
 {% capture loading_sizes_example %}
 <div class="field">
   <div class="control is-small is-loading">
-    <textarea class="textarea is-small" type="text" placeholder="Small loading textarea"></textarea>
+    <textarea class="textarea is-small" placeholder="Small loading textarea"></textarea>
   </div>
 </div>
 <div class="field">
   <div class="control is-loading">
-    <textarea class="textarea" type="text" placeholder="Normal loading textarea"></textarea>
+    <textarea class="textarea" placeholder="Normal loading textarea"></textarea>
   </div>
 </div>
 <div class="field">
   <div class="control is-medium is-loading">
-    <textarea class="textarea is-medium" type="text" placeholder="Medium loading textarea"></textarea>
+    <textarea class="textarea is-medium" placeholder="Medium loading textarea"></textarea>
   </div>
 </div>
 <div class="field">
   <div class="control is-large is-loading">
-    <textarea class="textarea is-large" type="text" placeholder="Large loading textarea"></textarea>
+    <textarea class="textarea is-large" placeholder="Large loading textarea"></textarea>
   </div>
 </div>
 {% endcapture %}
 
 {% capture disabled_example %}
 <div class="control">
-  <textarea class="textarea" type="text" placeholder="Disabled textarea" disabled></textarea>
+  <textarea class="textarea" placeholder="Disabled textarea" disabled></textarea>
 </div>
 {% endcapture %}
 
 {% capture readonly_example %}
 <div class="control">
-  <textarea class="textarea" type="text" readonly>This content is readonly</textarea>
+  <textarea class="textarea" readonly>This content is readonly</textarea>
 </div>
 {% endcapture %}
 
@@ -136,7 +136,7 @@ meta:
 
 {% capture fixedsize_example %}
 <div class="control">
-  <textarea class="textarea has-fixed-size" type="text" placeholder="Fixed size textarea"></textarea>
+  <textarea class="textarea has-fixed-size" placeholder="Fixed size textarea"></textarea>
 </div>
 {% endcapture %}
 


### PR DESCRIPTION
This is a **documentation fix**.

`Type` is not a valid attribute for <textarea> tag. [(W3Schools)](https://www.w3schools.com/tags/tag_textarea.asp)