### PR TITLE
Add example on how to delete notifications with JS

### DIFF
--- a/docs/documentation/elements/notification.html
+++ b/docs/documentation/elements/notification.html
@@ -34,10 +34,49 @@ meta:
 {% endfor %}
 {% endcapture %}
 
+{% capture notification_js_html %}
+<div class="notification">
+  <button class="delete"></button>
+  Lorem ipsum
+</div>
+{% endcapture %}
+
+{% capture notification_js_code %}
+document.addEventListener('DOMContentLoaded', () => {
+  (document.querySelectorAll('.notification .delete') || []).forEach(($delete) => {
+    $notification = $delete.parentNode;
+    $delete.addEventListener('click', () => {
+      $notification.parentNode.removeChild($notification);
+    });
+  });
+});
+{% endcapture %}
+
 {% include elements/snippet.html content=notification %}
 
 {% include elements/anchor.html name="Colors" %}
 
 {% include elements/snippet.html content=notification_colors %}
+
+<div id="notificationJsExample" class="message is-info">
+  <h4 class="message-header">Javascript delete notification</h4>
+  <div class="message-body">
+    <div class="content">
+      <p>
+        The Bulma package <strong>does not come with any JavaScript</strong>.
+        <br>
+        Here is however an implementation example, which sets <code>click</code> handler for <code>delete</code> elements of all notifications on the page, in Vanilla Javascript.
+      </p>
+
+      {% highlight html %}{{ notification_js_html }}{% endhighlight %}
+
+      {% highlight javascript %}{{ notification_js_code }}{% endhighlight %}
+
+      <p>
+        Remember, these are just implementation examples. The Bulma package <strong>does not come with any JavaScript</strong>.
+      </p>
+    </div>
+  </div>
+</div>
 
 {% include elements/variables.html type='element' %}


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **documentation fix**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->
This change adds example to delete notifications. It's automatically loaded on dom-ready, and sets `click` handler for all `.delete` elements of `.notification`s.

### Tradeoffs
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->
It's example in JavaScript, there is no tradeoffs, because it's optional.

### Testing Done

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
Yes, it works. I tried it in my own application, and it handler works perfectly.
<!-- Please explain more than "Yes". -->

<!-- Thanks! -->
