### PR TITLE
Update docs table background vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.7.3
 
 ### New features
-
+* #2206 Fix #2046 -> Set background-color for Tables via sass vars
 * #2145 Fix #372 -> New indeterminate progress bars
 
 ### Improvements

--- a/docs/_data/variables/elements/table.json
+++ b/docs/_data/variables/elements/table.json
@@ -14,6 +14,13 @@
       "computed_type": "color",
       "computed_value": "hsl(0, 0%, 100%)"
     },
+    "$table-body-background-color": {
+      "name": "$table-body-background-color",
+      "value": "transparent",
+      "type": "variable",
+      "computed_type": "color",
+      "computed_value": "transparent"
+    },
     "$table-cell-border": {
       "name": "$table-cell-border",
       "value": "1px solid $grey-lighter",
@@ -36,6 +43,13 @@
       "computed_type": "color",
       "computed_value": "hsl(0, 0%, 21%)"
     },
+    "$table-head-background-color": {
+      "name": "$table-head-background-color",
+      "value": "transparent",
+      "type": "variable",
+      "computed_type": "color",
+      "computed_value": "transparent"
+    },
     "$table-head-cell-border-width": {
       "name": "$table-head-cell-border-width",
       "value": "0 0 2px",
@@ -47,6 +61,13 @@
       "type": "variable",
       "computed_type": "color",
       "computed_value": "hsl(0, 0%, 21%)"
+    },
+    "$table-foot-background-color": {
+      "name": "$table-foot-background-color",
+      "value": "transparent",
+      "type": "variable",
+      "computed_type": "color",
+      "computed_value": "transparent"
     },
     "$table-foot-cell-border-width": {
       "name": "$table-foot-cell-border-width",
@@ -99,12 +120,15 @@
   "list": [
     "$table-color",
     "$table-background-color",
+    "$table-body-background-color",
     "$table-cell-border",
     "$table-cell-border-width",
     "$table-cell-padding",
     "$table-cell-heading-color",
+    "$table-head-background-color",
     "$table-head-cell-border-width",
     "$table-head-cell-color",
+    "$table-foot-background-color",
     "$table-foot-cell-border-width",
     "$table-foot-cell-color",
     "$table-row-hover-background-color",

--- a/sass/elements/table.sass
+++ b/sass/elements/table.sass
@@ -11,6 +11,10 @@ $table-head-cell-color: $text-strong !default
 $table-foot-cell-border-width: 2px 0 0 !default
 $table-foot-cell-color: $text-strong !default
 
+$table-head-background-color: transparent !default
+$table-body-background-color: transparent !default
+$table-foot-background-color: transparent !default
+
 $table-row-hover-background-color: $white-bis !default
 
 $table-row-active-background-color: $primary !default
@@ -62,16 +66,19 @@ $table-striped-row-even-hover-background-color: $white-ter !default
         border-color: $table-row-active-color
         color: currentColor
   thead
+    background-color: $table-head-background-color
     td,
     th
       border-width: $table-head-cell-border-width
       color: $table-head-cell-color
   tfoot
+    background-color: $table-foot-background-color
     td,
     th
       border-width: $table-foot-cell-border-width
       color: $table-foot-cell-color
   tbody
+    background-color: $table-body-background-color
     tr
       &:last-child
         td,


### PR DESCRIPTION
<!-- Choose one of the following: -->
This is a **documentation fix**.

### Proposed solution
Updated the docs for previous PR https://github.com/jgthms/bulma/pull/2206. 

### Tradeoffs
I'm not quite sure what `type`, `computed_type`,`computed_value` so I took a guess. I'm not aware of any other use of `transparent` currently in the docs. 

### Testing Done
I ran the docs via jekyll an confirmed new variables were in on the table docs page. 
