### PR TITLE
Add is- prefix to list of display helper classes

### DIFF
--- a/docs/documentation/modifiers/responsive-helpers.html
+++ b/docs/documentation/modifiers/responsive-helpers.html
@@ -65,11 +65,11 @@ breadcrumb:
     You can use one of the following <code>display</code> classes:
   </p>
   <ul>
-    <li><code>block</code></li>
-    <li><code>flex</code></li>
-    <li><code>inline</code></li>
-    <li><code>inline-block</code></li>
-    <li><code>inline-flex</code></li>
+    <li><code>is-block</code></li>
+    <li><code>is-flex</code></li>
+    <li><code>is-inline</code></li>
+    <li><code>is-inline-block</code></li>
+    <li><code>is-inline-flex</code></li>
   </ul>
   <p>For example, here's how the <code>is-flex</code> helper works:</p>
 </div>


### PR DESCRIPTION
This is a **documentation fix**.

### Proposed solution
I believe the `is-` class name prefix should be added to the list of display helper classes on the [responsive helpers](https://bulma.io/documentation/modifiers/responsive-helpers/) documentation page. I ran into the minor issue of skimming the page and thinking these shortened names would be the actual class names to use. This also improves consistency with the rest of the page where the prefix is always included.

### Comparison
**Current state:**
- `block`
- `flex`
- `inline`
- `inline-block`
- `inline-flex`

**Proposed state:**
- `is-block`
- `is-flex`
- `is-inline`
- `is-inline-block`
- `is-inline-flex`

### Tradeoffs
Adding the `is-` prefix is arguably a little bit more verbose and redundant in the list. However, I believe it is more valuable to read the literal class name.

### Testing Done
Yes, I built and served the documentation locally to confirm that the modified page is not broken somehow.
