### PR TITLE
Documentation additions

### DIFF
--- a/docs/documentation/columns/options.html
+++ b/docs/documentation/columns/options.html
@@ -10,6 +10,17 @@ breadcrumb:
 - columns-options
 ---
 
+{% capture columns_vcentered %}
+<div class="columns is-vcentered">
+  <div class="column is-8">
+    <p class="bd-notification is-primary">First column</p>
+  </div>
+  <div class="column">
+    <p class="bd-notification is-primary">Second column with more content. This is so you can see the vertical alignment.</p>
+  </div>
+</div>
+{% endcapture %}
+
 {% capture columns_multiline %}
 <div class="columns is-multiline is-mobile">
   <div class="column is-one-quarter">
@@ -86,6 +97,23 @@ breadcrumb:
   </div>
 </div>
 {% endcapture %}
+
+{% include elements/anchor.html name="Vertical alignment" %}
+
+<div class="content">
+  <p>To align your columns vertically, add the <code>is-vcentered</code> modifier to the <code>columns</code> container.</p>
+</div>
+
+<div class="columns is-vcentered">
+  <div class="column is-8">
+    <p class="bd-notification is-primary">First column</p>
+  </div>
+  <div class="column">
+    <p class="bd-notification is-primary">Second column with more content. This is so you can see the vertical alignment.</p>
+  </div>
+</div>
+
+{% highlight html %}{{ columns_vcentered }}{% endhighlight %}
 
 {% include elements/anchor.html name="Multiline" %}
 

--- a/docs/documentation/components/menu.html
+++ b/docs/documentation/components/menu.html
@@ -51,6 +51,130 @@ meta:
 </aside>
 {% endcapture %}
 
+{% capture menu_small_example %}
+<aside class="menu is-small">
+  <p class="menu-label">
+    General
+  </p>
+  <ul class="menu-list">
+    <li><a>Dashboard</a></li>
+    <li><a>Customers</a></li>
+  </ul>
+  <p class="menu-label">
+    Administration
+  </p>
+  <ul class="menu-list">
+    <li><a>Team Settings</a></li>
+    <li>
+      <a class="is-active">Manage Your Team</a>
+      <ul>
+        <li><a>Members</a></li>
+        <li><a>Plugins</a></li>
+        <li><a>Add a member</a></li>
+      </ul>
+    </li>
+    <li><a>Invitations</a></li>
+    <li><a>Cloud Storage Environment Settings</a></li>
+    <li><a>Authentication</a></li>
+  </ul>
+  <p class="menu-label">
+    Transactions
+  </p>
+  <ul class="menu-list">
+    <li><a>Payments</a></li>
+    <li><a>Transfers</a></li>
+    <li><a>Balance</a></li>
+  </ul>
+</aside>
+{% endcapture %}
+
+{% capture menu_medium_example %}
+<aside class="menu is-medium">
+  <p class="menu-label">
+    General
+  </p>
+  <ul class="menu-list">
+    <li><a>Dashboard</a></li>
+    <li><a>Customers</a></li>
+  </ul>
+  <p class="menu-label">
+    Administration
+  </p>
+  <ul class="menu-list">
+    <li><a>Team Settings</a></li>
+    <li>
+      <a class="is-active">Manage Your Team</a>
+      <ul>
+        <li><a>Members</a></li>
+        <li><a>Plugins</a></li>
+        <li><a>Add a member</a></li>
+      </ul>
+    </li>
+    <li><a>Invitations</a></li>
+    <li><a>Cloud Storage Environment Settings</a></li>
+    <li><a>Authentication</a></li>
+  </ul>
+  <p class="menu-label">
+    Transactions
+  </p>
+  <ul class="menu-list">
+    <li><a>Payments</a></li>
+    <li><a>Transfers</a></li>
+    <li><a>Balance</a></li>
+  </ul>
+</aside>
+{% endcapture %}
+
+{% capture menu_large_example %}
+<aside class="menu is-large">
+  <p class="menu-label">
+    General
+  </p>
+  <ul class="menu-list">
+    <li><a>Dashboard</a></li>
+    <li><a>Customers</a></li>
+  </ul>
+  <p class="menu-label">
+    Administration
+  </p>
+  <ul class="menu-list">
+    <li><a>Team Settings</a></li>
+    <li>
+      <a class="is-active">Manage Your Team</a>
+      <ul>
+        <li><a>Members</a></li>
+        <li><a>Plugins</a></li>
+        <li><a>Add a member</a></li>
+      </ul>
+    </li>
+    <li><a>Invitations</a></li>
+    <li><a>Cloud Storage Environment Settings</a></li>
+    <li><a>Authentication</a></li>
+  </ul>
+  <p class="menu-label">
+    Transactions
+  </p>
+  <ul class="menu-list">
+    <li><a>Payments</a></li>
+    <li><a>Transfers</a></li>
+    <li><a>Balance</a></li>
+  </ul>
+</aside>
+{% endcapture %}
+
 {% include elements/snippet.html content=menu_example size="one-third" %}
