### PR TITLE
Fix #2271

### DIFF
--- a/docs/documentation/form/checkbox.html
+++ b/docs/documentation/form/checkbox.html
@@ -29,7 +29,7 @@ meta:
 {% endcapture %}
 
 {% capture checkbox_disabled_example %}
-<label class="checkbox" disabled>
+<label class="checkbox is-disabled">
   <input type="checkbox" disabled>
   Save my preferences
 </label>

--- a/docs/documentation/form/radio.html
+++ b/docs/documentation/form/radio.html
@@ -50,7 +50,7 @@ meta:
     <input type="radio" name="rsvp">
     Not going
   </label>
-  <label class="radio" disabled>
+  <label class="radio is-disabled">
     <input type="radio" name="rsvp" disabled>
     Maybe
   </label>
@@ -93,6 +93,9 @@ meta:
 <div class="content">
   <p>
     You can <strong>disable</strong> a radio button by adding the <code>disabled</code> HTML attribute to both the <code>&lt;label&gt;</code> and the <code>&lt;input&gt;</code>.
+  </p>
+  <p>
+    Alternatively for the <code>&lt;label&gt;</code> you can add the <code>is-disabled</code> class.
   </p>
 </div>
 

--- a/sass/form/checkbox-radio.sass
+++ b/sass/form/checkbox-radio.sass
@@ -11,6 +11,9 @@
   fieldset[disabled] &
     color: $input-disabled-color
     cursor: not-allowed
+  @at-root #{selector-append("label.is-disabled", &)}
+    color: $input-disabled-color
+    cursor: not-allowed
 
 .checkbox
   @extend %checkbox-radio


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **bugfix** for issue #2271.

### Proposed solution

Add .is-disabled for radio/checkbox labels

### Tradeoffs

This does duplicate the disabled styles (which is only 2 lines). However there is continued backwards compatability for anyone using the `%checkbox-radio` snippet.

### Testing Done

I updated the docs and looked to ensure the disabled buttons look the same.

### Changelog updated?

No.

<!-- Thanks! -->
