### PR TITLE
invert button spinner colour when focussed

### DIFF
--- a/sass/elements/button.sass
+++ b/sass/elements/button.sass
@@ -171,6 +171,8 @@ $button-static-border-color: $grey-lighter !default
         &.is-loading
           &::after
             border-color: transparent transparent $color $color !important
+          &:focus::after
+            border-color: transparent transparent $color-invert $color-invert !important
           &:hover,
           &.is-hovered,
           &:focus,


### PR DESCRIPTION
When you click a button with `.is-loading` class, it has the `:focus` property. I am using a button with the following classes, which means the background colour is the same as the spinner.
`button is-black is-outlined is-loading`

This edit inverts the button colour when it is focussed.

<!-- Choose one of the following: -->
This is an **improvement**.


### Testing Done

None.

### Changelog updated?

No.