### PR TITLE
Add "is-vcentered" modifier

### DIFF
--- a/docs/documentation/columns/options.html
+++ b/docs/documentation/columns/options.html
@@ -10,6 +10,17 @@ breadcrumb:
 - columns-options
 ---
 
+{% capture columns_vcentered %}
+<div class="columns is-vcentered">
+  <div class="column is-8">
+    <p class="bd-notification is-primary">First column</p>
+  </div>
+  <div class="column">
+    <p class="bd-notification is-primary">Second column with more content. This is so you can see the vertical alignment.</p>
+  </div>
+</div>
+{% endcapture %}
+
 {% capture columns_multiline %}
 <div class="columns is-multiline is-mobile">
   <div class="column is-one-quarter">
@@ -86,6 +97,23 @@ breadcrumb:
   </div>
 </div>
 {% endcapture %}
+
+{% include elements/anchor.html name="Vertical alignment" %}
+
+<div class="content">
+  <p>To align your columns vertically, add the <code>is-vcentered</code> modifier to the <code>columns</code> container.</p>
+</div>
+
+<div class="columns is-vcentered">
+  <div class="column is-8">
+    <p class="bd-notification is-primary">First column</p>
+  </div>
+  <div class="column">
+    <p class="bd-notification is-primary">Second column with more content. This is so you can see the vertical alignment.</p>
+  </div>
+</div>
+
+{% highlight html %}{{ columns_vcentered }}{% endhighlight %}
 
 {% include elements/anchor.html name="Multiline" %}
 


### PR DESCRIPTION
This is a documentation fix.

This PR adds how to vertically align columns in Bulma by using the modifier provided.