### PR TITLE
responsive image sizes to have is-16by9 and is-4by3-mobile at the same image

### DIFF
--- a/sass/elements/_all.sass
+++ b/sass/elements/_all.sass
@@ -6,6 +6,7 @@
 @import "content.sass"
 @import "icon.sass"
 @import "image.sass"
+@import "image_responsive_dimensions.sass"
 @import "notification.sass"
 @import "progress.sass"
 @import "table.sass"

--- a/sass/elements/image_responsive_dimensions.sass
+++ b/sass/elements/image_responsive_dimensions.sass
@@ -1,0 +1,69 @@
+$img-size-array: ( "1by1": "100%", "5by4": "80%", "4by3": "75%", "3by2": "66.6666%", "5by3": "60%", "16by9": "56.25%", "2by1": "50%", "3by1": "33.3333%", "4by5": "125%", "3by4": "133.3333%", "2by3": "150%", "3by5": "166.6666%", "9by16": "177.7777%", "1by2": "200%", "1by3": "300%" ) !default
+
+$device-size-list: "mobile", "tablet", "tablet-only", "touch", "desktop", "desktop-only", "until-widescreen", "widescreen", "widescreen-only", "until-fullhd", "fullhd" !default
+
+@if index( $device-size-list, "mobile" )
+  +mobile
+    @each $img-size, $img-padding in $img-size-array
+      .image.is-#{$img-size}-mobile
+        padding-top: #{$img-padding} !important
+
+@if index( $device-size-list, "tablet" )
+  +tablet
+    @each $img-size, $img-padding in $img-size-array
+      .image.is-#{$img-size}-tablet
+        padding-top: #{$img-padding} !important
+
+@if index( $device-size-list, "tablet-only" )
+  +tablet-only
+    @each $img-size, $img-padding in $img-size-array
+      .image.is-#{$img-size}-tablet-only
+        padding-top: #{$img-padding} !important
+
+@if index( $device-size-list, "touch" )
+  +touch
+    @each $img-size, $img-padding in $img-size-array
+      .image.is-#{$img-size}-touch
+        padding-top: #{$img-padding} !important
+
+@if index( $device-size-list, "desktop" )
+  +desktop
+    @each $img-size, $img-padding in $img-size-array
+      .image.is-#{$img-size}-desktop
+        padding-top: #{$img-padding} !important
+
+@if index( $device-size-list, "desktop-only" )
+  +desktop-only
+    @each $img-size, $img-padding in $img-size-array
+      .image.is-#{$img-size}-desktop-only
+        padding-top: #{$img-padding} !important
+
+@if index( $device-size-list, "until-widescreen" )
+  +until-widescreen
+    @each $img-size, $img-padding in $img-size-array
+      .image.is-#{$img-size}-until-widescreen
+        padding-top: #{$img-padding} !important
+
+@if index( $device-size-list, "widescreen" )
+  +widescreen
+    @each $img-size, $img-padding in $img-size-array
+      .image.is-#{$img-size}-widescreen
+        padding-top: #{$img-padding} !important
+
+@if index( $device-size-list, "widescreen-only" )
+  +widescreen-only
+    @each $img-size, $img-padding in $img-size-array
+      .image.is-#{$img-size}-widescreen-only
+        padding-top: #{$img-padding} !important
+
+@if index( $device-size-list, "until-fullhd" )
+  +until-fullhd
+    @each $img-size, $img-padding in $img-size-array
+      .image.is-#{$img-size}-until-fullhd
+        padding-top: #{$img-padding} !important
+
+@if index( $device-size-list, "fullhd" )
+  +fullhd
+    @each $img-size, $img-padding in $img-size-array
+      .image.is-#{$img-size}-fullhd
+        padding-top: #{$img-padding} !important


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
### New **feature responsive image sizes**.

If you need another image dimension at the same image at different devices you can do now: 
```
<img class="is-16by9 is-4by3-mobile"> 
<img class="is-1by1-mobile is-16by9-tablet is-4by3-desktop" 
         srcset="1x1-image.jpg 414w 414h, 
                     16by9-image.jpg 1024w 576h, 
                     4by3-image.jpg 1200w 800h">
```
So it's possible to use different images with srcset. You can also work with the ```<picture>```-tag.

The image sizes var and the device size var is adjustable to include only the needed dimensions and devices.

<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Tradeoffs

It produces a lot of css code. So you should override the variables to have only the needed variations. Dynamic mixins are still not possible.

### Testing Done
Tested at my own project - seems to work :-)


<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

### Changelog updated?

No.

<!-- Thanks! -->
