### PR TITLE
Make fields fullwidth in panel-blocks (Fixes #2501)

### DIFF
--- a/sass/components/panel.sass
+++ b/sass/components/panel.sass
@@ -76,7 +76,8 @@ $panel-icon-color: $text-light !default
   padding: 0.5em 0.75em
   input[type="checkbox"]
     margin-right: 0.75em
-  & > .control
+  & > .control,
+  & > .field
     flex-grow: 1
     flex-shrink: 1
     width: 100%


### PR DESCRIPTION
This is a **bugfix**. (#2501)

### Proposed solution

Currently, when using a `.field` as a child of a `.panel-block`, the `.field` doesn't take up the full width available to it. This causes the `.is-expanded` modifier to do nothing on controls within the `.field`, which is undesirable.

This behavior applies the same styles to `.field`s as to `.control`s, which already work as intended in this setup.

### Tradeoffs

None that I can think of, as fields without any `is-expanded` controls will behave the same as before.

### Testing Done

None, WIP.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

### Changelog updated?

No, WIP.
