### PR TITLE
Visual bug on button

### DIFF
--- a/sass/elements/button.sass
+++ b/sass/elements/button.sass
@@ -172,12 +172,13 @@ $button-static-border-color: $border !default
         &.is-loading
           &::after
             border-color: transparent transparent $color $color !important
-          &:hover,
-          &.is-hovered,
-          &:focus,
-          &.is-focused
-            &::after
-              border-color: transparent transparent $color-invert $color-invert !important
+          &:not([disabled])
+            &:hover,
+            &.is-hovered,
+            &:focus,
+            &.is-focused
+              &::after
+                border-color: transparent transparent $color-invert $color-invert !important
         &[disabled],
         fieldset[disabled] &
           background-color: transparent


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **bugfix** of #2957.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution
I added the case when the button is disabled, outlined, loading when it is focus/hover.

<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

### Tradeoffs
Normally you can't focus a button when it is disabled, but when you change the state to disabled the focus stay. Firefox and Chrome have this comportment.
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->

### Testing Done
Test on my own application. 

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

### Changelog updated?

No.

<!-- Thanks! -->
