### PR TITLE
Add Visited Link Variable

### DIFF
--- a/sass/base/generic.sass
+++ b/sass/base/generic.sass
@@ -67,6 +67,8 @@ a
     color: currentColor
   &:hover
     color: $link-hover
+  &:visited
+    color: $link-visited
 
 code
   background-color: $code-background


### PR DESCRIPTION
Included link visited variable for styling visited links.

<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **bugfix**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->
It fixes #2415 where `$link-visited` does not appear to be used. 

### Tradeoffs
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->
None

### Testing Done

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
- [x] Pull the latest `master` branch
- [x] Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide)
- [x] Make sure your PR only affects `.sass` or documentation files
- [x] [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes).

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->
Confirmed visited links show as the default `$purple` variable or as any color set in a customization override as explained in the [docs](https://bulma.io/documentation/customize/variables/)

<!-- Thanks! -->
