### PR TITLE
Fix 'align' attribute in td/th being ignored- Fixes #2414

### DIFF
--- a/sass/base/generic.sass
+++ b/sass/base/generic.sass
@@ -126,7 +126,8 @@ pre
 table
   td,
   th
-    text-align: left
     vertical-align: top
+    &:not([align])
+      text-align: left
   th
     color: $text-strong

--- a/sass/base/minireset.sass
+++ b/sass/base/minireset.sass
@@ -81,4 +81,5 @@ table
 td,
 th
   padding: 0
-  text-align: left
+  &:not([align])
+    text-align: left

--- a/sass/elements/content.sass
+++ b/sass/elements/content.sass
@@ -125,7 +125,8 @@ $content-table-foot-cell-color: $text-strong !default
       vertical-align: top
     th
       color: $content-table-cell-heading-color
-      text-align: left
+      &:not([align])
+        text-align: left
     thead
       td,
       th

--- a/sass/elements/table.sass
+++ b/sass/elements/table.sass
@@ -53,7 +53,8 @@ $table-striped-row-even-hover-background-color: $white-ter !default
         color: currentColor
   th
     color: $table-cell-heading-color
-    text-align: left
+    &:not([align])
+      text-align: left
   tr
     &.is-selected
       background-color: $table-row-active-background-color


### PR DESCRIPTION
This is a **bugfix**.

Fixes issue #2414:
There are multiple `<td>` and `<th>` selectors which set `text-align:left` taking precedence over the elements' attribute `align` (from HTML versions lower than HTML5)

### Proposed solution
From  `<th>` and `<td>` selectors which set `text-align` deselect elements with attribute `align`.

### Tradeoffs
None detected

### Testing Done
Tested in Firefox 66.0 and Chrome 73.0.3683.
