### PR TITLE
#2731 - Fix Button size with is-sr-only label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * #2664 Fixes #2671 -> Add `$panel-colors` variable
+* #2731 Fixes Button size with is-sr-only label adding `is-only-child` to icon
 
 ## 0.8.0
 
@@ -251,7 +252,7 @@ Fix #1979 -> Correct loading spinner color when a button is:
 * #1905 Fix `modal` for IE11 #1902
 * #1919 New `is-arrowless` class for navbar items
 * #1949 New `is-fullheight-with-navbar` class for heros
-* #1764 New `.is-sr-only` helper
+* #1764 New `.is-only-child` button helper
 * #2109 Add and use `$navbar-breakpoint` variable
 * New variables `$control-height`, `$control-line-height`, `$pagination-min-width`, `$input-height`
 * #1720 Add list element feature

--- a/docs/documentation/elements/button.html
+++ b/docs/documentation/elements/button.html
@@ -267,11 +267,11 @@ meta:
 
 {% capture button_only_icon_example %}
 <p class="buttons">
-  <button class="button is-small">
-        <span class="is-sr-only">Heading</span>
-    <span class="icon is-small">
-      <i class="fas fa-heading"></i>
+  <button class="button">
+    <span class="icon is-small is-only-child">
+      <i class="far fa-heading"></i>
     </span>
+    <span class="is-sr-only">Heading</span>
   </button>
 </p>
 <p class="buttons">
@@ -791,7 +791,7 @@ meta:
         If the button only contains an icon, Bulma will make sure the button remains <strong>square</strong>, no matter the size of the button <em>or</em> of the icon.
       </p>
       <p>
-        You can add <code>&lt;span="is-sr-only"&gt;</code> before the icon as a screen-reader label.
+        In case of icon only button, you must add the class <code>is-only-child</code> in the icon.
       </p>
     </div>
     {{ button_only_icon_example }}

--- a/docs/documentation/elements/button.html
+++ b/docs/documentation/elements/button.html
@@ -268,6 +268,7 @@ meta:
 {% capture button_only_icon_example %}
 <p class="buttons">
   <button class="button is-small">
+        <span class="is-sr-only">Heading</span>
     <span class="icon is-small">
       <i class="fas fa-heading"></i>
     </span>
@@ -788,6 +789,9 @@ meta:
     <div class="content">
       <p>
         If the button only contains an icon, Bulma will make sure the button remains <strong>square</strong>, no matter the size of the button <em>or</em> of the icon.
+      </p>
+      <p>
+        You can add <code>&lt;span="is-sr-only"&gt;</code> before the icon as a screen-reader label.
       </p>
     </div>
     {{ button_only_icon_example }}

--- a/sass/elements/button.sass
+++ b/sass/elements/button.sass
@@ -1,4 +1,4 @@
-$button-color: $text-strong !default
+$button-color: red !default
 $button-background-color: $scheme-main !default
 $button-family: false !default
 
@@ -21,7 +21,7 @@ $button-active-border-color: $link-active-border !default
 
 $button-text-color: $text !default
 $button-text-hover-background-color: $background !default
-$button-text-hover-color: $text-strong !default
+$button-text-hover-color: red !default
 
 $button-disabled-background-color: $scheme-main !default
 $button-disabled-border-color: $border !default
@@ -78,6 +78,11 @@ $button-static-border-color: $border !default
     &:first-child:last-child
       margin-left: calc(#{-1 / 2 * $button-padding-horizontal} - #{$button-border-width})
       margin-right: calc(#{-1 / 2 * $button-padding-horizontal} - #{$button-border-width})
+  .is-sr-only
+    + .icon
+        &:last-child:not(:first-child)
+          margin-left: calc(#{-1 / 2 * $button-padding-horizontal} - #{$button-border-width})
+          margin-right: calc(#{-1 / 2 * $button-padding-horizontal} - #{$button-border-width})
   // States
   &:hover,
   &.is-hovered

--- a/sass/elements/button.sass
+++ b/sass/elements/button.sass
@@ -69,20 +69,16 @@ $button-static-border-color: $border !default
     &.is-large
       height: 1.5em
       width: 1.5em
-    &:first-child:not(:last-child)
+    &:first-child:not(:last-child):not(.is-only-child)
       margin-left: calc(#{-1 / 2 * $button-padding-horizontal} - #{$button-border-width})
       margin-right: $button-padding-horizontal / 4
     &:last-child:not(:first-child)
       margin-left: $button-padding-horizontal / 4
       margin-right: calc(#{-1 / 2 * $button-padding-horizontal} - #{$button-border-width})
-    &:first-child:last-child
+    &:first-child:last-child,
+    &.is-only-child
       margin-left: calc(#{-1 / 2 * $button-padding-horizontal} - #{$button-border-width})
       margin-right: calc(#{-1 / 2 * $button-padding-horizontal} - #{$button-border-width})
-  .is-sr-only
-    + .icon
-        &:last-child:not(:first-child)
-          margin-left: calc(#{-1 / 2 * $button-padding-horizontal} - #{$button-border-width})
-          margin-right: calc(#{-1 / 2 * $button-padding-horizontal} - #{$button-border-width})
   // States
   &:hover,
   &.is-hovered


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **new feature | improvement | bugfix | documentation fix**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution

This fixes the issue reported in #2731 where the icon size wasn't correct if you decide to add a label for screen-reader only.

### Tradeoffs

The issue reported was using the ` is-sr-only` label after ` icon` . However, the solution changes the order of elements. The label must be before the icon.

### Testing Done

Manually tested importing the generated version and also tested with Chrome Developer Tools.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

### Changelog updated?

Yes.

<!-- Thanks! -->
