### PR TITLE
Improving example of modular button classes in documentation

### DIFF
--- a/docs/documentation/overview/modular.html
+++ b/docs/documentation/overview/modular.html
@@ -31,21 +31,21 @@ breadcrumb:
 {% endcapture %}
 
 {% capture buttons %}
-<a class="button">
+<button class="button">
   Button
-</a>
+</button>
 
-<a class="button is-primary">
+<button class="button is-primary">
   Primary button
-</a>
+</button>
 
-<a class="button is-large">
+<button class="button is-large">
   Large button
-</a>
+</button>
 
-<a class="button is-loading">
+<button class="button is-loading">
   Loading button
-</a>
+</button>
 {% endcapture %}
 
 <div class="content">


### PR DESCRIPTION
<!-- Choose one of the following: -->
<!-- Improvement? Explain how and why. -->

- Links and buttons have different semantic html meanings, and it is somewhat of a design (and accessibility) anti-pattern to style links as a button. Let's not reinforce that behavior by providing examples of doing it.