### PR TITLE
Replaced 'mobile' w/ 'touch devices' on nav burger

### DIFF
--- a/docs/documentation/components/navbar.html
+++ b/docs/documentation/components/navbar.html
@@ -711,7 +711,7 @@ $(document).ready(function() {
 
 <div class="content">
   <p>
-    The <code>navbar-burger</code> is a hamburger menu that only appears on <strong>mobile</strong>. It has to appear as the last child of <code>navbar-brand</code>. It has to contain three empty <code>span</code> tags in order to visualize the hamburger lines or the cross (when active).
+    The <code>navbar-burger</code> is a hamburger menu that only appears on <strong>touch devices</strong>. It has to appear as the last child of <code>navbar-brand</code>. It has to contain three empty <code>span</code> tags in order to visualize the hamburger lines or the cross (when active).
   </p>
 </div>
 


### PR DESCRIPTION
# Documentation fix:
Replaced 'mobile' w/ 'touch devices' on nav burger documentation.

# Changelog updated?
No.
