### PR TITLE
fix border radius on last-child of list, (Fixes #2435)

### DIFF
--- a/sass/components/list.sass
+++ b/sass/components/list.sass
@@ -26,8 +26,8 @@ $list-item-hover-background-color: $background !default
     border-top-left-radius: $list-radius
     border-top-right-radius: $list-radius
   &:last-child
-    border-top-left-radius: $list-radius
-    border-top-right-radius: $list-radius
+    border-bottom-left-radius: $list-radius
+    border-bottom-right-radius: $list-radius
   &:not(:last-child)
     border-bottom: $list-item-border
   &.is-active


### PR DESCRIPTION

This is a **bugfix** for #2435 

### Proposed solution
replace last-child styles with bottom-radius instead of top-radius
### Tradeoffs
none really, it takes a few extra characters I guess, but it now works. so.
### Testing Done
before change:
![55373504-43397500-54ba-11e9-9a7f-d6a34521ba5d](https://user-images.githubusercontent.com/7551957/55463460-da323880-5644-11e9-8285-0a2d273e9321.png)

after change:
<img width="317" alt="Screen Shot 2019-04-03 at 7 14 25 pm" src="https://user-images.githubusercontent.com/7551957/55463478-e3bba080-5644-11e9-9988-215e0a3de875.png">

<!-- Thanks! -->