### PR TITLE
Center table cell content vertically

### DIFF
--- a/sass/elements/table.sass
+++ b/sass/elements/table.sass
@@ -51,6 +51,8 @@ $table-striped-row-even-hover-background-color: $scheme-main-ter !default
       a,
       strong
         color: currentColor
+    &.is-vcentered
+      vertical-align: middle
   th
     color: $table-cell-heading-color
     &:not([align])


### PR DESCRIPTION
Adding .is-vcentered as an option for td and th elements that are part of a .table.

This is an **improvement**.  It offers a way to vertically center table cell content, using the same class name used to vertically center columns.

### Proposed solution

.is-vcentered for th and td elements.

### Tradeoffs

None.

### Testing Done

In my own project.  Working there.

### Changelog updated?

No.
