### PR TITLE
Fix RSS Feed under docs: Xml Escape for Author Name

### DIFF
--- a/docs/atom.xml
+++ b/docs/atom.xml
@@ -9,7 +9,7 @@
     <id>{{ site.url }}</id>
     <updated>{{ site.time | date_to_xmlschema }}</updated>
     <author>
-      <name>{{ site.data.meta.title }}</name>
+      <name>{{ site.data.meta.title | xml_escape }}</name>
       <email>bbxdesign@gmail.com</email>
     </author>
     <atom:link href="{{ site.url }}/atom.xml" rel="self" type="application/rss+xml" />


### PR DESCRIPTION
The following xml contains a unescaped "&", which is not valid, e.g. check here https://validator.w3.org/feed/check.cgi?url=https%3A%2F%2Fbulma.io%2Fatom.xml :

```
    <author>
      <name>Bulma: Free, open source, & modern CSS framework based on Flexbox</name>
      <email>bbxdesign@gmail.com</email>
    </author>
```

This change should fix it.

