### PR TITLE
Add "Vue CLI" to "Customize"

### DIFF
--- a/docs/_data/links.json
+++ b/docs/_data/links.json
@@ -25,7 +25,7 @@
     },
     "overview-customize": {
       "name": "Customize",
-      "subtitle": "Create your <strong>own theme</strong> with a simple set of <strong>variables</strong>",
+      "subtitle": "Create your <strong>own themes</strong> with a simple set of <strong>variables</strong>",
       "color": "purple",
       "icon": "paint-brush",
       "path": "/documentation/overview/customize"
@@ -82,7 +82,7 @@
     },
     "customize": {
       "name": "Customize",
-      "subtitle": "Create your <strong>own theme</strong> with a simple set of <strong>variables</strong>",
+      "subtitle": "Create your <strong>own themes</strong> with a simple set of <strong>variables</strong>",
       "color": "purple",
       "icon": "paint-brush",
       "path": "/documentation/customize"
@@ -124,6 +124,14 @@
       "icon_brand": "true",
       "icon": "js",
       "path": "/documentation/customize/with-webpack"
+    },
+    "customize-vue-cli": {
+      "name": "With Vue CLI",
+      "subtitle": "Use Bulma with the Vue CLI",
+      "color": "warning",
+      "icon_brand": "true",
+      "icon": "js",
+      "path": "/documentation/customize/with-vue-cli"
     },
     "modifiers": {
       "name": "Modifiers",
@@ -551,13 +559,80 @@
     "extensions"
   ],
   "categories": {
-    "overview": ["overview-start", "overview-classes", "overview-modular", "overview-responsiveness", "overview-colors", "overview-functions", "overview-mixins"],
-    "customize": ["customize-concepts", "customize-variables", "customize-node-sass", "customize-sass-cli", "customize-webpack"],
-    "modifiers": ["modifiers-syntax", "modifiers-helpers", "modifiers-responsive-helpers", "modifiers-color-helpers", "modifiers-typography-helpers"],
-    "columns": ["columns-basics", "columns-sizes", "columns-responsiveness", "columns-nesting", "columns-gap", "columns-options"],
-    "layout": ["layout-container", "layout-level", "layout-media", "layout-hero", "layout-section", "layout-footer", "layout-tiles"],
-    "form": ["form-general", "form-input", "form-textarea", "form-select", "form-checkbox", "form-radio", "form-file"],
-    "elements": ["elements-box", "elements-button", "elements-content", "elements-delete", "elements-icon", "elements-image", "elements-notification", "elements-progress", "elements-table", "elements-tag", "elements-title"],
-    "components": ["components-breadcrumb", "components-card", "components-dropdown", "components-menu", "components-message", "components-modal", "components-navbar", "components-pagination", "components-panel", "components-tabs"]
+    "overview": [
+      "overview-start",
+      "overview-classes",
+      "overview-modular",
+      "overview-responsiveness",
+      "overview-colors",
+      "overview-functions",
+      "overview-mixins"
+    ],
+    "customize": [
+      "customize-concepts",
+      "customize-variables",
+      "customize-node-sass",
+      "customize-sass-cli",
+      "customize-webpack",
+      "customize-vue-cli"
+    ],
+    "modifiers": [
+      "modifiers-syntax",
+      "modifiers-helpers",
+      "modifiers-responsive-helpers",
+      "modifiers-color-helpers",
+      "modifiers-typography-helpers"
+    ],
+    "columns": [
+      "columns-basics",
+      "columns-sizes",
+      "columns-responsiveness",
+      "columns-nesting",
+      "columns-gap",
+      "columns-options"
+    ],
+    "layout": [
+      "layout-container",
+      "layout-level",
+      "layout-media",
+      "layout-hero",
+      "layout-section",
+      "layout-footer",
+      "layout-tiles"
+    ],
+    "form": [
+      "form-general",
+      "form-input",
+      "form-textarea",
+      "form-select",
+      "form-checkbox",
+      "form-radio",
+      "form-file"
+    ],
+    "elements": [
+      "elements-box",
+      "elements-button",
+      "elements-content",
+      "elements-delete",
+      "elements-icon",
+      "elements-image",
+      "elements-notification",
+      "elements-progress",
+      "elements-table",
+      "elements-tag",
+      "elements-title"
+    ],
+    "components": [
+      "components-breadcrumb",
+      "components-card",
+      "components-dropdown",
+      "components-menu",
+      "components-message",
+      "components-modal",
+      "components-navbar",
+      "components-pagination",
+      "components-panel",
+      "components-tabs"
+    ]
   }
 }

