### PR TITLE
Hide burger menu after tap on phones and tablets

### DIFF
--- a/docs/documentation/components/navbar.html
+++ b/docs/documentation/components/navbar.html
@@ -562,27 +562,26 @@ meta:
 {% capture navbar_js_code %}
 document.addEventListener('DOMContentLoaded', () => {
 
-  // Get all "navbar-burger" elements
-  const $navbarBurgers = Array.prototype.slice.call(document.querySelectorAll('.navbar-burger'), 0);
+  // Get burger element and his data-target menu
+  const burger = document.querySelector('.navbar-burger');
+  const menu = document.getElementById(burger.dataset.target);
+  
+  burger.addEventListener('click', () => {
+    // Toggle burger icon to cross
+    burger.classList.toggle('is-active');
 
-  // Check if there are any navbar burgers
-  if ($navbarBurgers.length > 0) {
+    // Toggle menu visibility on touch device
+    menu.classList.toggle('is-active');
+  });
 
-    // Add a click event on each of them
-    $navbarBurgers.forEach( el => {
-      el.addEventListener('click', () => {
+  menu.addEventListener('click', () => {
 
-        // Get the target from the "data-target" attribute
-        const target = el.dataset.target;
-        const $target = document.getElementById(target);
+    // Hide menu after tap on touch device
+    if (window.getComputedStyle(burger).display == 'block') {
+      burger.click();
+    }
 
-        // Toggle the "is-active" class on both the "navbar-burger" and the "navbar-menu"
-        el.classList.toggle('is-active');
-        $target.classList.toggle('is-active');
-
-      });
-    });
-  }
+  });
 
 });
 {% endcapture %}

--- a/docs/documentation/components/navbar.html
+++ b/docs/documentation/components/navbar.html
@@ -581,7 +581,7 @@ document.addEventListener('DOMContentLoaded', () => {
       burger.click();
     }
 
-  });
+  }, true);
 
 });
 {% endcapture %}


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **documentation improvement**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->
Current js example in documentation doesn't hide target menu after tap on touch devices by default. Also 95% of bulma users have only one burger menu on web page and current solution is overcomlicated IMHO.

### Tradeoffs
If you have many hamburgers you need to wrap this solution in cycle by yourself.
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->

### Testing Done
Tested on pc and mobile device in online.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

<!-- Thanks! -->
