### PR TITLE
Docs: Add JavaScript filename example

### DIFF
--- a/docs/documentation/form/file.html
+++ b/docs/documentation/form/file.html
@@ -459,6 +459,35 @@ meta:
 </div>
 {% endcapture %}
 
+{% capture file_javascript %}
+<div id="file-js-example" class="file has-name">
+  <label class="file-label">
+    <input class="file-input" type="file" name="resume">
+    <span class="file-cta">
+      <span class="file-icon">
+        <i class="fas fa-upload"></i>
+      </span>
+      <span class="file-label">
+        Choose a file…
+      </span>
+    </span>
+    <span class="file-name">
+      No file uploaded
+    </span>
+  </label>
+</div>
+
+<script>
+  const fileInput = document.querySelector('#file-js-example input[type=file]');
+  fileInput.onchange = () => {
+    if (fileInput.files.length > 0) {
+      const fileName = document.querySelector('#file-js-example .file-name');
+      fileName.textContent = fileInput.files[0].name;
+    }
+  }
+</script>
+{% endcapture %}
+
 {% capture file_sizes_boxed_name %}
 <div class="field">
   <div class="file is-small is-boxed has-name">
@@ -725,9 +754,9 @@ meta:
 <div class="content">
   <p>
     A file upload input requires JavaScript to <strong>retrieve</strong> the <strong>selected file name</strong>.
-    <br>
-    User <a href="https://github.com/chintanbanugaria"><strong>@chintanbanugaria</strong></a> on GitHub <a href="https://github.com/jgthms/bulma/issues/280#issuecomment-294099510">has provided</a> a simple solution <a href="https://jsfiddle.net/chintanbanugaria/uzva5byy/">on JSFiddle</a>.
+    Here is an example of how this could be done:
   </p>
+  {% include elements/snippet.html content=file_javascript %}
 </div>
 
 {% include elements/variables.html


### PR DESCRIPTION
Embedding it directly into the docs is better than an external jsfiddle,
especially since the code snippet is so simple.

This is a **documentation fix**.

### Proposed solution

See https://github.com/jgthms/bulma/issues/280#issuecomment-529114648.

It fixes the markup injection vulnerability and it moves the code under the control of Bulma.

### Tradeoffs

- This might be the first JS snippet integrated into the docs. I think it's still much better than an external page that isn't controlled by the Bulma project.
- I used an id attribute to reference the element, since the JS code does not run sandboxed for this example. We need to ensure that this id is unique.

### Testing Done

Tested it locally in my browser. Seems to work as intended.

![screenshot](https://user-images.githubusercontent.com/105168/64488672-d4bbc880-d24a-11e9-8adc-d5a64da5498d.png)

### Changelog updated?

No, minor change.