### PR TITLE
Fixes #2780: Add list to components

### DIFF
--- a/docs/_data/links.json
+++ b/docs/_data/links.json
@@ -430,6 +430,12 @@
       "icon": "angle-down",
       "path": "/documentation/components/dropdown"
     },
+    "components-list": {
+      "name": "List",
+      "subtitle": "A convenient <strong>list</strong> to display series of content",
+      "icon": "th-list",
+      "path": "/documentation/components/list"
+    },
     "components-menu": {
       "name": "Menu",
       "subtitle": "A simple <strong>menu</strong>, for any type of vertical navigation",
@@ -585,6 +591,6 @@
     "layout": ["layout-container", "layout-level", "layout-media", "layout-hero", "layout-section", "layout-footer", "layout-tiles"],
     "form": ["form-general", "form-input", "form-textarea", "form-select", "form-checkbox", "form-radio", "form-file"],
     "elements": ["elements-box", "elements-button", "elements-content", "elements-delete", "elements-icon", "elements-image", "elements-notification", "elements-progress", "elements-table", "elements-tag", "elements-title"],
-    "components": ["components-breadcrumb", "components-card", "components-dropdown", "components-menu", "components-message", "components-modal", "components-navbar", "components-pagination", "components-panel", "components-tabs"]
+    "components": ["components-breadcrumb", "components-card", "components-dropdown", "components-list", "components-menu", "components-message", "components-modal", "components-navbar", "components-pagination", "components-panel", "components-tabs"]
   }
 }

--- a/docs/_includes/content/comparison.html
+++ b/docs/_includes/content/comparison.html
@@ -351,10 +351,12 @@
   </td>
 </tr>
 <tr>
-  <td class="bd-is-empty">
-    –
+  <td>
+    <a href="{{ site.url }}/documentation/components/list">
+      list
+    </a>
   </td>
-  <td class="bd-is-unique">
+  <td>
     <a href="https://getbootstrap.com/css/#type-lists" target="_blank">
       lists
     </a>


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **documentation fix** for #2780.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution

<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->
1. Adds the [List](https://github.com/jgthms/bulma/blob/master/docs/documentation/components/list.html) component to the Components in Documentation (tabs, sidebar).
2. Adds the [List](https://github.com/jgthms/bulma/blob/master/docs/documentation/components/list.html) component to the [Alternative to Boostrap](https://bulma.io/alternative-to-bootstrap/) comparison (removing `empty` from Bulma, and `unique` from Bootstrap, and adding the component).

### Tradeoffs

None. 

The component already existed; simply had to be linked in the appropriate documentation sections.
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->

### Testing Done

I have tested this component against the **Steps to Reproduce** in #2780.

Without this change, List is not present. With this change, List is present.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

### Changelog updated?

No.

<!-- Thanks! -->