### PR TITLE
Fixes #1540

### DIFF
--- a/docs/documentation/components/navbar.html
+++ b/docs/documentation/components/navbar.html
@@ -885,6 +885,12 @@ $(document).ready(function() {
       <code>is-tab</code> to add a bottom border on hover and show the bottom border using <code>is-active</code>
     </li>
   </ul>
+  <div class="message is-info">
+    <p class="message-body">
+        When using the <code>is-expanded</code> modfier with <code>navbar-start</code> or <code>navbar-end</code>
+        you must also add the <code>is-expanded</code> class to those elements as well.
+    </p>
+  </div>
 </div>
 
 {% include elements/anchor.html name="Transparent navbar" %}

--- a/sass/components/navbar.sass
+++ b/sass/components/navbar.sass
@@ -353,6 +353,11 @@ a.navbar-item,
   .navbar-end
     justify-content: flex-end
     margin-left: auto
+  .navbar-start,
+  .navbar-end
+    &.is-expanded
+      flex-grow: 1
+      flex-shrink: 1
   .navbar-dropdown
     background-color: $navbar-dropdown-background-color
     border-bottom-left-radius: $navbar-dropdown-radius


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **bugfix**.

This is a fix for issue #1540

### Proposed solution

Add support for `.is-expanded` to `.navbar-start` and `.navbar-end`

Docs have been updated.

### Tradeoffs

None.

### Testing Done

I have tested this on a sample navbar on the docs page. I have looked at box the fully expanded navbar and the collapsed version. No override for the collapsed version was needed.

**Before** (Only added `.is-expanded` to the first `.navbar-item`):
![Before PNG](https://user-images.githubusercontent.com/22060392/61754346-ff6fc180-ad6f-11e9-9e7f-d8939d8b28ea.PNG)


**After** (Added `.is-expanded` to the first `.navbar-item` and `.navbar-start`):
![After PNG](https://user-images.githubusercontent.com/22060392/61754293-d2231380-ad6f-11e9-9f6b-ab4bde583060.PNG)


### Changelog updated?

No.

<!-- Thanks! -->
