### PR TITLE
Fixes #2367 add optional ability to push down footer for short content

### DIFF
--- a/sass/layout/footer.sass
+++ b/sass/layout/footer.sass
@@ -7,3 +7,11 @@ $footer-padding: 3rem 1.5rem 6rem !default
   padding: $footer-padding
   @if $footer-color
     color: $footer-color
+
+.has-pushed-down-footer-child
+  height: 100vh
+  display: flex
+  flex-direction: column
+
+.has-pushed-down-footer-child>section:nth-last-child(2)
+  flex-grow: 1


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **improvement**.
Having the ability to push down the footer for short content pages has been requested by many. This pull request is referencing issue #2367.

### Proposed solution

The solution adds an optional class for footer-parents to push the footer down by growing the second-last section to fill the remaining space.

Without this improvement:
![grafik](https://user-images.githubusercontent.com/53540163/84566182-87d3c800-ad6f-11ea-81cd-adc396723212.png)

With this improvement:
![grafik](https://user-images.githubusercontent.com/53540163/84566185-9326f380-ad6f-11ea-9661-92cc2593bb4b.png)

<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

### Tradeoffs

As this is optional, there are no drawbacks by simply not using this class. The drawback _when_ using the class, is that at the moment only sections are working as the element to be growed. 

### Testing Done

None.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->
I tried it in a project and pasted screenshots above - it seems to work though I am not 100% sure it works all the time, maybe there are special cases where this does not work.

### Changelog updated?

No.

<!-- Thanks! -->
