### PR TITLE
Replace index() to keep duplicate sizes, FIXES #2802

### DIFF
--- a/sass/elements/title.sass
+++ b/sass/elements/title.sass
@@ -46,8 +46,8 @@ $subtitle-negative-margin: -1.25rem !default
   &:not(.is-spaced) + .subtitle
     margin-top: $subtitle-negative-margin
   // Sizes
-  @each $size in $sizes
-    $i: index($sizes, $size)
+  @for $i from 1 through length($sizes)
+    $size: nth($sizes, $i)
     &.is-#{$i}
       font-size: $size
 
@@ -64,7 +64,7 @@ $subtitle-negative-margin: -1.25rem !default
   &:not(.is-spaced) + .title
     margin-top: $subtitle-negative-margin
   // Sizes
-  @each $size in $sizes
-    $i: index($sizes, $size)
+  @for $i from 1 through length($sizes)
+    $size: nth($sizes, $i)
     &.is-#{$i}
       font-size: $size

--- a/sass/helpers/typography.sass
+++ b/sass/helpers/typography.sass
@@ -1,6 +1,6 @@
 =typography-size($target:'')
-  @each $size in $sizes
-    $i: index($sizes, $size)
+  @for $i from 1 through length($sizes)
+    $size: nth($sizes, $i)
     .is-size-#{$i}#{if($target == '', '', '-' + $target)}
       font-size: $size !important
 


### PR DESCRIPTION
This is a **bugfix** 

### Proposed solution

Prefer `@for` over `@each` for sizes.

### Tradeoffs

Using `@each` is cosmetically nicer and more modern. Maybe there's a solution that uses `@each` but not `index()`?

### Testing Done

- I verified that all the sizes (1-7) appear correctly in the generated CSS
- I applied and verified these changes with the reproduced demo project: https://github.com/hkgumbs/bulma-size-bug-demo

### Changelog updated?

No.
