### PR TITLE
Distinguish link color in hero container and in .is-link elements fixes #1646

### DIFF
--- a/sass/base/generic.sass
+++ b/sass/base/generic.sass
@@ -65,9 +65,10 @@ a
   text-decoration: none
   strong
     color: currentColor
+  .is-link &
+    color: $black
   &:hover
     color: $link-hover
-
 code
   background-color: $code-background
   color: $code

--- a/sass/layout/hero.sass
+++ b/sass/layout/hero.sass
@@ -17,7 +17,6 @@
     &.is-#{$name}
       background-color: $color
       color: $color-invert
-      a:not(.button):not(.dropdown-item):not(.tag),
       strong
         color: inherit
       .title


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **improvement | bugfix** for issue #1646 .
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution
In the hero container there was an exception for links not to change colors, I removed this so the links are distinguishable even in hero containers.
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

### Tradeoffs
When you add the `is-link` class to your  `.hero` container the links in it will have the same color as the background so the link will not be visible. This is the same for all elements for which you add the `.is-link` class. To remedy this I added an extra color to the generic sass for the `<a>` tag so now the link is just black. This will effect links contained in a `is-link` element everywhere.
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->

### Testing Done

Examples of some hero containers with the distinguishable links:
![image](https://user-images.githubusercontent.com/11733084/47855168-19353700-dde4-11e8-837f-549a9762f2b8.png)

Examples of tags with links, no change here except for the last `is-link` tag:

![image](https://user-images.githubusercontent.com/11733084/47855203-34a04200-dde4-11e8-9317-16d4e015e4ba.png)

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

<!-- Thanks! -->
