### PR TITLE
Make centered buttons have equal margin

### DIFF
--- a/sass/elements/button.sass
+++ b/sass/elements/button.sass
@@ -277,3 +277,7 @@ $button-static-border-color: $grey-lighter !default
         margin-right: 0.25rem
   &.is-right
     justify-content: flex-end
+    &:not(.has-addons) 
+      .button:not(.is-fullwidth)
+        margin-left: 0.25rem
+        margin-right: 0.25rem

--- a/sass/elements/button.sass
+++ b/sass/elements/button.sass
@@ -271,8 +271,9 @@ $button-static-border-color: $grey-lighter !default
         flex-grow: 1
   &.is-centered
     justify-content: center
-    .button:not(.is-fullwidth)
-      margin-left: 0.25rem
-      margin-right: 0.25rem
+    &:not(.has-addons) 
+      .button:not(.is-fullwidth)
+        margin-left: 0.25rem
+        margin-right: 0.25rem
   &.is-right
     justify-content: flex-end

--- a/sass/elements/button.sass
+++ b/sass/elements/button.sass
@@ -271,5 +271,8 @@ $button-static-border-color: $grey-lighter !default
         flex-grow: 1
   &.is-centered
     justify-content: center
+    .button:not(.is-fullwidth)
+      margin-left: 0.25rem
+      margin-right: 0.25rem
   &.is-right
     justify-content: flex-end


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **bugfix**.

### Proposed solution
#### Issue
When you have long buttons within **.buttons.is-centered** and a button moves to a lower line the alignment of each button is off.
Same issue with **.buttons.is-right**
#### Solution
Add equal margin to both sides of the button.

### Tradeoffs
We are using button margin value of **0.5rem** (**0.25rem** each side for **.is-centered**) that value could change so it might be beneficial to use a variable here instead.

### Testing Done
I have some js-fiddles with my tests:
* Fiddle before fix: https://jsfiddle.net/james_wasson/a9nmyzcg/
* Fiddle after fix: https://jsfiddle.net/james_wasson/9kfnz3b0/

shrink the screen to see the broken buttons under
* Test Buttons Group -> Text Case 1 -> Centered
* Test Buttons Is-Right -> Any test case

#### Before:
![bulmabeforefix](https://user-images.githubusercontent.com/22060392/53293407-e4852b00-3798-11e9-9f91-b4bc0f45c82f.PNG)
#### After:
![bulmaafterfix](https://user-images.githubusercontent.com/22060392/53293454-6ffebc00-3799-11e9-9015-531127d233fb.PNG)
<!-- Thanks! -->
