### PR TITLE
Update colors.json approving it 0.8.0 version

### DIFF
--- a/docs/_data/colors.json
+++ b/docs/_data/colors.json
@@ -68,7 +68,7 @@
     {
       "id":"green",
       "name":"Green",
-      "value": "hsl(141, 71%, 48%)"
+      "value": "hsl(141, 53%, 53%)"
     },
     {
       "id":"turquoise",


### PR DESCRIPTION
Update success color in docs.

This is a documentation fix

Fix color hsl greeen and success in docs. Approving it in version 0.8.0.

### Changelog updated?

No.

