### PR TITLE
Fixes #1186 - Reset the offset on columns

### DIFF
--- a/sass/grid/columns.sass
+++ b/sass/grid/columns.sass
@@ -56,7 +56,7 @@ $column-gap: 0.75rem !default
     margin-left: 60%
   .columns.is-mobile > &.is-offset-four-fifths
     margin-left: 80%
-  @for $i from 1 through 12
+  @for $i from 0 through 12
     .columns.is-mobile > &.is-#{$i}
       flex: none
       width: percentage($i / 12)
@@ -113,7 +113,7 @@ $column-gap: 0.75rem !default
       margin-left: 60%
     &.is-offset-four-fifths-mobile
       margin-left: 80%
-    @for $i from 1 through 12
+    @for $i from 0 through 12
       &.is-#{$i}-mobile
         flex: none
         width: percentage($i / 12)
@@ -190,7 +190,7 @@ $column-gap: 0.75rem !default
     &.is-offset-four-fifths,
     &.is-offset-four-fifths-tablet
       margin-left: 80%
-    @for $i from 1 through 12
+    @for $i from 0 through 12
       &.is-#{$i},
       &.is-#{$i}-tablet
         flex: none
@@ -249,7 +249,7 @@ $column-gap: 0.75rem !default
       margin-left: 60%
     &.is-offset-four-fifths-touch
       margin-left: 80%
-    @for $i from 1 through 12
+    @for $i from 0 through 12
       &.is-#{$i}-touch
         flex: none
         width: percentage($i / 12)
@@ -306,7 +306,7 @@ $column-gap: 0.75rem !default
       margin-left: 60%
     &.is-offset-four-fifths-desktop
       margin-left: 80%
-    @for $i from 1 through 12
+    @for $i from 0 through 12
       &.is-#{$i}-desktop
         flex: none
         width: percentage($i / 12)
@@ -363,7 +363,7 @@ $column-gap: 0.75rem !default
       margin-left: 60%
     &.is-offset-four-fifths-widescreen
       margin-left: 80%
-    @for $i from 1 through 12
+    @for $i from 0 through 12
       &.is-#{$i}-widescreen
         flex: none
         width: percentage($i / 12)
@@ -420,7 +420,7 @@ $column-gap: 0.75rem !default
       margin-left: 60%
     &.is-offset-four-fifths-fullhd
       margin-left: 80%
-    @for $i from 1 through 12
+    @for $i from 0 through 12
       &.is-#{$i}-fullhd
         flex: none
         width: percentage($i / 12)


### PR DESCRIPTION
This is a **bugfix**.

### Proposed solution
Enables the resetting of the offsets on columns for different break points. 
https://github.com/jgthms/bulma/issues/1186

### Tradeoffs
Possible tradeoff: this fix creates `.is-0`, `.is-0-mobile`, etc. classes, which increases filesize, but won't get used, as it is not a good way to 'hide' content. 

### Testing Done
As the fix is just changing a 1 to 0, running `test/sass-compile-tester.sh` passed and generated a valid output. 

I already tested the fix in a project I am currently working on. 