### PR TITLE
Add tip to open local server URL after build

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,4 +24,6 @@ To view the documentation on your system locally:
 jekyll serve --incremental --config _config.local.yml
 ```
 
-This will start an HTTP server at `http://localhost:4000/` that serves the docs built in the `_site` directory; and anytime the docs are rebuilt by you, it will serve the docs site on the fly. In your main shell session where you develop, if you change anything in `docs/` the jekyll server will rebuild those on the fly. But if you change anything about the Bulma SASS or CSS, you need to do `npm run start` to build the docs' CSS before you will see it in the browser. The process running `jekyll serve` will pick up the new CSS automatically.
+This will start an HTTP server at `http://localhost:4000/` that serves the docs built in the `_site` directory; and anytime the docs are rebuilt by you, it will serve the docs site on the fly. You can also add the `--open-url` option (or its alias `--o`) to automatically open the server URL in your default browser when it's ready.
+
+In your main shell session where you develop, if you change anything in `docs/` the jekyll server will rebuild those on the fly. But if you change anything about the Bulma SASS or CSS, you need to do `npm run start` to build the docs' CSS before you will see it in the browser. The process running `jekyll serve` will pick up the new CSS automatically.


### PR DESCRIPTION
This is a **documentation fix**.

Add a suggestion in the docs readme to include the `--open-url` or `--o` option in the `jekyll serve` command to automatically open the server URL after it has finished building. At least I find the command `jekyll serve --open-url --incremental --config _config.local.yml` very handy for a launcher batch script so I thought I'd share.