--- a/docs/_data/links.json
+++ b/docs/_data/links.json
@@ -25,7 +25,7 @@
     },
     "overview-customize": {
       "name": "Customize",
-      "subtitle": "Create your <strong>own themes</strong> with a simple set of <strong>variables</strong>",
+      "subtitle": "Create your <strong>own theme</strong> with a simple set of <strong>variables</strong>",
       "color": "purple",
       "icon": "paint-brush",
       "path": "/documentation/overview/customize"
@@ -82,7 +82,7 @@
     },
     "customize": {
       "name": "Customize",
-      "subtitle": "Create your <strong>own themes</strong> with a simple set of <strong>variables</strong>",
+      "subtitle": "Create your <strong>own theme</strong> with a simple set of <strong>variables</strong>",
       "color": "purple",
       "icon": "paint-brush",
       "path": "/documentation/customize"
@@ -559,80 +559,13 @@
     "extensions"
   ],
   "categories": {
-    "overview": [
-      "overview-start",
-      "overview-classes",
-      "overview-modular",
-      "overview-responsiveness",
-      "overview-colors",
-      "overview-functions",
-      "overview-mixins"
-    ],
-    "customize": [
-      "customize-concepts",
-      "customize-variables",
-      "customize-node-sass",
-      "customize-sass-cli",
-      "customize-webpack",
-      "customize-vue-cli"
-    ],
-    "modifiers": [
-      "modifiers-syntax",
-      "modifiers-helpers",
-      "modifiers-responsive-helpers",
-      "modifiers-color-helpers",
-      "modifiers-typography-helpers"
-    ],
-    "columns": [
-      "columns-basics",
-      "columns-sizes",
-      "columns-responsiveness",
-      "columns-nesting",
-      "columns-gap",
-      "columns-options"
-    ],
-    "layout": [
-      "layout-container",
-      "layout-level",
-      "layout-media",
-      "layout-hero",
-      "layout-section",
-      "layout-footer",
-      "layout-tiles"
-    ],
-    "form": [
-      "form-general",
-      "form-input",
-      "form-textarea",
-      "form-select",
-      "form-checkbox",
-      "form-radio",
-      "form-file"
-    ],
-    "elements": [
-      "elements-box",
-      "elements-button",
-      "elements-content",
-      "elements-delete",
-      "elements-icon",
-      "elements-image",
-      "elements-notification",
-      "elements-progress",
-      "elements-table",
-      "elements-tag",
-      "elements-title"
-    ],
-    "components": [
-      "components-breadcrumb",
-      "components-card",
-      "components-dropdown",
-      "components-menu",
-      "components-message",
-      "components-modal",
-      "components-navbar",
-      "components-pagination",
-      "components-panel",
-      "components-tabs"
-    ]
+    "overview": ["overview-start", "overview-classes", "overview-modular", "overview-responsiveness", "overview-colors", "overview-functions", "overview-mixins"],
+    "customize": ["customize-concepts", "customize-variables", "customize-node-sass", "customize-sass-cli", "customize-webpack", "customize-vue-cli"],
+    "modifiers": ["modifiers-syntax", "modifiers-helpers", "modifiers-responsive-helpers", "modifiers-color-helpers", "modifiers-typography-helpers"],
+    "columns": ["columns-basics", "columns-sizes", "columns-responsiveness", "columns-nesting", "columns-gap", "columns-options"],
+    "layout": ["layout-container", "layout-level", "layout-media", "layout-hero", "layout-section", "layout-footer", "layout-tiles"],
+    "form": ["form-general", "form-input", "form-textarea", "form-select", "form-checkbox", "form-radio", "form-file"],
+    "elements": ["elements-box", "elements-button", "elements-content", "elements-delete", "elements-icon", "elements-image", "elements-notification", "elements-progress", "elements-table", "elements-tag", "elements-title"],
+    "components": ["components-breadcrumb", "components-card", "components-dropdown", "components-menu", "components-message", "components-modal", "components-navbar", "components-pagination", "components-panel", "components-tabs"]
   }
 }

--- a/docs/documentation/customize/concepts.html
+++ b/docs/documentation/customize/concepts.html
@@ -4,17 +4,18 @@ layout: documentation
 doc-tab: customize
 doc-subtab: concepts
 breadcrumb:
