### PR TITLE
Fix issue when there's only one is-toggle tag

### DIFF
--- a/sass/components/tabs.sass
+++ b/sass/components/tabs.sass
@@ -121,9 +121,11 @@ $tabs-toggle-link-active-color: $link-invert !default
       & + li
         margin-left: -#{$tabs-toggle-link-border-width}
       &:first-child a
-        border-radius: $tabs-toggle-link-radius 0 0 $tabs-toggle-link-radius
+        border-top-left-radius: $tabs-toggle-link-radius
+        border-bottom-left-radius: $tabs-toggle-link-radius
       &:last-child a
-        border-radius: 0 $tabs-toggle-link-radius $tabs-toggle-link-radius 0
+        border-bottom-right-radius: $tabs-toggle-link-radius
+        border-top-right-radius: $tabs-toggle-link-radius
       &.is-active
         a
           background-color: $tabs-toggle-link-active-background-color


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a bugfix.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->
Currently tags.is-toggle was displayed incorrectly when there's only one list item in .tabs.is-toggle.


<img width="151" alt="image" src="https://user-images.githubusercontent.com/8980455/82128228-89699a80-9787-11ea-9b3b-b82b70c55b35.png">


This is due to to border-radius shorthand overriding each other.
<img width="276" alt="image" src="https://user-images.githubusercontent.com/8980455/82128261-ccc40900-9787-11ea-9246-705b67fcd92b.png">



### Proposed solution

Replace border-radius short-hand with individual properties in .tags.is-toggle li:last-child a

### Tradeoffs
None.

### Testing Done

After making those changes, .tags.is-toggle with only one child can be rendered correctly.

<img width="132" alt="image" src="https://user-images.githubusercontent.com/8980455/82128339-64295c00-9788-11ea-9d1e-d4408aeaf2c9.png">


<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

### Changelog updated?

No.

<!-- Thanks! -->
