### PR TITLE
Add style to disabled file input field

### DIFF
--- a/sass/elements/form.sass
+++ b/sass/elements/form.sass
@@ -381,6 +381,9 @@ $help-size: $size-small !default
   background-color: $file-cta-background-color
   color: $file-cta-color
 
+.file-input[disabled] ~ .file-cta
+  opacity: 0.5
+
 .file-name
   border-color: $file-name-border-color
   border-style: $file-name-border-style


### PR DESCRIPTION
Just as with the button element we add an opacity rule when the file input is disabled.

This is an improvement.
Previously a disabled file input field was not styled differently from an enabled one.

### Tradeoffs
This relies on the .file-cta element being a sibling of the .file-input element.
The `~` selector still gives the user some freedom with respect to the structure of the html.
Alternatively one could use the `+` selector, which trades this flexibility for better efficiency.

### Testing Done
I have tested this feature on my existing forms and it works without any issues.

