### PR TITLE
Fix index.js when Vimeo does not load

### DIFF
--- a/docs/lib/index.js
+++ b/docs/lib/index.js
@@ -8,7 +8,7 @@ document.addEventListener('DOMContentLoaded', function () {
   var introIframe = document.getElementById('introIframe');
   var npmClipboard = new Clipboard('#npmCopy');
 
-  if (Vimeo) {
+  if (window.Vimeo) {
     var introPlayer = new Vimeo.Player(introIframe);
     introPlayer.ready().then(function () {
       introVideo.classList.add('has-loaded');


### PR DESCRIPTION
This is a **documentation bugfix**.

### Proposed solution

This fixes the homepage JS to not break spectacularly if Vimeo's JS doesn't load for any reason.

### Testing Done

None.

### Changelog updated?

No.