+
+{% include elements/anchor.html name="Sizes" %}
+
+<p class="content">
+  The menu component comes in <strong>3 additional sizes</strong>.<br>
+  You only need to append the <strong>modifier</strong> <code>is-small</code>, <code>is-medium</code>, or <code>is-large</code> to the <code>menu</code> component.
+</p>
+
+{% include elements/snippet.html content=menu_small_example more=true size="one-third" %}
+
+{% include elements/snippet.html content=menu_medium_example more=true size="one-third" %}
+
+{% include elements/snippet.html content=menu_large_example more=true size="one-third" %}
 
 {% include elements/variables.html type='component' %}

--- a/docs/documentation/elements/table.html
+++ b/docs/documentation/elements/table.html
@@ -314,6 +314,98 @@ meta:
 </table>
 {% endcapture %}
 
+{% capture table_responsive_example %}
+<div class="table-container">
+  <table class="table">
+    <thead>
+      <tr>
+        <th><abbr title="Position">Pos</abbr></th>
+        <th>Team</th>
+        <th><abbr title="Played">Pld</abbr></th>
+        <th><abbr title="Won">W</abbr></th>
+        <th><abbr title="Drawn">D</abbr></th>
+        <th><abbr title="Lost">L</abbr></th>
+        <th><abbr title="Goals for">GF</abbr></th>
+        <th><abbr title="Goals against">GA</abbr></th>
+        <th><abbr title="Goal difference">GD</abbr></th>
+        <th><abbr title="Points">Pts</abbr></th>
+        <th>Qualification or relegation</th>
+      </tr>
+    </thead>
+    <tfoot>
+      <tr>
+        <th><abbr title="Position">Pos</abbr></th>
+        <th>Team</th>
+        <th><abbr title="Played">Pld</abbr></th>
+        <th><abbr title="Won">W</abbr></th>
+        <th><abbr title="Drawn">D</abbr></th>
+        <th><abbr title="Lost">L</abbr></th>
+        <th><abbr title="Goals for">GF</abbr></th>
+        <th><abbr title="Goals against">GA</abbr></th>
+        <th><abbr title="Goal difference">GD</abbr></th>
+        <th><abbr title="Points">Pts</abbr></th>
+        <th>Qualification or relegation</th>
+      </tr>
+    </tfoot>
+    <tbody>
+      <tr>
+        <th>1</th>
+        <td><a href="https://en.wikipedia.org/wiki/Leicester_City_F.C." title="Leicester City F.C.">Leicester City</a> <strong>(C)</strong>
+        </td>
+        <td>38</td>
+        <td>23</td>
+        <td>12</td>
+        <td>3</td>
+        <td>68</td>
+        <td>36</td>
+        <td>+32</td>
+        <td>81</td>
+        <td>Qualification for the <a href="https://en.wikipedia.org/wiki/2016%E2%80%9317_UEFA_Champions_League#Group_stage" title="2016–17 UEFA Champions League">Champions League group stage</a></td>
+      </tr>
+      <tr>
+        <th>2</th>
+        <td><a href="https://en.wikipedia.org/wiki/Arsenal_F.C." title="Arsenal F.C.">Arsenal</a></td>
+        <td>38</td>
+        <td>20</td>
+        <td>11</td>
+        <td>7</td>
+        <td>65</td>
+        <td>36</td>
+        <td>+29</td>
+        <td>71</td>
+        <td>Qualification for the <a href="https://en.wikipedia.org/wiki/2016%E2%80%9317_UEFA_Champions_League#Group_stage" title="2016–17 UEFA Champions League">Champions League group stage</a></td>
+      </tr>
+      <tr>
+        <th>3</th>
+        <td><a href="https://en.wikipedia.org/wiki/Tottenham_Hotspur_F.C." title="Tottenham Hotspur F.C.">Tottenham Hotspur</a></td>
+        <td>38</td>
+        <td>19</td>
+        <td>13</td>
+        <td>6</td>
+        <td>69</td>
+        <td>35</td>
+        <td>+34</td>
+        <td>70</td>
+        <td>Qualification for the <a href="https://en.wikipedia.org/wiki/2016%E2%80%9317_UEFA_Champions_League#Group_stage" title="2016–17 UEFA Champions League">Champions League group stage</a></td>
+      </tr>
+      <tr class="is-selected">
+        <th>4</th>
+        <td><a href="https://en.wikipedia.org/wiki/Manchester_City_F.C." title="Manchester City F.C.">Manchester City</a></td>
+        <td>38</td>
+        <td>19</td>
+        <td>9</td>
+        <td>10</td>
+        <td>71</td>
+        <td>41</td>
+        <td>+30</td>
+        <td>66</td>
+        <td>Qualification for the <a href="https://en.wikipedia.org/wiki/2016%E2%80%9317_UEFA_Champions_League#Play-off_round" title="2016–17 UEFA Champions League">Champions League play-off round</a></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+{% endcapture %}
+
 <div class="content">
   <p>You simply need to attach a single <code>.table</code> CSS class on a <code>&lt;table&gt;</code> with the following structure:</p>
   <ul>
