### PR TITLE
Fixes #2926 Added a selector for the light button in a disabled fieldset

### DIFF
--- a/sass/elements/button.sass
+++ b/sass/elements/button.sass
@@ -211,7 +211,8 @@ $button-static-border-color: $border !default
       @if length($pair) >= 4
         $color-light: nth($pair, 3)
         $color-dark: nth($pair, 4)
-        &.is-light
+        &.is-light,
+        fieldset[disabled] &.is-light
           background-color: $color-light
           color: $color-dark
           &:hover,


### PR DESCRIPTION

This is a **bugfix**.

### Proposed solution

This PR adds a selector to apply the same style when a light button is disabled and when a light button is in a disabled fieldset


