### PR TITLE
fix bulma.sass path in documentation

### DIFF
--- a/docs/documentation/customize/with-sass-cli.html
+++ b/docs/documentation/customize/with-sass-cli.html
@@ -119,7 +119,7 @@ sass --watch --sourcemap=none sass/mystyles.scss:css/mystyles.css
 
 <hr>
 
-{% assign bulma_path = site.data.meta.version | prepend: "../bulma-" | append: "/bulma/bulma.sass" %}
+{% assign bulma_path = site.data.meta.version | prepend: "../bulma-" | append: "/bulma.sass" %}
 
 {% include steps/create-sass-file.html
   number="3"


### PR DESCRIPTION
the bulma archive has bulma.sass directly at the root of the bulma-$version/ directory, not in a bulma subdirectory. contradicting the documentation at https://bulma.io/documentation/customize/with-sass-cli/


This is a **documentation fix**.

### Proposed solution

update the bulma_path variable

### Tradeoffs
can't think of any
### Testing Done

None.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

### Changelog updated?

No.

<!-- Thanks! -->
