### PR TITLE
Fix typo in documentation

### DIFF
--- a/docs/documentation/form/select.html
+++ b/docs/documentation/form/select.html
@@ -281,7 +281,7 @@ meta:
 
 <div class="content">
   <p>
-    The <code>select</code> class is a simple wrapper around the <code>&lt;select"&gt;</code> HTML element, which gives the styling more flexibility and support for icons.
+    The <code>select</code> class is a simple wrapper around the <code>&lt;select&gt;</code> HTML element, which gives the styling more flexibility and support for icons.
   </p>
 </div>
 


### PR DESCRIPTION
This is a **documentation fix**.

### Proposed solution

Fix typo in Home > Documentation > Form > Select.

### Tradeoffs

None.

### Testing Done

None.

### Changelog updated?

No.
