### PR TITLE
Remove duplicate "with" in concepts.html

### DIFF
--- a/docs/documentation/customize/concepts.html
+++ b/docs/documentation/customize/concepts.html
@@ -65,18 +65,18 @@ breadcrumb:
   </ul>
 
   <p>
-    This can be achieved with:
+    This can be achieved with any of the following:
   </p>
 
   <ul>
     <li>
-      with <a href="{{ site.url }}{{ node_sass_link.path }}">node-sass</a>
+     <a href="{{ site.url }}{{ node_sass_link.path }}">node-sass</a>
     </li>
     <li>
-      with the <a href="{{ site.url }}{{ sass_cli_link.path }}">Sass CLI</a>
+      the <a href="{{ site.url }}{{ sass_cli_link.path }}">Sass CLI</a>
     </li>
     <li>
-      with <a href="{{ site.url }}{{ webpack_link.path }}">webpack</a>
+      <a href="{{ site.url }}{{ webpack_link.path }}">webpack</a>
     </li>
   </ul>
 </div>


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a documentation fix.

### Proposed solution
Update some phrasing in concepts.html.
<!-- Which specific problem does this PR solve and how?  -->
This solves a grammar error in the ```<ul>``` in concepts.html: By removing the _with_ at the top of the list, the grammar error is fixed.

### Tradeoffs

<!-- What are the drawbacks of this solution? Are there alternative ones? -->
None.
<!-- Think of performance, build time, usability, complexity, coupling…) -->

### Testing Done

None.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

### Changelog updated?

No.

<!-- Thanks! -->