@@ -583,5 +675,13 @@ meta:
     </table>
   </div>
 </div>
+
+{% include elements/anchor.html name="Responsive Table" %}
+
+<div class="content">
+  <p>To ensure that your table does not overflow it's parent container for smaller devices, attach the <code>.table-container</code> CSS class to a parent div tag.</p>
+</div>
+
+{% include elements/snippet.html content=table_responsive_example horizontal=true more=true %}
 
 {% include elements/variables.html type='element' %}

--- a/docs/documentation/modifiers/responsive-helpers.html
+++ b/docs/documentation/modifiers/responsive-helpers.html
@@ -65,120 +65,118 @@ breadcrumb:
     You can use one of the following <code>display</code> classes:
   </p>
   <ul>
-    <li><code>block</code></li>
-    <li><code>flex</code></li>
-    <li><code>inline</code></li>
-    <li><code>inline-block</code></li>
-    <li><code>inline-flex</code></li>
+    <li><code>is-block</code></li>
+    <li><code>is-flex</code></li>
+    <li><code>is-inline</code></li>
+    <li><code>is-inline-block</code></li>
+    <li><code>is-inline-flex</code></li>
   </ul>
   <p>For example, here's how the <code>is-flex</code> helper works:</p>
 </div>
 
 {% include layout/main-close.html show_categories=true %}
 
