### PR TITLE
Fixes #2862

### DIFF
--- a/docs/documentation/elements/button.html
+++ b/docs/documentation/elements/button.html
@@ -221,7 +221,7 @@ meta:
     <span class="icon">
       <i class="fab fa-twitter"></i>
     </span>
-    <span>@Bulma</span>
+    <span>@jgthms</span>
   </button>
   <button class="button is-success">
     <span class="icon is-small">


### PR DESCRIPTION
This is a improvement.

Why:
* According Twitter brand guideline says we cannot use the "Twitter icon" with "Twitter text".

This change addresses the need by:
* Replacing the span text from Twitter for @Bulma

