### PR TITLE
fix(panel): use $panel-colors variable

### DIFF
--- a/sass/components/panel.sass
+++ b/sass/components/panel.sass
@@ -26,6 +26,7 @@ $panel-block-active-color: $link-active !default
 $panel-block-active-icon-color: $link !default
 
 $panel-icon-color: $text-light !default
+$panel-colors: $colors !default
 
 .panel
   border-radius: $panel-radius
@@ -34,7 +35,7 @@ $panel-icon-color: $text-light !default
   &:not(:last-child)
     margin-bottom: $panel-margin
   // Colors
-  @each $name, $components in $message-colors
+  @each $name, $components in $panel-colors
     $color: nth($components, 1)
     $color-invert: nth($components, 2)
     &.is-#{$name}


### PR DESCRIPTION
<!-- Choose one of the following: -->
This is a **bugfix**.

When importing the panel sass file individually, it throws an error as the `$message-colors` variable is not defined.

### Proposed solution

<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

 I think `panel.sass` should have the same logic as `message.sass` & declare a `$panel-colors` variable on top.

<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->

### Changelog updated?

No.

<!-- Thanks! -->
