### PR TITLE
Fix #2739 add variables size for layout hero

### DIFF
--- a/docs/_data/variables/layout/hero.json
+++ b/docs/_data/variables/layout/hero.json
@@ -1,0 +1,25 @@
+{
+  "by_name": {
+    "$hero-padding": {
+      "name": "$hero-padding",
+      "value": "1.5rem 0rem",
+      "type": "size"
+    },
+    "$hero-padding-medium": {
+      "name": "$hero-padding-medium",
+      "value": "9rem 0rem",
+      "type": "size"
+    },
+    "$hero-padding-large": {
+      "name": "$hero-padding-large",
+      "value": "18rem 0rem",
+      "type": "size"
+    }
+  },
+  "list": [
+    "$hero-padding",
+    "$hero-padding-medium",
+    "$hero-padding-large"
+  ],
+  "file_path": "layout/hero.sass"
+} 

--- a/docs/documentation/customize/concepts.html
+++ b/docs/documentation/customize/concepts.html
@@ -14,7 +14,7 @@ breadcrumb:
 
 <div class="content">
   <p>
-    Bulma is highly customizable thanks to <strong>415 Sass variables</strong> living across <strong>28 files</strong>.
+    Bulma is highly customizable thanks to <strong>418 Sass variables</strong> living across <strong>28 files</strong>.
   </p>
 
   <p>

--- a/docs/documentation/layout/hero.html
+++ b/docs/documentation/layout/hero.html
@@ -13,7 +13,7 @@ breadcrumb:
 meta:
   colors: true
   sizes: true
-  variables: false
+  variables: true
 ---
 
 <div class="content">

--- a/sass/layout/hero.sass
+++ b/sass/layout/hero.sass
@@ -1,5 +1,8 @@
-// Main container
+$hero-padding: 1.5rem 0rem !default
+$hero-padding-medium: 9rem 0rem !default
+$hero-padding-large: 18rem 0rem !default
 
+// Main container
 .hero
   align-items: stretch
   display: flex
@@ -71,18 +74,15 @@
   // Sizes
   &.is-small
     .hero-body
-      padding-bottom: 1.5rem
-      padding-top: 1.5rem
+      padding: $hero-padding
   &.is-medium
     +tablet
       .hero-body
-        padding-bottom: 9rem
-        padding-top: 9rem
+        padding: $hero-padding-medium
   &.is-large
     +tablet
       .hero-body
-        padding-bottom: 18rem
-        padding-top: 18rem
+        padding: $hero-padding-large
   &.is-halfheight,
   &.is-fullheight,
   &.is-fullheight-with-navbar


### PR DESCRIPTION
This is an improvement|documentation fix.

Fixes issue #2739 adding three sass variables to hero layout

### Proposed solution
![Screen Shot 2019-12-14 at 9 31 39](https://user-images.githubusercontent.com/16979749/70851738-3a28e200-1e56-11ea-9a15-dc77a4b27df8.png)

### Testing Done
It was tested locally and the layout hero is still working the same way as before.

### Changelog updated?

No.