### PR TITLE
#2473 - Add percentage into progress bar

### DIFF
--- a/sass/elements/progress.sass
+++ b/sass/elements/progress.sass
@@ -60,6 +60,45 @@ $progress-indeterminate-duration: 1.5s !default
   &.is-large
     height: $size-large
 
+  &.has-percentage
+    background-color: $progress-bar-background-color
+    $value: 0
+    @extend .is-#{$value}
+    .progress-bar
+      position: relative
+      display: block
+      width: 0
+      height: 100%
+      background-color: $progress-value-background-color
+    .progress-text
+      top: 50%
+      left: 50%
+      -webkit-transform: translate(-50%,-50%)
+      transform: translate(-50%,-50%)
+      position: absolute
+      margin: 0
+      font-size: .75rem
+      font-weight: 700
+      color: #fff
+      white-space: nowrap
+
+    @each $name, $pair in $colors
+      $color: nth($pair, 1)
+      $color-invert: nth($pair, 2)
+      &.is-#{$name}
+        .progress-bar
+          background-color: $color
+        .progress-text
+          color: $color-invert
+    @for $i from 0 through 100 // 0 - 100
+      &.is-#{$i}
+        .progress-bar
+          width: percentage($i/100)
+        .progress-text:after
+          content: "#{$i}%"
+      &[value="#{$i}"]
+        @extend .is-#{$i}
+        
 @keyframes moveIndeterminate
   from
     background-position: 200% 0


### PR DESCRIPTION
This is a new feature for issue #2473

### Proposed solution

Add percentage valueinto progress bar required into issue #2473.
You can use `has-percentage` with `process` class.
For example:
```
<div class="progress has-percentage is-link" value="35">
  <div class="progress-bar">
    <div class="progress-text"></div>
  </div>
</div>
```
This solution is not compatible with `<process>` tag.

### Testing Done

Manually tested with Mozilla Firefox and Microsoft Edge

![immagine](https://user-images.githubusercontent.com/10075337/72672086-5fac9b00-3a55-11ea-833c-37da80304277.png)
![immagine](https://user-images.githubusercontent.com/10075337/72672096-73580180-3a55-11ea-85fa-ac6376758cfd.png)
![immagine](https://user-images.githubusercontent.com/10075337/72672099-8ff43980-3a55-11ea-8867-b9a7f06d7ddb.png)


### Changelog updated?

No.

Any suggestions?