### PR TITLE
NEW FEATURE: Boxes Class - A container for the box element

### DIFF
--- a/sass/elements/box.sass
+++ b/sass/elements/box.sass
@@ -16,9 +16,66 @@ $box-link-active-shadow: inset 0 1px 2px rgba($black, 0.2), 0 0 0 1px $link !def
   display: block
   padding: $box-padding
 
+  // Allows and individual .box to be the full screen width (consitent with other uses of .is-fullwidth)
+  &.is-fullwidth
+    width: 100%
+
 a.box
   &:hover,
   &:focus
     box-shadow: $box-link-hover-shadow
   &:active
     box-shadow: $box-link-active-shadow
+
+// Container for a group of .box's
+.boxes
+  align-items: stretch
+  display: flex
+  flex-wrap: wrap
+  justify-content: flex-start
+
+  .box
+    margin-bottom: 1.5rem
+
+    &:not(:last-child)
+      margin-right: 0.5rem
+
+    // Allows an individual .box in group to fill remaining space (consitent with other uses of .is-expanded)
+    &.is-expanded
+      flex-grow: 1
+
+  // Connected .box's (consitent with other uses of .has-addons)
+  &.has-addons
+    .box
+      margin-right: 0
+
+      &:not(:first-child)
+        border-bottom-left-radius: 0
+        border-top-left-radius: 0
+
+      &:not(:last-child)
+        border-bottom-right-radius: 0
+        border-top-right-radius: 0
+
+  // .boxes group aligned to the center (consistent with other group containers .is-centered)
+  &.is-centered
+    justify-content: center
+
+    &:not(.has-addons)
+      .box
+        margin-right: 0.25rem
+        margin-left: 0.25rem
+
+  // .boxes group aligned to the right (consistent with other group containers .is-right)
+  &.is-right
+    justify-content: flex-end
+
+    &:not(.has-addons)
+      .box
+        &:not(:first-child)
+          margin-left: 0.5rem
+
+        &:not(:last-child)
+          margin-right: 0
+
+


### PR DESCRIPTION
This is a new feature.

### Proposed solution
Add new 'container' class - .boxes
 - can be coupled with .has-addons, .is-centered, .is-right
 - .box in .boxes can be set to .is-expanded
 - .box within .boxes are all of equal height (fix to issues similar to #1788)

Modification to .box
 - can be set to .is-fullwidth

_Have not yet modified CHANGELOG.md or docs_

### Sample Code
![untitled](https://user-images.githubusercontent.com/32887870/51092768-50b25d80-17ef-11e9-815c-75659b4b7529.png)

```html
<div class='boxes has-addons'>
  <div class='box has-background-primary'>
    <h1 class='title is-3 is-family-secondary has-text-white has-text-centered'>13</h1>
    <h2 class='subtitle is-6 has-text-white has-text-centered'>JAN</h2>
  </div>
  <div class='box is-expanded'>
    <h1 class='title is-4'>Event Title: </h1>
    <p class='subtitle is-5'>Details: </p>
  </div>
</div>
```
_I have changed default colours and fonts for the project I am currently working on. The image above will look slightly different using the default Bulma settings._

### Tradeoffs
box.sass file size increased from 675b to 1960b (with comments)

### Testing Done
Features tested alone and in combinations. 
Nill issues noted. Nil impact on other features noted.
