### PR TITLE
Fixes #2685: calculate input width taking padding into account. 

### DIFF
--- a/sass/form/input-textarea.sass
+++ b/sass/form/input-textarea.sass
@@ -6,7 +6,7 @@ $textarea-min-height: 8em !default
   @extend %input
   box-shadow: $input-shadow
   max-width: 100%
-  width: 100%
+  width: calc(100% - 2 * #{$control-padding-horizontal})
   &[readonly]
     box-shadow: none
   // Colors
@@ -40,12 +40,14 @@ $textarea-min-height: 8em !default
     border-radius: $radius-rounded
     padding-left: calc(#{$control-padding-horizontal} + 0.375em)
     padding-right: calc(#{$control-padding-horizontal} + 0.375em)
+    width: calc(100% - 2 * calc(#{$control-padding-horizontal} + 0.375em))
   &.is-static
     background-color: transparent
     border-color: transparent
     box-shadow: none
     padding-left: 0
     padding-right: 0
+    width: 100%
 
 .textarea
   @extend %input-textarea


### PR DESCRIPTION
This is a **bugfix**.
Solves input width issue described in #2685 

### Proposed solution

As stated in #2685 the input width is currently set to 100% but the actual width is more than 100% because of the padding applied to the input.

This PR calculates the input width by subtracting the padding on each side of the input to the current 100%.

### Testing Done

I have built the bulma.css file with my changed and tested on the use case described in the issue #2685 that it works as intended.

### Changelog updated?

No.
