### PR TITLE
Move table reset styles to mixins

### DIFF
--- a/sass/base/minireset.sass
+++ b/sass/base/minireset.sass
@@ -70,10 +70,8 @@ iframe
 
 // Table
 table
-  border-collapse: collapse
-  border-spacing: 0
+  @extend %table-reset
 
 td,
 th
-  padding: 0
-  text-align: left
+  @extend %table-col-reset

--- a/sass/elements/table.sass
+++ b/sass/elements/table.sass
@@ -24,11 +24,13 @@ $table-striped-row-even-background-color: $white-bis !default
 $table-striped-row-even-hover-background-color: $white-ter !default
 
 .table
+  @extend %table-reset
   @extend %block
   background-color: $table-background-color
   color: $table-color
   td,
   th
+    @extend %table-col-reset
     border: $table-cell-border
     border-width: $table-cell-border-width
     padding: $table-cell-padding

--- a/sass/utilities/mixins.sass
+++ b/sass/utilities/mixins.sass
@@ -259,3 +259,17 @@
 
 %overlay
   +overlay
+
+=table-reset
+  border-collapse: collapse
+  border-spacing: 0
+
+%table-reset
+  +table-reset
+
+=table-col-reset
+  padding: 0
+  text-align: left
+
+%table-col-reset
+  +table-col-reset


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **improvement**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

Looking for issue #2353, make sense that people would like to use table styles only. Furthermore, isn't necessary getting all `minireset.sass` styles when you only want table styles.
I've created two mixins with styles for `table` and `th, td` reset. These mixins are extended now in the `table.sass` file.

### Testing Done

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

<!-- Thanks! -->

I created a simple project using my branch version and imported only the necessary files to have the table working.
