### PR TITLE
Add border-radius settings to panel-block.hover

### DIFF
--- a/sass/components/panel.sass
+++ b/sass/components/panel.sass
@@ -109,6 +109,8 @@ label.panel-block
   cursor: pointer
   &:hover
     background-color: $panel-block-hover-background-color
+    border-top-left-radius: $panel-radius
+    border-top-right-radius: $panel-radius
 
 .panel-icon
   +fa(14px, 1em)


### PR DESCRIPTION
This PR fixes border-radius settings when moving the mouse over a panel block