### PR TITLE
apply expanded menu rules only to not(.is-burger) navbars

### DIFF
--- a/sass/components/navbar.sass
+++ b/sass/components/navbar.sass
@@ -231,6 +231,9 @@ a.navbar-item,
   display: none
   height: $navbar-divider-height
   margin: 0.5rem 0
+.navbar.is-burger .navbar-menu
+  &.is-active
+    display: block!important
 
 +until($navbar-breakpoint)
   .navbar > .container
@@ -274,13 +277,13 @@ a.navbar-item,
       padding-bottom: $navbar-height
 
 +from($navbar-breakpoint)
-  .navbar,
-  .navbar-menu,
-  .navbar-start,
-  .navbar-end
+  .navbar:not(.is-burger),
+  .navbar:not(.is-burger) .navbar-menu,
+  .navbar:not(.is-burger) .navbar-start,
+  .navbar:not(.is-burger) .navbar-end
     align-items: stretch
     display: flex
-  .navbar
+  .navbar:not(.is-burger)
     min-height: $navbar-height
     &.is-spaced
       padding: $navbar-padding-vertical $navbar-padding-horizontal
@@ -313,13 +316,13 @@ a.navbar-item,
           &.is-active
             background-color: $navbar-dropdown-item-active-background-color
             color: $navbar-dropdown-item-active-color
-  .navbar-burger
+  .navbar:not(.is-burger) .navbar-burger
     display: none
-  .navbar-item,
-  .navbar-link
+  .navbar:not(.is-burger) .navbar-item,
+  .navbar:not(.is-burger) .navbar-link
     align-items: center
     display: flex
-  .navbar-item
+  .navbar:not(.is-burger) .navbar-item
     display: flex
     &.has-dropdown
       align-items: stretch
@@ -344,16 +347,16 @@ a.navbar-item,
           opacity: 1
           pointer-events: auto
           transform: translateY(0)
-  .navbar-menu
+  .navbar:not(.is-burger) .navbar-menu
     flex-grow: 1
     flex-shrink: 0
-  .navbar-start
+  .navbar:not(.is-burger) .navbar-start
     justify-content: flex-start
     margin-right: auto
-  .navbar-end
+  .navbar:not(.is-burger) .navbar-end
     justify-content: flex-end
     margin-left: auto
-  .navbar-dropdown
+  .navbar:not(.is-burger) .navbar-dropdown
     background-color: $navbar-dropdown-background-color
     border-bottom-left-radius: $navbar-dropdown-radius
     border-bottom-right-radius: $navbar-dropdown-radius
@@ -393,16 +396,16 @@ a.navbar-item,
     &.is-right
       left: auto
       right: 0
-  .navbar-divider
+  .navbar:not(.is-burger) .navbar-divider
     display: block
-  .navbar > .container,
-  .container > .navbar
+  .navbar:not(.is-burger) > .container,
+  .container > .navbar:not(.is-burger)
     .navbar-brand
       margin-left: -.75rem
     .navbar-menu
       margin-right: -.75rem
   // Fixed navbar
-  .navbar
+  .navbar:not(.is-burger)
     &.is-fixed-bottom-desktop,
     &.is-fixed-top-desktop
       +navbar-fixed
@@ -423,13 +426,13 @@ a.navbar-item,
     &.has-spaced-navbar-fixed-bottom
       padding-bottom: $navbar-height + ($navbar-padding-vertical * 2)
   // Hover/Active states
-  a.navbar-item,
-  .navbar-link
+  .navbar:not(.is-burger) a.navbar-item,
+  .navbar:not(.is-burger) .navbar-link
     &.is-active
       color: $navbar-item-active-color
     &.is-active:not(:focus):not(:hover)
       background-color: $navbar-item-active-background-color
-  .navbar-item.has-dropdown
+  .navbar:not(.is-burger) .navbar-item.has-dropdown
     &:focus,
     &:hover,
     &.is-active


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is an improvement. A few minor modifications on the navbar component, allowing for a class "is-burger" to be used in order to not apply the over $navbar-breakpoint css and be able to use navbars with the burger functionality on all screens. 
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution

<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

### Tradeoffs

<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->

### Testing Done

None.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

### Changelog updated?

No.

<!-- Thanks! -->
