### PR TITLE
Update correct lines in Docs compare Github repository

### DIFF
--- a/docs/documentation/overview/responsiveness.html
+++ b/docs/documentation/overview/responsiveness.html
@@ -40,7 +40,7 @@ $fullhd-enabled: false
 
 {% include elements/anchor.html name="Breakpoints" %}
 
-{% assign variables_file_url = "/blob/master/sass/utilities/initial-variables.sass#L46,L57" | prepend: site.data.meta.github %}
+{% assign variables_file_url = "/blob/master/sass/utilities/initial-variables.sass#L56,L64" | prepend: site.data.meta.github %}
 {% assign mixins_file_url = "/blob/master/sass/utilities/mixins.sass#L81,L129" | prepend: site.data.meta.github %}
 
 <div class="content">


### PR DESCRIPTION
Fix lines docs in Github repository

**Documentation fix**

### Proposed solution

In documentation/overview/responsiveness/ 5 breakpoints refers to other lines in Github repository.

### Testing Done

None.

### Changelog updated?

No.