### PR TITLE
Remove unnecessary </a> tag in Button element documentation page

### DIFF
--- a/docs/documentation/elements/button.html
+++ b/docs/documentation/elements/button.html
@@ -235,7 +235,6 @@ meta:
       <i class="fas fa-times"></i>
     </span>
   </button>
-  </a>
 </p>
 <p class="buttons">
   <button class="button is-small">


### PR DESCRIPTION
This is a **documentation fix**.

Removing an unnecessary tag in: https://github.com/jgthms/bulma/blob/master/docs/documentation/elements/button.html#L238

