### PR TITLE
Remove Open Iconic references

### DIFF
--- a/docs/_data/icons.json
+++ b/docs/_data/icons.json
@@ -1,7 +1,6 @@
 {
   "fontawesome4": "https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css",
   "fontawesome5": "https://use.fontawesome.com/releases/v5.3.1/js/all.js",
-  "iconic": "https://cdnjs.cloudflare.com/ajax/libs/open-iconic/1.1.1/font/css/open-iconic.min.css",
   "ionicons": "https://code.ionicframework.com/ionicons/2.0.1/css/ionicons.min.css",
   "mdi": "https://cdn.materialdesignicons.com/2.1.19/css/materialdesignicons.min.css"
 }

--- a/docs/_includes/global/head.html
+++ b/docs/_includes/global/head.html
@@ -9,9 +9,6 @@
   {% if page.fontawesome4 %}
     <link rel="stylesheet" href="{{ site.data.icons.fontawesome4 }}">
   {% endif %}
-  {% if page.iconic %}
-    <link rel="stylesheet" href="{{ site.data.icons.iconic }}">
-  {% endif %}
   {% if page.ionicons %}
     <link rel="stylesheet" href="{{ site.data.icons.ionicons }}">
   {% endif %}

--- a/docs/_posts/2018-01-18-bulma-supports-font-awesome-5.md
+++ b/docs/_posts/2018-01-18-bulma-supports-font-awesome-5.md
@@ -8,7 +8,7 @@ icon: "font-awesome"
 icon_brand: true
 ---
 
-Bulma is **icon library agnostic**: this means that you can use _any_ icon font library (like Font Awesome 4 or 5, Material Design Icons, Open Iconic, Ionicons…) with Bulma's `icon` class.
+Bulma is **icon library agnostic**: this means that you can use _any_ icon font library (like Font Awesome 4 or 5, Material Design Icons, Ionicons…) with Bulma's `icon` class.
 
 As a result, **Bulma already supports Font Awesome 5**! 😃
 

--- a/docs/documentation/elements/icon.html
+++ b/docs/documentation/elements/icon.html
@@ -1,8 +1,7 @@
 ---
 title: Icon
-subtitle: "Bulma is compatible with <strong>all icon font libraries</strong>: <a href=\"https://fontawesome.com/\">Font Awesome 5</a>, <a href=\"http://fontawesome.io/\">Font Awesome 4</a>, <a href=\"https://materialdesignicons.com\">Material Design Icons</a>, <a href=\"https://useiconic.com/open\">Open Iconic</a>, <a href=\"http://ionicons.com/\">Ionicons</a> etc."
+subtitle: "Bulma is compatible with <strong>all icon font libraries</strong>: <a href=\"https://fontawesome.com/\">Font Awesome 5</a>, <a href=\"http://fontawesome.io/\">Font Awesome 4</a>, <a href=\"https://materialdesignicons.com\">Material Design Icons</a>, <a href=\"http://ionicons.com/\">Ionicons</a>, etc."
 fontawesome4: true
-iconic: true
 ionicons: true
 mdi: true
 layout: documentation
@@ -745,104 +744,6 @@ meta:
         <br>
         <span class="icon">
           <i class="mdi mdi-signal-4g mdi-rotate-180"></i>
-        </span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
-{% include elements/anchor.html name="Open Iconic" %}
-
-<div class="content">
-  <p>
-    Here is how the <code>icon</code> container can be used with <a href="https://useiconic.com/open">Open Iconic</a>.
-  </p>
-</div>
-
-<table class="table is-bordered">
-  <thead>
-    <tr>
-      <th>Container class</th>
-      <th>Container size</th>
-      <th>Iconic class</th>
-      <th>Icon size</th>
-      <th>Result</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>icon is-small</code>
-      </td>
-      <td>
-        <code>1rem x 1rem</code>
-      </td>
-      <td>
-        <code>oi [data-glyph=puzzle-piece]</code>
-      </td>
-      <td>
-        <code>1em</code>
-      </td>
-      <td class="bd-icon-size">
-        <span class="icon is-small">
-          <span class="oi" data-glyph="puzzle-piece"></span>
-        </span>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>icon</code>
-      </td>
-      <td>
-        <code>1.5rem x 1.5rem</code>
-      </td>
-      <td>
-        <code>oi [data-glyph=puzzle-piece]</code>
-      </td>
-      <td>
-        <code>1em</code>
-      </td>
-      <td class="bd-icon-size">
-        <span class="icon">
-          <span class="oi" data-glyph="puzzle-piece"></span>
-        </span>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>icon is-medium</code>
-      </td>
-      <td>
-        <code>2rem x 2rem</code>
-      </td>
-      <td>
-        <code>oi [data-glyph=puzzle-piece]</code>
-      </td>
-      <td>
-        <code>1em</code>
-      </td>
-      <td class="bd-icon-size">
-        <span class="icon is-medium">
-          <span class="oi" data-glyph="puzzle-piece"></span>
-        </span>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>icon is-large</code>
-      </td>
-      <td>
-        <code>3rem x 3rem</code>
-      </td>
-      <td>
-        <code>oi [data-glyph=puzzle-piece]</code>
-      </td>
-      <td>
-        <code>1em</code>
-      </td>
-      <td class="bd-icon-size">
-        <span class="icon is-large">
-          <span class="oi" data-glyph="puzzle-piece"></span>
         </span>
       </td>
     </tr>


### PR DESCRIPTION
The Open Iconic project appears to be dead. No activity on GitHub in years, broken links to pages, etc. Probably best not to mention it as an option in the docs.

### Testing Done

Ran the website locally to verify that nothing is broken.

### Changelog updated?

No.