### PR TITLE
#2760 - Add feature for circular-progress-bar

### DIFF
--- a/sass/elements/progress.sass
+++ b/sass/elements/progress.sass
@@ -60,6 +60,129 @@ $progress-indeterminate-duration: 1.5s !default
   &.is-large
     height: $size-large
 
+  &.is-circle
+    $progress: 0
+    $color-active: #2ecc71
+    $color-inactive: #eee
+    $color-bg: $white
+    $color-font: #eee    
+
+    // background: $color-inactive
+    border-radius: 50%
+    position: relative
+    font-family: 'Lato', sans-serif
+    height: 150px
+    width: 150px
+    &.is-small
+      height: $size-small
+      width: $size-small
+    &.is-medium
+      height: $size-medium
+      width: $size-medium
+    &.is-large
+      height: $size-large
+      width: $size-large
+    &:not(.is-borderless)
+      border: 1px solid $color-active !important
+      &:before
+        border: 1px solid $color-active
+    overflow: hidden
+    &:before
+      content: $progress + "%"
+      text-align: center
+      padding-top: 34%
+      color: $color-font
+      width: 90%
+      height: 90%
+      //line-height: 100%
+      padding-top: calc($body-size + 23%)
+      background: $color-bg
+      position: absolute
+      border-radius: 50%
+      left: 5%
+      top: 5%
+      z-index: 1000
+      //box-shadow: inset 0px 0px 20px rgba(#000, 0.5)
+      border: 2px solid $color-bg
+      box-sizing: border-box
+    &.has-background-light
+      &:before
+        background-color: $grey-lighter
+    &.has-background-heavy
+      &:before
+        background-color: $grey-light
+
+    .hide 
+      height: 100%
+      width: 50%
+      position: absolute
+      left: 50%
+      top: 0
+      background: $color-inactive
+      z-index: 200
+      transform-origin: left center
+      $deg: (360 / 100) * $progress
+      transform: rotate($deg + deg)
+    
+    .active, .active2 
+      width: 50%
+      height: 100%
+      background: $color-active
+      position: absolute
+      @if $progress > 50 
+        z-index: 300
+      
+      left: 50%
+      top: 0
+    
+    @if $progress > 50 
+      .active2 
+        transform-origin: left center
+        $deg: (360 / 100) * ($progress - 50)
+        transform: rotate($deg + deg)
+    
+    @each $name, $pair in $colors
+      $color: nth($pair, 1)
+      $color-invert: nth($pair, 2)
+      &.is-#{$name}
+        &:not(.is-borderless)
+          border: 1px solid $color !important
+          &:before
+            border: 1px solid $color
+          .hide
+
+        .active, .active2
+          background-color: $color
+        .hide
+          background: $color-invert
+        @if $progress > 50 
+          .active2
+            background-color: $color !important
+      &.has-text-#{$name}
+        &:before
+          color: $color
+    
+    @for $i from 0 through 100 // 0 - 100
+      &.is-#{$i}
+        &:before
+          content: $i + "%"
+        .hide
+          $deg: (360 / 100) * $i
+          transform: rotate($deg + deg)
+        .active, .active2
+          width: 50%
+          height: 100%
+          position: absolute
+          @if $i > 50 
+            z-index: 300
+          left: 50%
+          top: 0
+        @if $i > 50 
+          .active2
+            transform-origin: left center
+            $deg: (360 / 100) * ($i - 50)
+            transform: rotate($deg + deg)
+
 @keyframes moveIndeterminate
   from
     background-position: 200% 0

--- a/sass/elements/progress.sass
+++ b/sass/elements/progress.sass
@@ -65,7 +65,9 @@ $progress-indeterminate-duration: 1.5s !default
     $color-active: #2ecc71
     $color-inactive: #eee
     $color-bg: $white
-    $color-font: #eee    
+    $color-font: #eee
+
+    @extend .is-0
 
     // background: $color-inactive
     border-radius: 50%
@@ -182,6 +184,8 @@ $progress-indeterminate-duration: 1.5s !default
             transform-origin: left center
             $deg: (360 / 100) * ($i - 50)
             transform: rotate($deg + deg)
+      &[value="#{$i}"]
+        @extend .is-#{$i}
 
 @keyframes moveIndeterminate
   from


### PR DESCRIPTION
This is a new feature for issue #2760

### Proposed solution

This is my solution for circular progress bar required into issue #2760.
You can use `is-circle` with `process` class.
For example:
```
<div class="progress is-circle is-info has-text-info" value="40">
<div class="hide"></div>
<div class="active"></div>
<div class="active2"></div>
</div>
```
After `is-circle` you can append all standard Bulma classes for text colors(has-text-$color), bar color(is-info, is-danger), font width(is-size-1), etc...
Default size of bar is 0. You can change this size with value tag attribute `value="40"` from 0 to 100. 

This solution is not compatible with `<process>` tag.

### Tradeoffs

The issue reported was using the

### Testing Done

Manually tested with Mozilla Firefox and Microsoft Edge.
![immagine](https://user-images.githubusercontent.com/10075337/72658621-bbbee300-39b3-11ea-8d7f-9cf05c2dbd16.png)


### Changelog updated?

No.

Any suggestions?