-<div class="container">
-  <div class="table-container">
-    <table class="table is-bordered">
-      {{ thead }}
-      <tbody>
-        <tr>
-          <td class="is-narrow">
-            <code>is-flex-mobile</code>
-          </td>
-          {{ flex }}
-          {{ unchanged }}
-          {{ unchanged }}
-          {{ unchanged }}
-          {{ unchanged }}
-        </tr>
-        <tr>
-          <td class="is-narrow">
-            <code>is-flex-tablet-only</code>
-          </td>
-          {{ unchanged }}
-          {{ flex }}
-          {{ unchanged }}
-          {{ unchanged }}
-          {{ unchanged }}
-        </tr>
-        <tr>
-          <td class="is-narrow">
-            <code>is-flex-desktop-only</code>
-          </td>
-          {{ unchanged }}
-          {{ unchanged }}
-          {{ flex }}
-          {{ unchanged }}
-          {{ unchanged }}
-        </tr>
-        <tr>
-          <td class="is-narrow">
-            <code>is-flex-widescreen-only</code>
-          </td>
-          {{ unchanged }}
-          {{ unchanged }}
-          {{ unchanged }}
-          {{ flex }}
-          {{ unchanged }}
-        </tr>
-        <tr>
-          <th colspan="5">
-            <p>Classes to display <strong>up to</strong> or <strong>from</strong> a specific breakpoint</p>
-          </th>
-        </tr>
-        <tr>
-          <td class="is-narrow">
-            <code>is-flex-touch</code>
-          </td>
-          {{ flex }}
-          {{ flex }}
-          {{ unchanged }}
-          {{ unchanged }}
-          {{ unchanged }}
-        </tr>
-        <tr>
-          <td class="is-narrow">
-            <code>is-flex-tablet</code>
-          </td>
-          {{ unchanged }}
-          {{ flex }}
-          {{ flex }}
-          {{ flex }}
-          {{ flex }}
-        </tr>
-        <tr>
-          <td class="is-narrow">
-            <code>is-flex-desktop</code>
-          </td>
-          {{ unchanged }}
-          {{ unchanged }}
-          {{ flex }}
-          {{ flex }}
-          {{ flex }}
-        </tr>
-        <tr>
-          <td class="is-narrow">
-            <code>is-flex-widescreen</code>
-          </td>
-          {{ unchanged }}
-          {{ unchanged }}
-          {{ unchanged }}
-          {{ flex }}
-          {{ flex }}
-        </tr>
-        <tr>
-          <td class="is-narrow">
-            <code>is-flex-fullhd</code>
-          </td>
-          {{ unchanged }}
-          {{ unchanged }}
-          {{ unchanged }}
-          {{ unchanged }}
-          {{ flex }}
-        </tr>
-      </tbody>
-    </table>
-  </div>
+<div class="table-container">
+  <table class="table is-bordered">
+    {{ thead }}
+    <tbody>
+      <tr>
+        <td class="is-narrow">
+          <code>is-flex-mobile</code>
+        </td>
+        {{ flex }}
+        {{ unchanged }}
+        {{ unchanged }}
+        {{ unchanged }}
+        {{ unchanged }}
+      </tr>
+      <tr>
+        <td class="is-narrow">
+          <code>is-flex-tablet-only</code>
+        </td>
+        {{ unchanged }}
+        {{ flex }}
+        {{ unchanged }}
+        {{ unchanged }}
+        {{ unchanged }}
+      </tr>
+      <tr>
+        <td class="is-narrow">
+          <code>is-flex-desktop-only</code>
+        </td>
+        {{ unchanged }}
+        {{ unchanged }}
+        {{ flex }}
+        {{ unchanged }}
+        {{ unchanged }}
+      </tr>
+      <tr>
+        <td class="is-narrow">
+          <code>is-flex-widescreen-only</code>
+        </td>
+        {{ unchanged }}
+        {{ unchanged }}
+        {{ unchanged }}
+        {{ flex }}
+        {{ unchanged }}
+      </tr>
+      <tr>
+        <th colspan="5">
+          <p>Classes to display <strong>up to</strong> or <strong>from</strong> a specific breakpoint</p>
+        </th>
+      </tr>
+      <tr>
+        <td class="is-narrow">
+          <code>is-flex-touch</code>
+        </td>
+        {{ flex }}
+        {{ flex }}
+        {{ unchanged }}
+        {{ unchanged }}
+        {{ unchanged }}
+      </tr>
+      <tr>
+        <td class="is-narrow">
+          <code>is-flex-tablet</code>
+        </td>
+        {{ unchanged }}
+        {{ flex }}
+        {{ flex }}
+        {{ flex }}
+        {{ flex }}
+      </tr>
+      <tr>
+        <td class="is-narrow">
+          <code>is-flex-desktop</code>
+        </td>
+        {{ unchanged }}
+        {{ unchanged }}
+        {{ flex }}
+        {{ flex }}
+        {{ flex }}
+      </tr>
+      <tr>
+        <td class="is-narrow">
+          <code>is-flex-widescreen</code>
+        </td>
+        {{ unchanged }}
+        {{ unchanged }}
+        {{ unchanged }}
+        {{ flex }}
+        {{ flex }}
+      </tr>
+      <tr>
+        <td class="is-narrow">
+          <code>is-flex-fullhd</code>
+        </td>
+        {{ unchanged }}
+        {{ unchanged }}
+        {{ unchanged }}
+        {{ unchanged }}
+        {{ flex }}
+      </tr>
+    </tbody>
+  </table>
 </div>
 
 {% include layout/main-open.html %}

--- a/docs/documentation/modifiers/responsive-helpers.html
+++ b/docs/documentation/modifiers/responsive-helpers.html
@@ -76,107 +76,109 @@ breadcrumb:
 
 {% include layout/main-close.html show_categories=true %}
 
