### PR TITLE
Fixes #1553

### DIFF
--- a/sass/elements/form.sass
+++ b/sass/elements/form.sass
@@ -47,6 +47,7 @@ $help-size: $size-small !default
   @extend %control
   background-color: $input-background-color
   border-color: $input-border-color
+  border-radius: $input-radius
   color: $input-color
   +placeholder
     color: $input-placeholder-color


### PR DESCRIPTION
Unused $input-radius is now used as a default border-radius.

<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **bugfix**.

### Proposed solution
According to issue #1553, Bulma won't use the defined `$input-radius` by default. This fixes that by setting the `border-radius` on input element to `$input-radius`: 
```
border-radius: $input-radius
```

### Tradeoffs
This might be a breaking change. 

### Testing Done
Rebuilt a complete project I am working on right now using this and it solved the issue properly. 

<!-- Thanks! -->
