### PR TITLE
Fixes #2387

### DIFF
--- a/sass/components/modal.sass
+++ b/sass/components/modal.sass
@@ -47,7 +47,7 @@ $modal-card-body-padding: 20px !default
 
 .modal-content,
 .modal-card
-  margin: 0 $modal-content-margin-mobile
+  padding: 0 $modal-content-margin-mobile
   max-height: calc(100vh - #{$modal-content-spacing-mobile})
   overflow: auto
   position: relative


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **bugfix**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution

Fixes horizontal margins for `modal-card` and `modal-content` in mobile version.

### Tradeoffs

None.

### Testing Done

I have tested it for `modal-card` and `model-content` in 320x568 (iPhone 5/SE).

### Changelog updated?

No.

<!-- Thanks! -->
