### PR TITLE
Remove duplicate code

### DIFF
--- a/sass/components/navbar.sass
+++ b/sass/components/navbar.sass
@@ -319,7 +319,6 @@ a.navbar-item,
     align-items: center
     display: flex
   .navbar-item
-    display: flex
     &.has-dropdown
       align-items: stretch
     &.has-dropdown-up


### PR DESCRIPTION
This is an **improvement**.

Remove another duplicate code. The `.navbar-item` is already declared as `display: flex` at line 320

https://github.com/jgthms/bulma/blob/02630c0f6629c6c052c3cc7c981d4243cd1cb233/sass/components/navbar.sass#L320