### PR TITLE
Add is-spaced documentation in Navbar #2426 

### DIFF
--- a/docs/documentation/components/navbar.html
+++ b/docs/documentation/components/navbar.html
@@ -1280,5 +1280,24 @@ $(document).ready(function() {
   {% include examples/navbar-color.html color="white" light=true %}
 </div>
 
-{% include elements/variables.html type='component' %}
+{% include elements/anchor.html name="Navbar Helper Classes" %}
 
+<table class="table is-bordered">
+  <tbody>
+    <tr>
+      <th>Type</th>
+      <th>Name</th>
+      <th>Description</th>
+    </tr>
+    <tr>
+      <th rowspan="1">Spacing</th>
+      <td><code>is-spaced</code></td>
+      <td>Sets <strong>Top</strong> and <strong>Bottom</strong> paddings with <strong>1rem</strong>,
+          <br> <strong>Left</strong> and <strong>Right</strong> paddings with <strong>2rem</strong>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+
+{% include elements/variables.html type='component' %}


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a ** documentation fix**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->


### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->
Added is-spaced documentation under docs/documentation/components/navbar.html

### Tradeoffs
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->
N/A


### Testing Done

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->
Validated changes. Attached screenshot
<img width="1340" alt="navbar doc" src="https://user-images.githubusercontent.com/28580691/55440674-75a8a800-5576-11e9-8ae0-c6918e949d2d.png">


<!-- Thanks! -->
