### PR TITLE
Update tiles documentation

### DIFF
--- a/docs/documentation/layout/tiles.html
+++ b/docs/documentation/layout/tiles.html
@@ -560,7 +560,7 @@ tile is-ancestor
 
 <div class="columns">
   <div class="column is-one-third">
-    <p>If you want to stack tiles <strong>vertically</strong>, add <code>is-vertical</code> on the parent tile:</p>
+    <p>If you want to stack tiles <strong>vertically</strong>, add <code>is-vertical</code> on the containing tile:</p>
   </div>
   <div class="column is-two-thirds">
     {% highlight html %}{{ tile_vertical }}{% endhighlight %}
@@ -574,7 +574,7 @@ tile is-ancestor
       <ul>
         <li>add <em>any</em> class you want, like <code>box</code></li>
         <li>add the <code>is-child</code> modifier on the tile</li>
-        <li>add the <code>is-parent</code> modifier on the <em>parent</em> tile</li>
+        <li>add the <code>is-parent</code> modifier on the <em>containing</em> tile</li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
This is a **documentation fix**.

It is unclear what is meant by "parent tile" (the containing HTML element or the `is-parent` tile), so this clarifies the documentation to say "containing tile" instead of "parent tile".