### PR TITLE
Correct active pagination link text colour on hero - Fixes #2441

### DIFF
--- a/sass/layout/hero.sass
+++ b/sass/layout/hero.sass
@@ -17,7 +17,7 @@
     &.is-#{$name}
       background-color: $color
       color: $color-invert
-      a:not(.button):not(.dropdown-item):not(.tag),
+      a:not(.button):not(.dropdown-item):not(.tag):not(.pagination-link.is-current),
       strong
         color: inherit
       .title


### PR DESCRIPTION
Make sure that active pagination link text is not drawn in black on hero

This is a **bugfix** 


### Proposed solution

this is a bugfix for for issue #2441 it fixes the colour of current pagination text on a hero when using `a` instead of `button`

### Tradeoffs

It adds some more chars. to the code, but it now looks good.

### Testing Done

**Before change:**
<img width="168" alt="Screen Shot 2019-05-18 at 8 19 23 am" src="https://user-images.githubusercontent.com/7551957/57959376-f95ffd80-7946-11e9-9275-6c983d13c319.png">

**After Change:**
<img width="168" alt="Screen Shot 2019-05-18 at 8 19 39 am" src="https://user-images.githubusercontent.com/7551957/57959383-067cec80-7947-11e9-8c27-5438dba29613.png">

### Changelog updated?

No.

<!-- Thanks! -->