### PR TITLE
improvement - Bring code-example as readable HTML

### DIFF
--- a/docs/documentation/columns/nesting.html
+++ b/docs/documentation/columns/nesting.html
@@ -69,6 +69,8 @@ breadcrumb:
 </div>
 {% endcapture %}
 
+{{ columns_nested_example }}
+
 <div class="content">
   <p>
     Multiline columns will also have a <strong>gap</strong> between each <strong>line</strong>.

--- a/docs/documentation/columns/nesting.html
+++ b/docs/documentation/columns/nesting.html
@@ -39,6 +39,7 @@ breadcrumb:
   </p>
 </div>
 
+{% capture columns_nested_example %}
 <div class="columns">
   <div class="column">
     <p class="bd-notification is-info">First column</p>
@@ -66,9 +67,14 @@ breadcrumb:
     </div>
   </div>
 </div>
+{% endcapture %}
 
 <div class="content">
   <p>
     Multiline columns will also have a <strong>gap</strong> between each <strong>line</strong>.
   </p>
+</div>
+
+<div class="highlight-full">
+  {% highlight html %}{{ columns_nested_example }}{% endhighlight %}
 </div>


### PR DESCRIPTION
In all other documentation -> column documents there is the source code clearly written, so I missed it in the nested documentation and brought it in. Please verify and thanks for merge :+1:

<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **improvement**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
I missed the HTML to be clearly readable (without going to "view source")
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution
There was no issue. Life would go on without it, but it's easier to read, so why not?
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

### Tradeoffs
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
There are alternatives like Right-Click -> View Source.
<!-- Think of performance, build time, usability, complexity, coupling…) -->

### Testing Done
Mhm, ok, I believe it works, because I copied the commands for highlight html from gap-docs and really when you look at that tiny bits, I don't think I need to install via npm, or? I hope not, because it is too late this evening :-)

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

<!-- Thanks! -->
