### PR TITLE
#2729 - Add level align modifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,6 +224,7 @@ Fix #1979 -> Correct loading spinner color when a button is:
 * #592 -> Give arbitrary elements access to the image/ratio classes
 * #1682 Fix #1681 -> Adds disabled styles for `<fieldset disabled>`
 * #2201 Fix #1875 -> `.buttons` and `.tags` group sizing (`.are-small`, `.are-medium`, `.are-large`)
+* #2747 Fix #2729 Adds item alignment classes
 
 ### Improvements
 

--- a/docs/documentation/modifiers/helpers.html
+++ b/docs/documentation/modifiers/helpers.html
@@ -71,5 +71,22 @@ breadcrumb:
       <td><code>is-relative</code></td>
       <td>Applies <code>position: relative</code> to the element.</td>
     </tr>
+    <tr>
+      <th rowspan="4">Item Alignment</th>
+      <td>align-start</td>
+      <td>The element is positioned at the <strong>beginning</strong> of the container</td>
+    </tr>
+    <tr>
+      <td>align-center</td>
+      <td>The element is positioned at the <strong>center</strong> of the container</td>
+    </tr>
+    <tr>
+      <td>align-bottom</td>
+      <td>The element is positioned at the <strong>end</strong> of the container</td>
+    </tr>
+    <tr>
+      <td>align-stretch</td>
+      <td>The element is positioned to <strong>fit</strong> the container</td>
+    </tr>
   </tbody>
 </table>

--- a/sass/base/helpers.sass
+++ b/sass/base/helpers.sass
@@ -279,3 +279,9 @@ $displays: 'block' 'flex' 'inline' 'inline-block' 'inline-flex'
 
 .is-relative
   position: relative !important
+  
+$alignments-self: ('start': 'flext-start', 'center': 'center', 'bottom': 'flex-end', 'stretch': 'stretch')
+
+@each $align-self, $value in $alignments-self
+  .align-#{$align-self}
+    align-self: $value !important


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **new feature**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution

This aims to fix #2729 adding new 4 classes to help item alignment.
It uses `align-self` to determine items position.

### Tradeoffs

The only tradeoff is that this uses flexbox. So, there isn't a tradeoff.

### Testing Done

Tested locally to check if it works as expected.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

### Changelog updated?

Yes.

<!-- Thanks! -->