-<div class="table-container">
-  <table class="table is-bordered">
-    {{ thead }}
-    <tbody>
-      <tr>
-        <td class="is-narrow">
-          <code>is-flex-mobile</code>
-        </td>
-        {{ flex }}
-        {{ unchanged }}
-        {{ unchanged }}
-        {{ unchanged }}
-        {{ unchanged }}
-      </tr>
-      <tr>
-        <td class="is-narrow">
-          <code>is-flex-tablet-only</code>
-        </td>
-        {{ unchanged }}
-        {{ flex }}
-        {{ unchanged }}
-        {{ unchanged }}
-        {{ unchanged }}
-      </tr>
-      <tr>
-        <td class="is-narrow">
-          <code>is-flex-desktop-only</code>
-        </td>
-        {{ unchanged }}
-        {{ unchanged }}
-        {{ flex }}
-        {{ unchanged }}
-        {{ unchanged }}
-      </tr>
-      <tr>
-        <td class="is-narrow">
-          <code>is-flex-widescreen-only</code>
-        </td>
-        {{ unchanged }}
-        {{ unchanged }}
-        {{ unchanged }}
-        {{ flex }}
-        {{ unchanged }}
-      </tr>
-      <tr>
-        <th colspan="5">
-          <p>Classes to display <strong>up to</strong> or <strong>from</strong> a specific breakpoint</p>
-        </th>
-      </tr>
-      <tr>
-        <td class="is-narrow">
-          <code>is-flex-touch</code>
-        </td>
-        {{ flex }}
-        {{ flex }}
-        {{ unchanged }}
-        {{ unchanged }}
-        {{ unchanged }}
-      </tr>
-      <tr>
-        <td class="is-narrow">
-          <code>is-flex-tablet</code>
-        </td>
-        {{ unchanged }}
-        {{ flex }}
-        {{ flex }}
-        {{ flex }}
-        {{ flex }}
-      </tr>
-      <tr>
-        <td class="is-narrow">
-          <code>is-flex-desktop</code>
-        </td>
-        {{ unchanged }}
-        {{ unchanged }}
-        {{ flex }}
-        {{ flex }}
-        {{ flex }}
-      </tr>
-      <tr>
-        <td class="is-narrow">
-          <code>is-flex-widescreen</code>
-        </td>
-        {{ unchanged }}
-        {{ unchanged }}
-        {{ unchanged }}
-        {{ flex }}
-        {{ flex }}
-      </tr>
-      <tr>
-        <td class="is-narrow">
-          <code>is-flex-fullhd</code>
-        </td>
-        {{ unchanged }}
-        {{ unchanged }}
-        {{ unchanged }}
-        {{ unchanged }}
-        {{ flex }}
-      </tr>
-    </tbody>
-  </table>
+<div class="container">
+  <div class="table-container">
+    <table class="table is-bordered">
+      {{ thead }}
+      <tbody>
+        <tr>
+          <td class="is-narrow">
+            <code>is-flex-mobile</code>
+          </td>
+          {{ flex }}
+          {{ unchanged }}
+          {{ unchanged }}
+          {{ unchanged }}
+          {{ unchanged }}
+        </tr>
+        <tr>
+          <td class="is-narrow">
+            <code>is-flex-tablet-only</code>
+          </td>
+          {{ unchanged }}
+          {{ flex }}
+          {{ unchanged }}
+          {{ unchanged }}
+          {{ unchanged }}
+        </tr>
+        <tr>
+          <td class="is-narrow">
+            <code>is-flex-desktop-only</code>
+          </td>
+          {{ unchanged }}
+          {{ unchanged }}
+          {{ flex }}
+          {{ unchanged }}
+          {{ unchanged }}
+        </tr>
+        <tr>
+          <td class="is-narrow">
+            <code>is-flex-widescreen-only</code>
+          </td>
+          {{ unchanged }}
+          {{ unchanged }}
+          {{ unchanged }}
+          {{ flex }}
+          {{ unchanged }}
+        </tr>
+        <tr>
+          <th colspan="5">
+            <p>Classes to display <strong>up to</strong> or <strong>from</strong> a specific breakpoint</p>
+          </th>
+        </tr>
+        <tr>
+          <td class="is-narrow">
+            <code>is-flex-touch</code>
+          </td>
+          {{ flex }}
+          {{ flex }}
+          {{ unchanged }}
+          {{ unchanged }}
+          {{ unchanged }}
+        </tr>
+        <tr>
+          <td class="is-narrow">
+            <code>is-flex-tablet</code>
+          </td>
+          {{ unchanged }}
+          {{ flex }}
+          {{ flex }}
+          {{ flex }}
+          {{ flex }}
+        </tr>
+        <tr>
+          <td class="is-narrow">
+            <code>is-flex-desktop</code>
+          </td>
+          {{ unchanged }}
+          {{ unchanged }}
+          {{ flex }}
+          {{ flex }}
+          {{ flex }}
+        </tr>
+        <tr>
+          <td class="is-narrow">
+            <code>is-flex-widescreen</code>
+          </td>
+          {{ unchanged }}
+          {{ unchanged }}
+          {{ unchanged }}
+          {{ flex }}
+          {{ flex }}
+        </tr>
+        <tr>
+          <td class="is-narrow">
+            <code>is-flex-fullhd</code>
+          </td>
+          {{ unchanged }}
+          {{ unchanged }}
+          {{ unchanged }}
+          {{ unchanged }}
+          {{ flex }}
+        </tr>
+      </tbody>
+    </table>
+  </div>
 </div>
 
 {% include layout/main-open.html %}


### PR DESCRIPTION
This is a documentation fix.

This PR adds information regarding the `table-container` class, the different sizes for the `menu` component and adds the `is-` prefix for the responsive helpers.