### PR TITLE
✨ Fix </sbuttonan> tag in Button element documentation page #2676

### DIFF
--- a/docs/documentation/elements/button.html
+++ b/docs/documentation/elements/button.html
@@ -233,7 +233,8 @@ meta:
     <span>Delete</span>
     <span class="icon is-small">
       <i class="fas fa-times"></i>
-    </sbuttonan>
+    </span>
+  </button>
   </a>
 </p>
 <p class="buttons">


### PR DESCRIPTION
This is about the Bulma **Docs**

There is some strange tag in the code example:
```
<button class="button is-danger is-outlined">
    <span>Delete</span>
    <span class="icon is-small">
      <i class="fas fa-times"></i>
    </sbuttonan>
```

Code: 
https://github.com/jgthms/bulma/blob/master/docs/documentation/elements/button.html#L236