### PR TITLE
improvement | notification: add light colors

### DIFF
--- a/sass/elements/notification.sass
+++ b/sass/elements/notification.sass
@@ -34,3 +34,10 @@ $notification-padding: 1.25rem 2.5rem 1.25rem 1.5rem !default
     &.is-#{$name}
       background-color: $color
       color: $color-invert
+    // If light and dark colors are provided
+    @if length($pair) >= 4
+      $color-light: nth($pair, 3)
+      $color-dark: nth($pair, 4)
+      &.is-light
+        background-color: $color-light
+        color: $color-dark

--- a/sass/elements/notification.sass
+++ b/sass/elements/notification.sass
@@ -34,10 +34,10 @@ $notification-padding: 1.25rem 2.5rem 1.25rem 1.5rem !default
     &.is-#{$name}
       background-color: $color
       color: $color-invert
-    // If light and dark colors are provided
-    @if length($pair) >= 4
-      $color-light: nth($pair, 3)
-      $color-dark: nth($pair, 4)
-      &.is-light
-        background-color: $color-light
-        color: $color-dark
+      // If light and dark colors are provided
+      @if length($pair) >= 4
+        $color-light: nth($pair, 3)
+        $color-dark: nth($pair, 4)
+        &.is-light
+          background-color: $color-light
+          color: $color-dark


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is an improvement.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution

Add light color to notification with `is-light` modifier.

### Tradeoffs

None.

### Testing Done

Yes.
![Capture](https://user-images.githubusercontent.com/720636/69285169-8c2c6e00-0bf0-11ea-97dd-26b17ee20d4f.PNG)

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

### Changelog updated?

No.

<!-- Thanks! -->