-- home
-- documentation
-- customize
-- customize-concepts
+  - home
+  - documentation
+  - customize
+  - customize-concepts
 ---
 
 {% assign variables_link = site.data.links.by_id['customize-variables'] %}
 
 <div class="content">
   <p>
-    Bulma is highly customizable thanks to <strong>415 Sass variables</strong> living across <strong>28 files</strong>.
+    Bulma is highly customizable thanks to
+    <strong>415 Sass variables</strong> living across <strong>28 files</strong>.
   </p>
 
   <p>
@@ -23,29 +24,44 @@ breadcrumb:
 
   <ul>
     <li>
-      <strong><a href="{{ site.url }}{{ variables_link.path }}#initial-variables">initial variables</a></strong>: global variables with <strong>literal</strong> values
+      <strong
+        ><a href="{{ site.url }}{{ variables_link.path }}#initial-variables"
+          >initial variables</a
+        ></strong
+      >: global variables with <strong>literal</strong> values
     </li>
     <li>
-      <strong><a href="{{ site.url }}{{ variables_link.path }}#derived-variables">derived variables</a></strong>: global variables with values that reference other variables, or are computed
+      <strong
+        ><a href="{{ site.url }}{{ variables_link.path }}#derived-variables"
+          >derived variables</a
+        ></strong
+      >: global variables with values that reference other variables, or are
+      computed
     </li>
     <li>
-      <strong><a href="{{ site.url }}{{ variables_link.path }}#generic-variables">generic variables</a></strong>: for the HTML elements which carry no CSS class
+      <strong
+        ><a href="{{ site.url }}{{ variables_link.path }}#generic-variables"
+          >generic variables</a
+        ></strong
+      >: for the HTML elements which carry no CSS class
     </li>
     <li>
-      <strong>element/component variables</strong>: variables that are specific to a Bulma element/component
+      <strong>element/component variables</strong>: variables that are specific
+      to a Bulma element/component
     </li>
   </ul>
 
   <p>
-    Since these variables carry the <code>!default</code> flag, they can be assigned a <strong>new value</strong> either before or after having been imported.
+    Since these variables carry the <code>!default</code> flag, they can be
+    assigned a <strong>new value</strong> either before or after having been
+    imported.
   </p>
 </div>
 
-{% include elements/anchor.html name="Strategy" %}
-
-{% assign node_sass_link = site.data.links.by_id['customize-node-sass'] %}
-{% assign sass_cli_link = site.data.links.by_id['customize-sass-cli'] %}
-{% assign webpack_link = site.data.links.by_id['customize-webpack'] %}
+{% include elements/anchor.html name="Strategy" %} {% assign node_sass_link =
+site.data.links.by_id['customize-node-sass'] %} {% assign sass_cli_link =
+site.data.links.by_id['customize-sass-cli'] %} {% assign webpack_link =
+site.data.links.by_id['customize-webpack'] %}
 
 <div class="content">
   <p>
@@ -53,15 +69,9 @@ breadcrumb:
   </p>
 
   <ul>
-    <li>
-      <strong>install</strong> (or download) Bulma
-    </li>
-    <li>
-      have a working <strong>Sass setup</strong>
-    </li>
-    <li>
-      create your own <code>.scss</code> or <code>.sass</code> file
-    </li>
+    <li><strong>install</strong> (or download) Bulma</li>
+    <li>have a working <strong>Sass setup</strong></li>
+    <li>create your own <code>.scss</code> or <code>.sass</code> file</li>
   </ul>
 
   <p>
@@ -75,8 +85,6 @@ breadcrumb:
     <li>
       with the <a href="{{ site.url }}{{ sass_cli_link.path }}">Sass CLI</a>
     </li>
-    <li>
-      with <a href="{{ site.url }}{{ webpack_link.path }}">webpack</a>
-    </li>
+    <li>with <a href="{{ site.url }}{{ webpack_link.path }}">webpack</a></li>
   </ul>
 </div>

--- a/docs/documentation/customize/concepts.html
+++ b/docs/documentation/customize/concepts.html
@@ -4,18 +4,17 @@ layout: documentation
 doc-tab: customize
 doc-subtab: concepts
 breadcrumb:
-  - home
-  - documentation
-  - customize
-  - customize-concepts
+- home
+- documentation
+- customize
+- customize-concepts
 ---
 
 {% assign variables_link = site.data.links.by_id['customize-variables'] %}
 
 <div class="content">
   <p>
