### PR TITLE
Add support for tables without table tags

### DIFF
--- a/sass/elements/content.sass
+++ b/sass/elements/content.sass
@@ -115,7 +115,8 @@ $content-table-foot-cell-color: $text-strong !default
   sup,
   sub
     font-size: 75%
-  table
+  table,
+  .table
     width: 100%
     td,
     th

--- a/sass/elements/table.sass
+++ b/sass/elements/table.sass
@@ -27,10 +27,20 @@ $table-striped-row-even-hover-background-color: $white-ter !default
   @extend %block
   background-color: $table-background-color
   color: $table-color
+  display: table
+  .caption
+    display: table-caption
+  .col
+    display: table-column
+  .colgroup
+    display: table-column-group
+  .td,
+  .th,
   td,
   th
     border: $table-cell-border
     border-width: $table-cell-border-width
+    display: table-cell
     padding: $table-cell-padding
     vertical-align: top
     // Colors
@@ -51,69 +61,100 @@ $table-striped-row-even-hover-background-color: $white-ter !default
       a,
       strong
         color: currentColor
+  .th,
   th
     color: $table-cell-heading-color
     text-align: left
+  .tr,
   tr
+    display: table-row
     &.is-selected
       background-color: $table-row-active-background-color
       color: $table-row-active-color
       a,
       strong
         color: currentColor
+      .td,
+      .th,
       td,
       th
         border-color: $table-row-active-color
         color: currentColor
+  .thead,
   thead
     background-color: $table-head-background-color
+    display: table-header-group
+    .td,
+    .th,
     td,
     th
       border-width: $table-head-cell-border-width
       color: $table-head-cell-color
+  .tfoot,
   tfoot
     background-color: $table-foot-background-color
+    display: table-footer-group
+    .td,
+    .th,
     td,
     th
       border-width: $table-foot-cell-border-width
       color: $table-foot-cell-color
+  .tbody,
   tbody
     background-color: $table-body-background-color
+    display: table-row-group
+    .tr,
     tr
       &:last-child
+        .td,
+        .th,
         td,
         th
           border-bottom-width: 0
   // Modifiers
   &.is-bordered
+    .td,
+    .th,
     td,
     th
       border-width: 1px
+    .tr,
     tr
       &:last-child
+        .td,
+        .th,
         td,
         th
           border-bottom-width: 1px
   &.is-fullwidth
     width: 100%
   &.is-hoverable
+    .tbody,
     tbody
+      .tr:not(.is-selected),
       tr:not(.is-selected)
         &:hover
           background-color: $table-row-hover-background-color
     &.is-striped
+      .tbody,
       tbody
+        .tr:not(.is-selected),
         tr:not(.is-selected)
           &:hover
             background-color: $table-row-hover-background-color
             &:nth-child(even)
               background-color: $table-striped-row-even-hover-background-color
   &.is-narrow
+    .td,
+    .th,
     td,
     th
       padding: 0.25em 0.5em
   &.is-striped
+    .tbody,
     tbody
+      .tr:not(.is-selected),
       tr:not(.is-selected)
         &:nth-child(even)
           background-color: $table-striped-row-even-background-color


### PR DESCRIPTION
This is an **improvement**.

It adds the ability to get table styling without using table tags (`table`, `tr`, `td`, etc.)

With this PR you can use whatever HTML tags you want and still have the content displayed as a table. I used it to put an anchor tag (`a`) where a table row tag (`tr`) would ordinarily be, this making the entire row clickable.

### Proposed solution

Everywhere we have styling for table tags, I have added a class selector that will apply the same styling. I have also added a `display` property so the class will be rendered just like the corresponding tag.

### Tradeoffs

Downsides:
- More selectors in the SASS.
- There are now two ways to create a table.
- The `display` property is redundant for the tags and may causes problems if someone had done the extremely weird thing of overriding them. That could be limited to the CSS selectors.

Upsides
- New table styling more closely matching the style guide directive to use only CSS classes.

### Testing Done

This works in the current version of the Neverbust transaction list https://www.neverbust.com/transactions.