### PR TITLE
Display list component in side menu and Tab menu  #2402 

### DIFF
--- a/docs/_data/links.json
+++ b/docs/_data/links.json
@@ -430,6 +430,12 @@
       "icon": "angle-down",
       "path": "/documentation/components/dropdown"
     },
+    "components-list": {
+      "name": "List",
+      "subtitle": "A basic <strong>List</strong>, to display series of content vertically",
+      "icon": "bars",
+      "path": "/documentation/components/list"
+    },
     "components-menu": {
       "name": "Menu",
       "subtitle": "A simple <strong>menu</strong>, for any type of vertical navigation",
@@ -558,6 +564,6 @@
     "layout": ["layout-container", "layout-level", "layout-media", "layout-hero", "layout-section", "layout-footer", "layout-tiles"],
     "form": ["form-general", "form-input", "form-textarea", "form-select", "form-checkbox", "form-radio", "form-file"],
     "elements": ["elements-box", "elements-button", "elements-content", "elements-delete", "elements-icon", "elements-image", "elements-notification", "elements-progress", "elements-table", "elements-tag", "elements-title"],
-    "components": ["components-breadcrumb", "components-card", "components-dropdown", "components-menu", "components-message", "components-modal", "components-navbar", "components-pagination", "components-panel", "components-tabs"]
+    "components": ["components-breadcrumb", "components-card", "components-dropdown", "components-list", "components-menu", "components-message", "components-modal", "components-navbar", "components-pagination", "components-panel", "components-tabs"]
   }
 }


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **documentation fix**.
To present the component-list in sidebar or tab menu


### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->
Component-List data is added to show up link URL in side menu or  tab menu

### Tradeoffs
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->
N/A

### Testing Done

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->
Testing done. Now user can navigate to list component using side menu or tab menu

<!-- Thanks! -->
-mi9dev