### PR TITLE
Image tag generics rule duplicates minireset's

### DIFF
--- a/sass/base/generic.sass
+++ b/sass/base/generic.sass
@@ -93,10 +93,6 @@ hr
   height: $hr-height
   margin: $hr-margin
 
-img
-  height: auto
-  max-width: 100%
-
 input[type="checkbox"],
 input[type="radio"]
   vertical-align: baseline


### PR DESCRIPTION
This is an **improvement** that removes a rule duplicated rule between `generics` and `minireset`.

### Proposed solution

Minireset already declares the following, therefore the _generics_ rule for `img` is not needed, and can be removed.

```
img,
video
  height: auto
  max-width: 100%
```

### Tradeoffs

Custom builds that include `generics` and not `miniresets` will lose the `img` rule.

### Testing Done

Checked that the rule is no longer duplicated, but still present.

### Changelog updated?

No.