-    Bulma is highly customizable thanks to
-    <strong>415 Sass variables</strong> living across <strong>28 files</strong>.
+    Bulma is highly customizable thanks to <strong>415 Sass variables</strong> living across <strong>28 files</strong>.
   </p>
 
   <p>
@@ -24,44 +23,29 @@ breadcrumb:
 
   <ul>
     <li>
-      <strong
-        ><a href="{{ site.url }}{{ variables_link.path }}#initial-variables"
-          >initial variables</a
-        ></strong
-      >: global variables with <strong>literal</strong> values
+      <strong><a href="{{ site.url }}{{ variables_link.path }}#initial-variables">initial variables</a></strong>: global variables with <strong>literal</strong> values
     </li>
     <li>
-      <strong
-        ><a href="{{ site.url }}{{ variables_link.path }}#derived-variables"
-          >derived variables</a
-        ></strong
-      >: global variables with values that reference other variables, or are
-      computed
+      <strong><a href="{{ site.url }}{{ variables_link.path }}#derived-variables">derived variables</a></strong>: global variables with values that reference other variables, or are computed
     </li>
     <li>
-      <strong
-        ><a href="{{ site.url }}{{ variables_link.path }}#generic-variables"
-          >generic variables</a
-        ></strong
-      >: for the HTML elements which carry no CSS class
+      <strong><a href="{{ site.url }}{{ variables_link.path }}#generic-variables">generic variables</a></strong>: for the HTML elements which carry no CSS class
     </li>
     <li>
-      <strong>element/component variables</strong>: variables that are specific
-      to a Bulma element/component
+      <strong>element/component variables</strong>: variables that are specific to a Bulma element/component
     </li>
   </ul>
 
   <p>
-    Since these variables carry the <code>!default</code> flag, they can be
-    assigned a <strong>new value</strong> either before or after having been
-    imported.
+    Since these variables carry the <code>!default</code> flag, they can be assigned a <strong>new value</strong> either before or after having been imported.
   </p>
 </div>
 
-{% include elements/anchor.html name="Strategy" %} {% assign node_sass_link =
-site.data.links.by_id['customize-node-sass'] %} {% assign sass_cli_link =
-site.data.links.by_id['customize-sass-cli'] %} {% assign webpack_link =
-site.data.links.by_id['customize-webpack'] %}
+{% include elements/anchor.html name="Strategy" %}
+
+{% assign node_sass_link = site.data.links.by_id['customize-node-sass'] %}
+{% assign sass_cli_link = site.data.links.by_id['customize-sass-cli'] %}
+{% assign webpack_link = site.data.links.by_id['customize-webpack'] %}
 
 <div class="content">
   <p>
@@ -69,9 +53,15 @@ site.data.links.by_id['customize-webpack'] %}
   </p>
 
   <ul>
-    <li><strong>install</strong> (or download) Bulma</li>
-    <li>have a working <strong>Sass setup</strong></li>
-    <li>create your own <code>.scss</code> or <code>.sass</code> file</li>
+    <li>
+      <strong>install</strong> (or download) Bulma
+    </li>
+    <li>
+      have a working <strong>Sass setup</strong>
+    </li>
+    <li>
+      create your own <code>.scss</code> or <code>.sass</code> file
+    </li>
   </ul>
 
   <p>
@@ -85,6 +75,8 @@ site.data.links.by_id['customize-webpack'] %}
     <li>
       with the <a href="{{ site.url }}{{ sass_cli_link.path }}">Sass CLI</a>
     </li>
-    <li>with <a href="{{ site.url }}{{ webpack_link.path }}">webpack</a></li>
+    <li>
+      with <a href="{{ site.url }}{{ webpack_link.path }}">webpack</a>
+    </li>
   </ul>
 </div>

