### PR TITLE
Fix inconsistent input[disabled] color in Safari. Fixes #2355

### DIFF
--- a/sass/form/shared.sass
+++ b/sass/form/shared.sass
@@ -48,6 +48,8 @@ $input-radius: $radius !default
     border-color: $input-disabled-border-color
     box-shadow: none
     color: $input-disabled-color
+    -webkit-text-fill-color: $input-disabled-color
+    opacity: 1
     +placeholder
       color: $input-disabled-placeholder-color
 


### PR DESCRIPTION
This is a **bugfix**.

### Proposed solution

<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

Safari is rendering `disabled` input fields with faded text. 

Instead of the Bulma default `#7a7a7a` (48% luminosity), the input text renders at `#cecece` (81% luminosity).

Multiple users reported confusion, thinking the `<input disabled> value=` was instead `placeholder=` text, because it was so faded.

Bulma is [already choosing to override the default `<input disabled>` text `color`](https://github.com/jgthms/bulma/blob/ff8c4c18accf2c0094aa77945b1d2180ac927159/sass/elements/form.sass#L67). 

That setting simply isn't taking effect in Safari & iOS Safari. 

Screenshots of the bug (top correct, bottom incorrect):

<img src="https://user-images.githubusercontent.com/6340841/52501503-5d7b6480-2b95-11e9-8902-0c965f8ef960.png" width="350px" />


This PR fixes it.


### Tradeoffs

<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->

This adds a bit of browser-specific attributes to the codebase.
A case could be made that's better handled by `normalize.css`.

### Testing Done

Confirmed to work in production.

### Changelog updated?

No.
