### PR TITLE
Add feature Modal is-xx sizes #2482

### DIFF
--- a/sass/components/modal.sass
+++ b/sass/components/modal.sass
@@ -59,12 +59,12 @@ $modal-card-body-padding: 20px !default
     width: $modal-content-width
 
   +mobile
-    &.is-small, &.is-medium, &.is-large, &.is-xlarge, &.is-full
+    &.is-small, &.is-medium, &.is-large, &.is-wide, &.is-full
       max-width: 100%
   +tablet
     &.is-small
       max-width: 768px
-    &.is-medium, &.is-large, &.is-xlarge
+    &.is-medium, &.is-large, &.is-wide
       min-width: 769px
       max-width: 1023px
     &.is-full

--- a/sass/components/modal.sass
+++ b/sass/components/modal.sass
@@ -58,6 +58,32 @@ $modal-card-body-padding: 20px !default
     max-height: calc(100vh - #{$modal-content-spacing-tablet})
     width: $modal-content-width
 
+  +mobile
+    &.is-small, &.is-medium, &.is-large, &.is-xlarge, &.is-full
+      max-width: 100%
+  +tablet
+    &.is-small
+      max-width: 768px
+    &.is-medium, &.is-large, &.is-xlarge
+      min-width: 769px
+      max-width: 1023px
+    &.is-full
+      min-width: 100%
+  +desktop
+    &.is-small
+      max-width: 768px
+    &.is-medium
+      min-width: 769px
+      max-width: 1023px
+    &.is-large
+      min-width: 1024px
+      max-width: 1215px
+    &.is-wide
+      min-width: 1216px
+      max-width: 90%
+    &.is-full
+      min-width: 100%
+
 .modal-close
   @extend %delete
   background: none

--- a/sass/components/modal.sass
+++ b/sass/components/modal.sass
@@ -80,7 +80,7 @@ $modal-card-body-padding: 20px !default
       max-width: 1215px
     &.is-wide
       min-width: 1216px
-      max-width: 90%
+      max-width: 1407px
     &.is-full
       min-width: 100%
 


### PR DESCRIPTION
This is a ** new feature **.

Attempt to fix #2482

### Proposed solution
Resize Modal layout with five new classes: `.is-small`, `.is-medium`, `.is-large`, `.is-wide` and `.is-full`.

This features are Responsiveness so they work on mobile, touch, desktop and wide.

### Tradeoffs

Append to `.modal-content` or `.modal-card` classes.

### Testing Done

I have tested these classes into a project and they work.