### PR TITLE
Add card with image cover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 
 * #2664 Fixes #2671 -> Add `$panel-colors` variable
 
+### Card with image findColorInvert
+
+The `card` component now supports image covers
+
 ## 0.8.0
 
 ### Big update

--- a/docs/_data/variables/components/card.json
+++ b/docs/_data/variables/components/card.json
@@ -79,6 +79,18 @@
       "type": "variable",
       "computed_type": "size",
       "computed_value": "1.5rem"
+    },
+    "$card-image-cover-text": {
+      "name": "$card-image-cover-text",
+      "value": "$white",
+      "type": "variable",
+      "computed_type": "color",
+      "computed_value": "hsl(0, 0%, 100%)"
+    },
+    "$card-image-cover-text-shadow": {
+      "name": "$card-media-margin",
+      "value": "11px 2px 10px rgba($black, 1)",
+      "type": "size"
     }
   },
   "list": [
@@ -95,7 +107,9 @@
     "$card-footer-background-color",
     "$card-footer-border-top",
     "$card-footer-padding",
-    "$card-media-margin"
+    "$card-media-margin",
+    "$card-image-cover-text",
+    "$card-image-cover-text-shadow"
   ],
   "file_path": "components/card.sass"
 }

--- a/docs/documentation/components/card.html
+++ b/docs/documentation/components/card.html
@@ -98,6 +98,60 @@ meta:
 </div>
 {% endcapture %}
 
+{% capture card_overlay_example %}
+<div class="card has-image-cover">
+  <div class="card-image">
+    <figure class="image">
+      <img src="{{site.url}}/images/various/tom-levold-260373.jpg" alt="Tom Levold">
+    </figure>
+  </div>
+  <div class="card-content">
+    <p class="title">
+      “There are two hard things in computer science: cache invalidation, naming things, and off-by-one errors.”
+    </p>
+    <p class="subtitle">
+      Jeff Atwood
+    </p>
+  </div>
+</div>
+{% endcapture %}
+
+{% capture card_overlay_default_example %}
+<div class="card has-image-cover">
+  <div class="card-image">
+    <figure class="image">
+      <img src="{{site.url}}/images/various/tom-levold-260373.jpg" alt="Tom Levold">
+    </figure>
+  </div>
+  <div class="card-content">
+    <p class="title">
+      “There are two hard things in computer science: cache invalidation, naming things, and off-by-one errors.”
+    </p>
+    <p class="subtitle">
+      Jeff Atwood
+    </p>
+  </div>
+</div>
+{% endcapture %}
+
+{% capture card_overlay_top_example %}
+<div class="card has-image-cover is-text-top">
+  <div class="card-image">
+    <figure class="image">
+      <img src="{{site.url}}/images/various/tom-levold-260373.jpg" alt="Tom Levold">
+    </figure>
+  </div>
+  <div class="card-content">
+    <p class="title">
+      “There are two hard things in computer science: cache invalidation, naming things, and off-by-one errors.”
+    </p>
+    <p class="subtitle">
+      Jeff Atwood
+    </p>
+  </div>
+</div>
+{% endcapture %}
+
 <div class="content">
   <p>The <strong>card</strong> component comprises several elements that you can mix and match:</p>
   <ul>
@@ -177,5 +231,26 @@ meta:
     {% highlight html %}{{card_title_example}}{% endhighlight %}
   </div>
 </div>
+
+<hr>
+
+<div class="columns">
+  <div class="column is-half">
+    {{card_overlay_default_example}}
+  </div>
+  <div class="column">
+    {{card_overlay_top_example}}
+  </div>
+</div>
+<div class="columns">
+  <div class="column is-half highlight-full">
+    {% highlight html %}{{card_overlay_default_example}}{% endhighlight %}
+  </div>
+  <div class="column highlight-full">
+    {% highlight html %}{{card_overlay_top_example}}{% endhighlight %}
+  </div>
+</div>
+
+
 
 {% include elements/variables.html type='component' %}

--- a/sass/components/card.sass
+++ b/sass/components/card.sass
@@ -17,12 +17,39 @@ $card-footer-padding: 0.75rem !default
 
 $card-media-margin: $block-spacing !default
 
+$card-image-cover-text: $white
+$card-image-cover-text-shadow: 11px 2px 10px rgba($black, 1)
+
 .card
   background-color: $card-background-color
   box-shadow: $card-shadow
   color: $card-color
   max-width: 100%
   position: relative
+  &.has-image-cover
+    .card-content
+      bottom: 0
+      display: flex
+      flex-direction: column
+      height: 100%
+      justify-content: flex-end
+      left: 0
+      position: absolute
+      right: 0
+      top: 0
+      *
+        color: $card-image-cover-text
+        text-shadow: $card-image-cover-text-shadow
+    .card-image
+      figure
+        height: 100%
+      img
+        height: 100%
+        object-fit: cover
+    &.is-text-top
+      .card-content
+        justify-content: flex-start
+
 
 .card-header
   background-color: $card-header-background-color


### PR DESCRIPTION
This is a **new feature**.

![Screenshot 2020-03-06 at 12 48 24](https://user-images.githubusercontent.com/1434/76081805-35358380-5faa-11ea-8be5-8980c497c17e.png)

### Proposed solution

Cards with an image background are a common pattern. In this proposal we implemented a version that prioritises the shape of the image. 

### Tradeoffs

An alternative approach would be for the image to "cover" the background of the card, prioritising content fit.

### Testing Done

Pulled from a internal project, targeting modern browsers only.

### Changelog updated?

No.
