### PR TITLE
Fix CSS filename for Webpack 4 config

### DIFF
--- a/docs/documentation/customize/with-webpack.html
+++ b/docs/documentation/customize/with-webpack.html
@@ -116,7 +116,7 @@ module.exports = {
   },
   plugins: [
     new MiniCssExtractPlugin({
-      filename: 'css/[name].bundle.css'
+      filename: 'css/mystyles.css'
     }),
   ]
 };


### PR DESCRIPTION
<!-- Choose one of the following: -->
This is a **documentation fix**.

### Proposed solution

<!-- Which specific problem does this PR solve and how?  -->
`npm run build` does not create the right CSS filename. This PR modifies the Webpack 4 config file to create the right filename

### Tradeoffs

<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->
None of my knowledge

### Testing Done

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->
Now `npm run build` creates the right CSS filename

### Changelog updated?

No.

<!-- Thanks! -->
