### PR TITLE
Add print column styles

### DIFF
--- a/sass/grid/columns.sass
+++ b/sass/grid/columns.sass
@@ -426,6 +426,63 @@ $column-gap: 0.75rem !default
         width: percentage($i / 12)
       &.is-offset-#{$i}-fullhd
         margin-left: percentage($i / 12)
+  +print
+    &.is-narrow-print
+      flex: none
+    &.is-full-print
+      flex: none
+      width: 100%
+    &.is-three-quarters-print
+      flex: none
+      width: 75%
+    &.is-two-thirds-print
+      flex: none
+      width: 66.6666%
+    &.is-half-print
+      flex: none
+      width: 50%
+    &.is-one-third-print
+      flex: none
+      width: 33.3333%
+    &.is-one-quarter-print
+      flex: none
+      width: 25%
+    &.is-one-fifth-print
+      flex: none
+      width: 20%
+    &.is-two-fifths-print
+      flex: none
+      width: 40%
+    &.is-three-fifths-print
+      flex: none
+      width: 60%
+    &.is-four-fifths-print
+      flex: none
+      width: 80%
+    &.is-offset-three-quarters-print
+      margin-left: 75%
+    &.is-offset-two-thirds-print
+      margin-left: 66.6666%
+    &.is-offset-half-print
+      margin-left: 50%
+    &.is-offset-one-third-print
+      margin-left: 33.3333%
+    &.is-offset-one-quarter-print
+      margin-left: 25%
+    &.is-offset-one-fifth-print
+      margin-left: 20%
+    &.is-offset-two-fifths-print
+      margin-left: 40%
+    &.is-offset-three-fifths-print
+      margin-left: 60%
+    &.is-offset-four-fifths-print
+      margin-left: 80%
+    @for $i from 0 through 12
+      &.is-#{$i}-print
+        flex: none
+        width: percentage($i / 12)
+      &.is-offset-#{$i}-print
+        margin-left: percentage($i / 12)
 
 .columns
   margin-left: (-$column-gap)

--- a/sass/utilities/initial-variables.sass
+++ b/sass/utilities/initial-variables.sass
@@ -61,6 +61,7 @@ $widescreen-enabled: true !default
 // 1344px container + 4rem
 $fullhd: 1344px + (2 * $gap) !default
 $fullhd-enabled: true !default
+$print-enabled: true !default
 
 // Miscellaneous
 

--- a/sass/utilities/mixins.sass
+++ b/sass/utilities/mixins.sass
@@ -128,6 +128,11 @@
     @media screen and (min-width: $fullhd)
       @content
 
+=print
+  @if $print-enabled
+    @media print
+      @content
+
 // Placeholders
 
 =unselectable


### PR DESCRIPTION
<!-- Choose one of the following: -->
This is a **new feature**.

Refers to: #721

### Testing Done

To use, add `is-[x]-print` to an existing `column`:

```html
<div class="columns">
    <div class="column is-8-desktop is-12-print">
      <div class="card">Card so you can see how wide it is</div>
    </div>
</div>
```


Result:

```
.-----.-----.-----.-----.-----.-----.-----.-----.-----.-----.-----.-----.

On screen:
 _______________________________________________
|                                               |
| Card so you can see how wide it is            |
|                                               |
|_______________________________________________|


On print:
 ______________________________________________________________________
|                                                                      |
| Card so you can see how wide it is                                   |
|                                                                      |
|______________________________________________________________________|

```

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

### Changelog updated?

No.

<!-- Thanks! -->
