### PR TITLE
Add helper classes for guaranteeing a "sticky footer"

### DIFF
--- a/docs/_data/links.json
+++ b/docs/_data/links.json
@@ -223,6 +223,11 @@
       "icon": "warehouse",
       "path": "/documentation/layout"
     },
+    "layout-page": {
+      "name": "Page",
+      "subtitle": "Helpers for managing basic page layout",
+      "path": "/documentation/layout/page"
+    },
     "layout-container": {
       "name": "Container",
       "subtitle": "A simple <strong>container</strong> to center your content horizontally",

--- a/docs/documentation/layout/page.html
+++ b/docs/documentation/layout/page.html
@@ -1,0 +1,42 @@
+---
+title: Page
+layout: documentation
+doc-tab: layout
+doc-subtab: page
+breadcrumb:
+- home
+- documentation
+- layout
+- layout-page
+---
+
+{% capture page_example %}
+<body class="page">
+  <main class="main">
+    <!-- All non-footer content goes here -->
+  </main>
+
+  <footer class="footer">
+
+  </footer>
+</body>
+{% endcapture %}
+
+<div class="content">
+  <p>
+    Bulma offers a handful of helper classes for determining your basic page layout.
+  </p>
+</div>
+
+{% include elements/anchor.html name="Sticky bottom footer" %}
+
+<div class="content">
+  <p>
+    The <code>page</code> and <code>main</code> classes can be used to ensure that your <a href="../footer">footer</a> remains "stuck" to the bottom of the page, regardless of how much vertical space is taken up by other elements on the page.
+  </p>
+  <p>
+    Apply the <code>page</code> class to an HTML element that encompasses the entire page, including the footer; apply the <code>main</code> class to an element that encompases everything <em>but</em> the footer.
+  </p>
+</div>
+
+{% highlight html %}{{ page_example }}{% endhighlight %}

--- a/sass/layout/_all.sass
+++ b/sass/layout/_all.sass
@@ -3,3 +3,4 @@
 @import "hero.sass"
 @import "section.sass"
 @import "footer.sass"
+@import "page.sass"

--- a/sass/layout/page.sass
+++ b/sass/layout/page.sass
@@ -1,0 +1,7 @@
+.page
+  display: flex
+  flex-direction: column
+  min-height: 100vh
+
+  .main
+    flex: 1


### PR DESCRIPTION
This is a **new feature** with accompanying **documentation**.

### Problem

At the moment, there's no way to ensure that the Bulma footer sticks to the bottom of the page.

### Solution

This PR adds two classes, `page` and `main`, that makes this simple. Here's an example:

```html
<body class="page">
  <main class="main">
    <!-- everything but the footer -->
  </main>

  <!-- anything here will automatically stick to the bottom of the page -->
</body>
```

### Approach

I've structured these changes under the assumption that the `page` and `main` classes could be used for other general layout purposes as well (hence the new `page.sass` file). I'm happy to place this logic elsewhere, however, if you feel that a new file isn't warranted.

I've also added some basic docs (a new `page.html` page under `/docs/layouts`) for this feature.

In terms of CSS, I think that this flexbox-based approach is consistent with the design of the rest of Bulma.

### Tradeoffs

Minimal. A wee bit of complexity and just a few lines of code.

### Testing Done

I've used this exact approach in numerous projects in which I've used Bulma, e.g. the [containerd docs](https://containerd.io), the [TiKV docs](https://tikv.org), and others.
