### PR TITLE
Fixes #1130: dropdown links underlining in Message component

### DIFF
--- a/sass/components/message.sass
+++ b/sass/components/message.sass
@@ -25,7 +25,7 @@ $message-header-body-border-width: 0 !default
   font-size: $size-normal
   strong
     color: currentColor
-  a:not(.button):not(.tag)
+  a:not(.button):not(.tag):not(.dropdown-item)
     color: currentColor
     text-decoration: underline
   // Sizes


### PR DESCRIPTION
This is a bugfix.

This is a fix for #1130 mentioning that there is a bug in Message component using the Dropdown component inside, underlining links item with a different color.

### Proposed solution
Add a `:not` pseudo-class on `.dropdown-item` for `.notification a` styles.
