### PR TITLE
Fix #2471: Page padding for fixed spaced navbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * #2664 Fixes #2671 -> Add `$panel-colors` variable
+* #2471 Document `has-spaced-navbar-fixed-top` for Navbar
 
 ## 0.8.0
 
@@ -19,7 +20,7 @@ $control-height: 2.25em
 $control-padding-vertical: calc(0.375em - #{$control-border-width})
 $control-padding-horizontal: calc(0.625em - #{$control-border-width})
 $button-padding-vertical: calc(0.375em - #{$button-border-width})
-$button-padding-horizontal: 0.75em 
+$button-padding-horizontal: 0.75em
 ```
 
 #### Light and dark colors

--- a/docs/documentation/components/navbar.html
+++ b/docs/documentation/components/navbar.html
@@ -915,6 +915,9 @@ $(document).ready(function() {
       {% highlight html %}<html class="has-navbar-fixed-top">{% endhighlight %}
     </li>
   </ul>
+  <p>
+    If using <code>is-spaced</code> modifier on navbar, apply <code>has-spaced-navbar-fixed-top</code> or <code>has-spaced-navbar-fixed-bottom</code> to <code>&lt;html&gt;</code> or <code>&lt;body&gt;</code> instead.
+  </p>
 </div>
 
 <h4 class="title is-5">Try it out!</h4>

--- a/sass/components/navbar.sass
+++ b/sass/components/navbar.sass
@@ -124,9 +124,11 @@ $navbar-breakpoint: $desktop !default
 
 html,
 body
-  &.has-navbar-fixed-top
+  &.has-navbar-fixed-top,
+  &.has-spaced-navbar-fixed-top
     padding-top: $navbar-height
-  &.has-navbar-fixed-bottom
+  &.has-navbar-fixed-bottom,
+  &.has-spaced-navbar-fixed-bottom
     padding-bottom: $navbar-height
 
 .navbar-brand,
@@ -268,9 +270,11 @@ a.navbar-item,
         overflow: auto
   html,
   body
-    &.has-navbar-fixed-top-touch
+    &.has-navbar-fixed-top-touch,
+    &.has-spaced-navbar-fixed-top-touch
       padding-top: $navbar-height
-    &.has-navbar-fixed-bottom-touch
+    &.has-navbar-fixed-bottom-touch,
+    &.has-spaced-navbar-fixed-bottom-touch
       padding-bottom: $navbar-height
 
 +from($navbar-breakpoint)


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **bugfix | documentation fix**.

- `has-spaced-navbar-fixed-top/bottom` is missing from documentation
- it only specifies padding for html/body on desktop and above

https://jsbin.com/buxaletika/edit?html,output
![navbar](https://user-images.githubusercontent.com/26761352/70633600-cf5d8800-1c56-11ea-968a-26c200115702.gif)

### Proposed solution
The solution here will apply correct padding to html/body by using only `has-spaced-navbar-fixed-top/bottom`.

### Tradeoffs
None that I can think of.

### Testing Done

![navbar_fix](https://user-images.githubusercontent.com/26761352/70634714-bc4bb780-1c58-11ea-841a-e6b0671dcc4f.gif)

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

### Changelog updated?

Yes.

<!-- Thanks! -->
