### PR TITLE
Docs: Prevent JS error if Vimeo does not load. Resolves #2635.

### DIFF
--- a/docs/_javascript/index.js
+++ b/docs/_javascript/index.js
@@ -6,7 +6,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const introIframe = document.getElementById('introIframe');
   const npmClipboard = new Clipboard('#npmCopy');
 
-  if (Vimeo) {
+  if (window.Vimeo) {
     const introPlayer = new Vimeo.Player(introIframe);
     introPlayer.ready().then(function() {
       introVideo.classList.add('has-loaded');

--- a/docs/lib/index.js
+++ b/docs/lib/index.js
@@ -8,7 +8,7 @@ document.addEventListener('DOMContentLoaded', function () {
   var introIframe = document.getElementById('introIframe');
   var npmClipboard = new Clipboard('#npmCopy');
 
-  if (Vimeo) {
+  if (window.Vimeo) {
     var introPlayer = new Vimeo.Player(introIframe);
     introPlayer.ready().then(function () {
       introVideo.classList.add('has-loaded');


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **documentation fix**.

There's an existing PR, #2635, that the original author has not updated for a while even after a review. Thought I'd help complete it.

<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution
Access `Vimeo` off of `window` object instead of directly.

### Tradeoffs
Not apparent right away why `Vimeo` is not referenced directly.
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->

### Testing Done

Vimeo's script is blocked and other JS related functionality on the page still works.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

### Changelog updated?

No.

<!-- Thanks! -->
