### PR TITLE
Add customizable border radius to progressbar

### DIFF
--- a/docs/_data/variables/elements/progress.json
+++ b/docs/_data/variables/elements/progress.json
@@ -18,12 +18,18 @@
       "name": "$progress-indeterminate-duration",
       "value": "1.5s",
       "type": "string"
+    },
+    "$progress-border-radius": {
+      "name": "$progress-border-radius",
+      "value": "$radius-rounded",
+      "type": "variable"
     }
   },
   "list": [
     "$progress-bar-background-color",
     "$progress-value-background-color",
-    "$progress-indeterminate-duration"
+    "$progress-indeterminate-duration",
+    "$progress-border-radius"
   ],
   "file_path": "elements/progress.sass"
 }

--- a/sass/elements/progress.sass
+++ b/sass/elements/progress.sass
@@ -1,5 +1,6 @@
 $progress-bar-background-color: $border !default
 $progress-value-background-color: $text !default
+$progress-border-radius: $radius-rounded !default
 
 $progress-indeterminate-duration: 1.5s !default
 
@@ -8,7 +9,7 @@ $progress-indeterminate-duration: 1.5s !default
   -moz-appearance: none
   -webkit-appearance: none
   border: none
-  border-radius: $radius-rounded
+  border-radius: $progress-border-radius
   display: block
   height: $size-normal
   overflow: hidden


### PR DESCRIPTION
This is a **improvement**.

`$radius-rounded` is not meant to be modified and is used directly to style progress bars. We need a dedicated variable to override this style if needed.

### Proposed solution
Add `$progress-border-radius` into `sass/elements/progress.sass` with `$radius-rounded` as default value.

### Tradeoffs
None

### Testing Done

For each test.
Defined `$progress-border-radius` to some values (px/rem/%), then imported bulma.
Checked the border-radius, with built css file, over progress element : ok.

Did the same with jekyll for the docs.
