### PR TITLE
Fix typo (remove extra word "add")

### DIFF
--- a/docs/documentation/form/radio.html
+++ b/docs/documentation/form/radio.html
@@ -92,7 +92,7 @@ meta:
 
 <div class="content">
   <p>
-    You can add <strong>disable</strong> a radio button by adding the <code>disabled</code> HTML attribute to both the <code>&lt;label&gt;</code> and the <code>&lt;input&gt;</code>.
+    You can <strong>disable</strong> a radio button by adding the <code>disabled</code> HTML attribute to both the <code>&lt;label&gt;</code> and the <code>&lt;input&gt;</code>.
   </p>
 </div>
 


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **documentation fix**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->
The [page on radio buttons](https://bulma.io/documentation/form/radio/) has a small typo. This pull request removes the extra, unnecessary word `add` from the line `You can add disable a radio button...`