### PR TITLE
Makes is-full-height-with-navbar samples match

### DIFF
--- a/docs/documentation/layout/hero.html
+++ b/docs/documentation/layout/hero.html
@@ -469,12 +469,12 @@ meta:
   </div>
 
 {% highlight html %}
-<section class="hero is-link is-fullheight">
+<section class="hero is-link is-fullheight-with-navbar">
   <div class="hero-body">
     <div class="container">
-      <h1 class="title">
+      <p class="title">
         Fullheight hero with navbar
-      </h1>
+      </p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **documentation fix**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

The code-sample in the Hero documentation didn't quite match the example. The `is-full-height-with-navbar` class had been omitted.

### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->
Add the missing class name. Also, the code-sample used `<h1>` while the example used `<p>`, so I made that match up too.
### Tradeoffs
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->
None?

### Testing Done
Ran jekyll locally-- looks good.
<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->
The code-sample now includes the `is-full-height-with-navbar` class, like so:
![2018-10-28-005909_467x183_scrot](https://user-images.githubusercontent.com/1462479/47613442-b262f700-da4c-11e8-8c90-5c5e31bd5a69.png)

<!-- Thanks! -->
