### PR TITLE
Fixes #2642

### DIFF
--- a/docs/documentation/layout/hero.html
+++ b/docs/documentation/layout/hero.html
@@ -34,7 +34,7 @@ meta:
     </li>
   </ul>
   <p>
-    For the <a href="#full-height-hero">full height hero</a> to work, you will also need a <code>hero-head</code> and a <code>hero-foot</code>.
+    For the <a href="#fullheight-hero-in-3-parts">full height hero</a> to work, you will also need a <code>hero-head</code> and a <code>hero-foot</code>.
   </p>
 </div>
 


### PR DESCRIPTION
Changed from "#full-height-hero" to "#fullheight-hero-in-3-parts"

<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **documentation fix**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution

<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->
This fixes #2642, where a link in the hero documentation was broken.

### Tradeoffs

<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->
Documentation fix.

### Testing Done

None.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

I have checked the link, but not actually cloned the repository and manually tested.

### Changelog updated?

No.

<!-- Thanks! -->
