### PR TITLE
Missing meta tags #2647 SOLVED

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug fixes
 
+* Fix #2647 -> Missing meta tags in snippet
 * Fix #2031, Fix #2483 -> Invalid output when declaring a custom shade map
 * Fix #2060 -> `height: auto` on HTML `audio` element breaks height of element
 * #1608 Fix #1552 -> `.container.is-fluid` margins

--- a/docs/_includes/snippets/mypage.html
+++ b/docs/_includes/snippets/mypage.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>My custom Bulma website</title>
     <link rel="stylesheet" href="css/mystyles.css">
   </head>


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a ** documentation fix **.

### Proposed solution
Hi, only add the next lines in  bulma/docs/_includes/snippets/mypage.html snippet sample not included
<meta charset="utf-8">
<meta http-equiv="X-UA-Compatible" content="IE=edge">
<meta name="viewport" content="width=device-width, initial-scale=1">


### Tradeoffs
N/A

<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->

### Testing Done
Yes, preview document using npm

### Changelog updated?

Yes.

