### PR TITLE
fix: navbar's documentation button hidden on tablets

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -27,3 +27,4 @@ test.scss
 /styles/node_modules
 /versions
 _site
+.jekyll-cache

--- a/docs/_includes/global/navbar.html
+++ b/docs/_includes/global/navbar.html
@@ -33,7 +33,7 @@
         <span class="is-hidden-touch is-hidden-widescreen">
           Docs
         </span>
-        <span class="is-hidden-tablet-only is-hidden-desktop-only">
+        <span class="is-hidden-desktop-only">
           Documentation
         </span>
       </a>


### PR DESCRIPTION
# Current
- https://streamable.com/hk07p

# Fix
- https://streamable.com/lxd8p

# Others
- add jekyll cache folder to .gitignore

