### PR TITLE
Fix docs: level-element can also have horizontal layout on mobile

### DIFF
--- a/docs/documentation/overview/responsiveness.html
+++ b/docs/documentation/overview/responsiveness.html
@@ -35,7 +35,7 @@ $fullhd-enabled: false
     <li>the <code>level</code> component will show its children stacked vertically</li>
     <li>the <code>nav</code> menu will be hidden</li>
   </ul>
-  <p>You can however enforce the <strong>horizontal</strong> layout for both <code>columns</code> or <code>nav</code> by appending the <code>is-mobile</code> modifier.</p>
+  <p>You can however enforce the <strong>horizontal</strong> layout for both <code>columns</code> or <code>level</code> by appending the <code>is-mobile</code> modifier.</p>
 </div>
 
 {% include elements/anchor.html name="Breakpoints" %}


### PR DESCRIPTION
This is a documentation fix.
The original documentation says columns and levels are stacked vertically on mobile.
After that sentence, we should write that those two elements can be aligned horizontally on mobile. The element "nav" is the wrong word in the context of this sentence - it should be "level".