### PR TITLE
Add cursor helper

### DIFF
--- a/sass/base/helpers.sass
+++ b/sass/base/helpers.sass
@@ -279,3 +279,6 @@ $displays: 'block' 'flex' 'inline' 'inline-block' 'inline-flex'
 
 .is-relative
   position: relative !important
+
+.has-cursor-pointer
+  cursor: pointer !important


### PR DESCRIPTION
This is a **new feature**.

This PR adds a new helper `.has-cursor-pointer` which sets the cursor to pointer on a given element. I find myself creating similar helper classes all the time.


### Tradeoffs

None.

### Testing Done

None.

### Changelog updated?

No.

<!-- Thanks! -->
