### PR TITLE
Fix rounded button paddings using a variable

### DIFF
--- a/sass/elements/button.sass
+++ b/sass/elements/button.sass
@@ -219,8 +219,8 @@ $button-static-border-color: $grey-lighter !default
     pointer-events: none
   &.is-rounded
     border-radius: $radius-rounded
-    padding-left: 1em
-    padding-right: 1em
+    padding-left: $button-padding-horizontal
+    padding-right: $button-padding-horizontal
 
 .buttons
   align-items: center


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **bugfix**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution
Just added `$button-padding-horizontal` on rounded buttons
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

### Tradeoffs
We can change rounded paddings on buttons using a custom value
