### PR TITLE
Image .is-fullwidth

### DIFF
--- a/sass/elements/image.sass
+++ b/sass/elements/image.sass
@@ -9,6 +9,8 @@ $dimensions: 16 24 32 48 64 96 128 !default
     width: 100%
     &.is-rounded
       border-radius: $radius-rounded
+  &.is-fullwidth
+    width: 100%
   // Ratio
   &.is-square,
   &.is-1by1,


### PR DESCRIPTION
<!-- Choose one of the following: -->
This is a **improvement**.
<!-- Improvement? Explain how and why. -->
Ability to image width 100%

### Proposed solution
Ability to use images with 100% width, needed on full width banners

### Tradeoffs

None

### Testing Done

None.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

### Changelog updated?

No.

<!-- Thanks! -->
