### PR TITLE
Add .is-title-adjacent helper -- support for arbitrarily moving elements closer to titles (Fixes #2346)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Upcoming release
 
+### New features
+
+* Add .is-title-adjacent helper
+
 ### Bug fixes
 
 * Fix #2031, Fix #2483 -> Invalid output when declaring a custom shade map

--- a/docs/documentation/elements/title.html
+++ b/docs/documentation/elements/title.html
@@ -59,6 +59,20 @@ meta:
 <p class="subtitle is-5">Subtitle 5</p>
 {% endcapture %}
 
+{% capture adjacent %}
+<p class="title is-1">Title 1</p>
+<p class="subtitle is-3">Subtitle 3</p>
+<p class="is-size-5 is-title-adjacent">Written by <strong>Jane Doe</strong></p>
+<div class="tags is-title-adjacent">
+  <span class="tag is-primary">Tag 1</span>
+  <span class="tag is-primary">Tag 2</span>
+  <span class="tag is-primary">Tag 3</span>
+</div>
+<div class="content">
+  <p>A few days ago, I thought strongly about taking a walk down the road. That thought led me into a journey into my mind, which in the end, ended up almost as strenuous as that walk would have been on its own!</p>
+</div>
+{% endcapture %}
+
 <div class="columns">
   <div class="column">
     <div class="content">
@@ -171,6 +185,38 @@ meta:
   </div>
   <div class="column">
     {% highlight html %}{{ spaced }}{% endhighlight %}
+  </div>
+</div>
+
+<hr>
+
+<div class="columns">
+  <div class="column">
+    <div class="content">
+      <p>
+        <span class="tag is-success">New!</span>
+      </p>
+      <p>You can arbitrarily move other elements closer to titles or subtitles in the same way that subtitles automatically move closer to titles by using the <code>is-title-adjacent</code> modifier.</p>
+      <p>Notice in the example how the margin that would normally be below the title or subtitle now appears below the article's tags.</p>
+    </div>
+  </div>
+  <div class="column">
+    <div class="block">
+      <p class="title is-1">Title 1</p>
+      <p class="subtitle is-3">Subtitle 3</p>
+      <p class="is-size-5 is-title-adjacent">Written by <strong>Jane Doe</strong></p>
+      <div class="tags is-title-adjacent">
+        <span class="tag is-primary">Tag 1</span>
+        <span class="tag is-primary">Tag 2</span>
+        <span class="tag is-primary">Tag 3</span>
+      </div>
+      <div class="content">
+        <p>A few days ago, I thought strongly about taking a walk down the road. That thought led me into a journey into my mind, which in the end, ended up almost as strenuous as that walk would have been on its own!</p>
+      </div>
+    </div>
+  </div>
+  <div class="column">
+    {% highlight html %}{{ adjacent }}{% endhighlight %}
   </div>
 </div>
 

--- a/sass/elements/title.sass
+++ b/sass/elements/title.sass
@@ -18,7 +18,8 @@ $subtitle-strong-weight: $weight-semibold !default
 $subtitle-negative-margin: -1.25rem !default
 
 .title,
-.subtitle
+.subtitle,
+.is-title-adjacent
   @extend %block
   word-break: break-word
   em,
@@ -68,3 +69,7 @@ $subtitle-negative-margin: -1.25rem !default
     $i: index($sizes, $size)
     &.is-#{$i}
       font-size: $size
+
+.is-title-adjacent
+  &:not(.is-spaced)
+    margin-top: $subtitle-negative-margin


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **new feature**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

Hi. This is my first time opening a pull request in Bulma! 👋🏻 The .is-title-adjacent helper adds the ability to arbitrarily move any element which is below a title or a subtitle closer to that title or subtitle, in the same way that a subtitle automatically moves closer to a title.

### Proposed solution

<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->
Some websites like to have things like bylines, post datetimes, or other things kept close to the post title area. This helper makes it easier to do this in Bulma without writing custom code.

It fixes Issue #2346, which I filed in February.

### Tradeoffs

The way this is written, it shouldn't impact those who have already written custom code to do this same thing, so that's thankfully *not* a tradeoff here. I don't see any reason why it adds any significant tradeoffs, though, of course, for more specific use cases, some users will continue to create their own custom classes.
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->

### Testing Done

The changes I've made are small, so they seem to work as intended. As I'm a first-time contributor, I wanted to submit this pull request with the intent of making sure that there isn't something I'm overlooking, but given the tests done both on my personal website and while updating the docs, things seem to look good.

On my personal website, before the changes:
![Screenshot 2019-06-05 12 58 57](https://user-images.githubusercontent.com/280610/58978036-f6636a80-8798-11e9-8eda-ac26846c7e89.png)

My personal website, after the changes:
![Screenshot 2019-06-05 12 55 56](https://user-images.githubusercontent.com/280610/58978044-01b69600-8799-11e9-8dc2-460e376967aa.png)

Screenshot of my modifications to the documentation:
![Screenshot 2019-06-05 13 49 20](https://user-images.githubusercontent.com/280610/58978062-0d09c180-8799-11e9-97c4-63ad6115d38c.png)


<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

### Changelog updated?

Yes, but not with PR # since I don't have one yet.

<!-- Thanks! -->