--- a/docs/documentation/customize/with-vue-cli.html
+++ b/docs/documentation/customize/with-vue-cli.html
@@ -1,0 +1,173 @@
+---
+title: With Vue CLI
+layout: documentation
+doc-tab: customize
+doc-subtab: vue-cli
+breadcrumb:
+- home
+- documentation
+- customize
+- customize-vue-cli
+---
+
+{% capture dependencies %}
+npm install bulma --save-dev
+npm install sass --save-dev
+npm install sass-loader --save-dev
+{% endcapture %}
+
+{% capture src %}
+- src
+  - assets
+  - components
+  - sass
+    - mystyles.scss
+  - views
+{% endcapture %}
+
+{% capture import %}
+@charset "utf-8";
+@import "bulma/bulma.sass";
+{% endcapture %}
+
+{% capture main %}
+import Vue from "vue";
+import App from "./App.vue";
+import "./sass/mystyles.scss";
+
+Vue.config.productionTip = false;
+
+new Vue({
+  render: h => h(App)
+}).$mount("#app");
+{% endcapture %}
+
+{% capture custom %}
+@charset "utf-8";
+
+// Import a Google Font
+@import url('https://fonts.googleapis.com/css?family=Nunito:400,700');
+
+// Set your brand colors
+$purple: #8A4D76;
+$pink: #FA7C91;
+$brown: #757763;
+$beige-light: #D0D1CD;
+$beige-lighter: #EFF0EB;
+
+// Update Bulma's global variables
+$family-sans-serif: "Nunito", sans-serif;
+$grey-dark: $brown;
+$grey-light: $beige-light;
+$primary: $purple;
+$link: $pink;
+$widescreen-enabled: false;
+$fullhd-enabled: false;
+
+// Update some of Bulma's component variables
+$body-background-color: $beige-lighter;
+$control-border-width: 2px;
+$input-border-color: transparent;
+$input-shadow: none;
+
+// Import only what you need from Bulma
+@import "../node_modules/bulma/sass/utilities/_all.sass";
+@import "../node_modules/bulma/sass/base/_all.sass";
+@import "../node_modules/bulma/sass/elements/button.sass";
+@import "../node_modules/bulma/sass/elements/container.sass";
+@import "../node_modules/bulma/sass/elements/title.sass";
+@import "../node_modules/bulma/sass/form/_all.sass";
+@import "../node_modules/bulma/sass/components/navbar.sass";
+@import "../node_modules/bulma/sass/layout/hero.sass";
+@import "../node_modules/bulma/sass/layout/section.sass";
+{% endcapture %}
+
+{% capture step_1 %}
+  {% highlight bash %}{{ dependencies }}{% endhighlight %}
+
+  <div class="content">
+    <p>
+      Your project may already contain the <code>sass</code> and <code>sass-loader</code> packages if you chose Sass support when you created your project from the Vue CLI.
+    </p>
+  </div>
+{% endcapture %}
+
+{% capture step_2 %}
+  <div class="content">
+    <p>
+      Create a <code>src/sass</code> folder in your Vue project and add a file called <code>mystyles.scss</code>.
+    </p>
+  </div>
+
+  {% highlight bash %}{{ src }}{% endhighlight %}
+{% endcapture %}
+
+{% capture step_3 %}
+  <div class="content">
+    <p>
+      import Bulma into the <code>mystyles.scss</code> file
+    </p>
+  </div>
+  {% highlight bash %}{{ import }}{% endhighlight %}
+{% endcapture %}
+
+{% capture step_4 %}
+  <div class="content">
+    <p>
+      Import the <code>mystyles.scss</code> file into your <code>main.js</code> file.
+    </p>
+  </div>
+  {% highlight bash %}{{ main }}{% endhighlight %}
+  <div class="content">
+    <p>
+      You can now use Bulma styles in any <code>.vue</code> file in your project.
+    </p>
+  </div>
+{% endcapture %}
+
+{% capture step_5 %}
+  <div class="content">
+    <p>
+      Replace the content of <code>mystyles.scss</code> file with the following:
+    </p>
+  </div>
+  {% highlight bash %}{{ custom }}{% endhighlight %}
+  <div class="content">
+    <p>
+      If you are running your project with <code>npm run serve</code>, your changes will automatically be picked up. You are now using a customized version of Bulma.
+    </p>
+  </div>
+{% endcapture %}
+
+{% include components/step.html
+  title="1. Install Bulma"
+  content=step_1
+%}
+
+<hr>
+
+{% include components/step.html
+  title="2. Create a Sass file"
+  content=step_2
+%}
+
+<hr>
+
+{% include components/step.html
+  title="3. Import Bulma"
+  content=step_3
+%}
+
+<hr>
+
+{% include components/step.html
+  title="4. Import mystyles.scss"
+  content=step_4
+%}
+
+<hr>
+
+{% include components/step.html
+  title="5. Customize which Bulma styles you want to use"
+  content=step_5
+%}


### PR DESCRIPTION
This is a **documentation fix**.

### Proposed solution

Adds instructions on how to include Bulma when using the Vue CLI.

### Tradeoffs

Assumes that the user already has a Vue CLI project and doesn't instruct them on how to set that part of it up.

### Testing Done

Locally

### Changelog updated?

No.
