### PR TITLE
Add size classes to field body (#2304)

### DIFF
--- a/sass/form/tools.sass
+++ b/sass/form/tools.sass
@@ -121,17 +121,6 @@ $help-size: $size-small !default
     flex-shrink: 0
     margin-right: 1.5rem
     text-align: right
-    &.is-small
-      font-size: $size-small
-      padding-top: 0.375em
-    &.is-normal
-      padding-top: 0.375em
-    &.is-medium
-      font-size: $size-medium
-      padding-top: 0.375em
-    &.is-large
-      font-size: $size-large
-      padding-top: 0.375em
 
 .field-body
   .field .field
@@ -150,10 +139,29 @@ $help-size: $size-small !default
       &:not(:last-child)
         margin-right: 0.75rem
 
+.field-label,.field-body
+  &.is-small
+    font-size: $size-small
+    padding-top: 0.375em
+  &.is-normal
+    padding-top: 0.375em
+  &.is-medium
+    font-size: $size-medium
+    padding-top: 0.375em
+  &.is-large
+    font-size: $size-large
+    padding-top: 0.375em
+
 .control
   box-sizing: border-box
   clear: both
   font-size: $size-normal
+  .is-small &
+    font-size: $size-small
+  .is-medium &
+    font-size: $size-medium
+  .is-large &
+    font-size: $size-large
   position: relative
   text-align: left
   // Modifiers


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a ** improvement | bugfix **.

Attempt to fix #2304 
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution

Misalignment happened because the `.is-size` classes added padding to the top of the labels but not the `div.field-body`, and the label in the div with `.control` had a fixed font-size. Added the possibility to add a `.is-size` class on the field-body so the font-size and padding would be the same as that of the field-label.
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

### Tradeoffs

Existing items with the `.control` class inside of an element with e.g. `.is-large` might change font-size.
Font-size of the label next to the checkbox will also increase/decrease.
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->

### Testing Done

Before:

```
<div class="field is-horizontal">
  <div class="field-label is-normal">
    <label class="label">No padding</label>
  </div>
  <div class="field-body">
    <div class="field">
      <div class="control">
        <label class="checkbox">
          <input type="checkbox">
          Checkbox
        </label>
      </div>
    </div>
  </div>
</div>
```
![image](https://user-images.githubusercontent.com/11733084/58767304-9054c880-8589-11e9-99e4-9cb4e89a2fe8.png)

After:
```
<div class="field is-horizontal">
  <div class="field-label is-large">
    <label class="label">No padding</label>
  </div>
  <div class="field-body is-large">
    <div class="field">
      <div class="control">
        <label class="checkbox">
          <input type="checkbox">
          Checkbox
        </label>
      </div>
    </div>
  </div>
</div>
```
![image](https://user-images.githubusercontent.com/11733084/58767310-9c408a80-8589-11e9-9f4e-0c2b5f88fc0c.png)


<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

### Changelog updated?

No.

<!-- Thanks! -->
