### PR TITLE
Make site-level overflow properties variables

### DIFF
--- a/docs/_data/variables/base/generic.json
+++ b/docs/_data/variables/base/generic.json
@@ -43,6 +43,16 @@
       "value": "1.5",
       "type": "unitless"
     },
+    "$body-overflow-x": {
+      "name": "$body-overflow-x",
+      "value": "hidden",
+      "type": "keyword"
+    },
+    "$body-overflow-y": {
+      "name": "$body-overflow-y",
+      "value": "scroll",
+      "type": "keyword",
+    },
     "$code-family": {
       "name": "$code-family",
       "value": "$family-code",

--- a/sass/base/generic.sass
+++ b/sass/base/generic.sass
@@ -5,6 +5,8 @@ $body-family: $family-primary !default
 $body-color: $text !default
 $body-weight: $weight-normal !default
 $body-line-height: 1.5 !default
+$body-overflow-x: hidden !default
+$body-overflow-y: scroll !default
 
 $code-family: $family-code !default
 $code-padding: 0.25em 0.5em 0.25em !default
@@ -24,8 +26,8 @@ html
   -moz-osx-font-smoothing: grayscale
   -webkit-font-smoothing: antialiased
   min-width: 300px
-  overflow-x: hidden
-  overflow-y: scroll
+  overflow-x: $body-overflow-x
+  overflow-y: $body-overflow-y
   text-rendering: $body-rendering
   text-size-adjust: 100%
 


### PR DESCRIPTION
The defaults for the site-level `overflow-x` and `overflow-y` properties are reasonable in most cases, but not always. I recently got burned in a project where a phantom extra scrollbar was appearing on Chrome on Linux and I couldn't figure out why. I addressed the issue by applying `html { overflow-y: auto !important }` but it'd be great if I could apply that via variable instead.