### PR TITLE
has-text-weight-medium should exist

### DIFF
--- a/sass/base/helpers.sass
+++ b/sass/base/helpers.sass
@@ -115,6 +115,8 @@ $alignments: ('centered': 'center', 'justified': 'justify', 'left': 'left', 'rig
   font-weight: $weight-light !important
 .has-text-weight-normal
   font-weight: $weight-normal !important
+.has-text-weight-medium
+  font-weight: $weight-medium !important
 .has-text-weight-semibold
   font-weight: $weight-semibold !important
 .has-text-weight-bold


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is an improvement.

There is no reason why has-text-weight-medium shouldn't exist, font-weight: 500 is a pretty common font-weight.