### PR TITLE
add variables for setting background-color thead, tbody, tfoot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.7.3
 
 ### New features
-
+* #2206 Fix #2046 -> Set background-color for Tables via sass vars
 * #2145 Fix #372 -> New indeterminate progress bars
 
 ### Improvements

--- a/sass/elements/table.sass
+++ b/sass/elements/table.sass
@@ -11,6 +11,10 @@ $table-head-cell-color: $text-strong !default
 $table-foot-cell-border-width: 2px 0 0 !default
 $table-foot-cell-color: $text-strong !default
 
+$table-head-background-color: transparent !default
+$table-body-background-color: transparent !default
+$table-foot-background-color: transparent !default
+
 $table-row-hover-background-color: $white-bis !default
 
 $table-row-active-background-color: $primary !default
@@ -62,16 +66,19 @@ $table-striped-row-even-hover-background-color: $white-ter !default
         border-color: $table-row-active-color
         color: currentColor
   thead
+    background-color: $table-head-background-color
     td,
     th
       border-width: $table-head-cell-border-width
       color: $table-head-cell-color
   tfoot
+    background-color: $table-foot-background-color
     td,
     th
       border-width: $table-foot-cell-border-width
       color: $table-foot-cell-color
   tbody
+    background-color: $table-body-background-color
     tr
       &:last-child
         td,


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
Based off of this discussion https://github.com/jgthms/bulma/issues/2046 I have an implementation being able to set the `background-color` for tables using variables.


<!-- Choose one of the following: -->
This is a **New feature**.

### Proposed solution
Fixes #2046


### Tradeoffs
- I'm not sure what issues would be around using `background-color: transparent` as the default for `thead, tbody, tfoot`


### Testing Done
- [x] `npm run build`

I built a sample table using football example from the docs. I tested it using all of the modifiers `is-bordered is-striped is-narrow is-hoverable is-fullwidth`. I also tested it using the background helper classes on individual `<td>`

<!-- Thanks! -->
