### PR TITLE
Added foreground (e.g., text) color to the footer

### DIFF
--- a/sass/layout/footer.sass
+++ b/sass/layout/footer.sass
@@ -1,6 +1,8 @@
 $footer-background-color: $white-bis !default
+$footer-color: $text !default
 $footer-padding: 3rem 1.5rem 6rem !default
 
 .footer
   background-color: $footer-background-color
+  color: $footer-color
   padding: $footer-padding

--- a/sass/layout/footer.sass
+++ b/sass/layout/footer.sass
@@ -1,4 +1,5 @@
 $footer-background-color: $white-bis !default
+$footer-color: false !default
 $footer-padding: 3rem 1.5rem 6rem !default
 
 .footer

--- a/sass/layout/footer.sass
+++ b/sass/layout/footer.sass
@@ -1,8 +1,8 @@
 $footer-background-color: $white-bis !default
-$footer-color: $text !default
 $footer-padding: 3rem 1.5rem 6rem !default
 
 .footer
   background-color: $footer-background-color
-  color: $footer-color
   padding: $footer-padding
+@if $footer-color
+   color: $footer-color


### PR DESCRIPTION
While setting up my own site, I was surprised to find that this wasn't an option!

This is an improvement to give better control over the coloration of the text in the footer, which often needs to be de-emphasized from the regular text. However, if I want a footer that stands out (which is the case on a few web sites I maintain), the option to alter the text color in SASS is something I would really like.

### Testing Done

I tested a recompile. It works as expected.

### Changelog updated?

No, though I'm not sure if it's significant enough, since there isn't much documentation on some SASS options.