### PR TITLE
Add print modifier and utility classes (fixes #721)

### DIFF
--- a/sass/base/helpers.sass
+++ b/sass/base/helpers.sass
@@ -258,6 +258,10 @@ $displays: 'block' 'flex' 'inline' 'inline-block' 'inline-flex'
   .is-invisible-fullhd
     visibility: hidden !important
 
++print
+  .is-hidden-print
+    display: none !important
+
 // Other
 
 .is-marginless

--- a/sass/grid/columns.sass
+++ b/sass/grid/columns.sass
@@ -426,6 +426,63 @@ $column-gap: 0.75rem !default
         width: percentage($i / 12)
       &.is-offset-#{$i}-fullhd
         margin-left: percentage($i / 12)
+  +print
+    &.is-narrow-print
+      flex: none
+    &.is-full-print
+      flex: none
+      width: 100%
+    &.is-three-quarters-print
+      flex: none
+      width: 75%
+    &.is-two-thirds-print
+      flex: none
+      width: 66.6666%
+    &.is-half-print
+      flex: none
+      width: 50%
+    &.is-one-third-print
+      flex: none
+      width: 33.3333%
+    &.is-one-quarter-print
+      flex: none
+      width: 25%
+    &.is-one-fifth-print
+      flex: none
+      width: 20%
+    &.is-two-fifths-print
+      flex: none
+      width: 40%
+    &.is-three-fifths-print
+      flex: none
+      width: 60%
+    &.is-four-fifths-print
+      flex: none
+      width: 80%
+    &.is-offset-three-quarters-print
+      margin-left: 75%
+    &.is-offset-two-thirds-print
+      margin-left: 66.6666%
+    &.is-offset-half-print
+      margin-left: 50%
+    &.is-offset-one-third-print
+      margin-left: 33.3333%
+    &.is-offset-one-quarter-print
+      margin-left: 25%
+    &.is-offset-one-fifth-print
+      margin-left: 20%
+    &.is-offset-two-fifths-print
+      margin-left: 40%
+    &.is-offset-three-fifths-print
+      margin-left: 60%
+    &.is-offset-four-fifths-print
+      margin-left: 80%
+    @for $i from 1 through 12
+      &.is-#{$i}-print
+        flex: none
+        width: percentage($i / 12)
+      &.is-offset-#{$i}-print
+        margin-left: percentage($i / 12)
 
 .columns
   margin-left: (-$column-gap)

--- a/sass/utilities/mixins.sass
+++ b/sass/utilities/mixins.sass
@@ -128,6 +128,11 @@
     @media screen and (min-width: $fullhd)
       @content
 
+// Media types
+=print
+  @media print
+    @content
+
 // Placeholders
 
 =unselectable


### PR DESCRIPTION
This is a **new feature**.

### Proposed solution
There is currently no way to modify the page layout based on the media type (specifically, print). This essentially adds modifiers to columns, and provides a helper class to hide when the print type is in use.

### Tradeoffs
N/A

### Testing Done

✅ Build project
✅ Test the added classes in a real scenario

![bulma-print](https://user-images.githubusercontent.com/1305308/51612319-1b0d2300-1f19-11e9-8258-3d0ac25e1dd6.gif)