### PR TITLE
outdated cards with new word in it changed

### DIFF
--- a/docs/documentation/components/card.html
+++ b/docs/documentation/components/card.html
@@ -134,10 +134,7 @@ meta:
   </ul>
 </div>
 
-<div class="tags has-addons">
-  <span class="tag">Since</span>
-  <span class="tag is-info">0.5.3</span>
-</div>
+{% include elements/new-tag.html version="0.5.3" %}
 
 <div class="content">
   <p>

--- a/docs/documentation/components/card.html
+++ b/docs/documentation/components/card.html
@@ -135,7 +135,7 @@ meta:
 </div>
 
 <div class="tags has-addons">
-  <span class="tag">New</span>
+  <span class="tag">Since</span>
   <span class="tag is-info">0.5.3</span>
 </div>
 

--- a/docs/documentation/form/input.html
+++ b/docs/documentation/form/input.html
@@ -380,7 +380,7 @@ meta:
 
 <h4 class="subtitle">Readonly and static inputs</h4>
 <p style="margin-bottom: 0.5rem;">
-  <span class="tag is-success">New!</span>
+  <span class="tag is-success">Since</span>
   <span class="tag is-info">0.5.3</span>
 </p>
 <div class="content">

--- a/docs/documentation/form/input.html
+++ b/docs/documentation/form/input.html
@@ -379,10 +379,8 @@ meta:
 </div>
 
 <h4 class="subtitle">Readonly and static inputs</h4>
-<p style="margin-bottom: 0.5rem;">
-  <span class="tag is-success">Since</span>
-  <span class="tag is-info">0.5.3</span>
-</p>
+{% include elements/new-tag.html version="0.5.3" %}
+
 <div class="content">
   <p>
     If you use the <code>readonly</code> HTML attribute, the input will look similar to a normal one, but is not editable and has no shadow.

--- a/docs/documentation/form/textarea.html
+++ b/docs/documentation/form/textarea.html
@@ -232,10 +232,7 @@ meta:
 
 <h4 class="subtitle">Readonly</h4>
 
-<div class="tags has-addons">
-  <span class="tag">Since</span>
-  <span class="tag is-info">0.5.3</span>
-</div>
+{% include elements/new-tag.html version="0.5.3" %}
 
 <div class="content">
   <p>

--- a/docs/documentation/form/textarea.html
+++ b/docs/documentation/form/textarea.html
@@ -233,7 +233,7 @@ meta:
 <h4 class="subtitle">Readonly</h4>
 
 <div class="tags has-addons">
-  <span class="tag">New</span>
+  <span class="tag">Since</span>
   <span class="tag is-info">0.5.3</span>
 </div>
 


### PR DESCRIPTION
This is a **documentation fix**.

### Proposed solution

In website, 0.5.3 version features (which published 2 years ago) were still had `New!` tag with it. They were replaced into `Since` tags like most of 0.6.1 version features had.

### Tradeoffs

N/A

### Testing Done

None.

### Changelog updated?

No.
