### PR TITLE
Remote duplicate code

### DIFF
--- a/sass/components/navbar.sass
+++ b/sass/components/navbar.sass
@@ -179,7 +179,6 @@ a.navbar-item,
     color: $navbar-item-hover-color
 
 .navbar-item
-  display: block
   flex-grow: 0
   flex-shrink: 0
   img


### PR DESCRIPTION
This is an **improvement**.

The `.navbar-item` is already declared as `display: block` at line 162.

https://github.com/jgthms/bulma/blob/f75ae3db01cb3be96dde517811f4950540f4c76f/sass/components/navbar.sass#L162