### PR TITLE
Apply the same style as icons in a button for icons directly adjacent…

### DIFF
--- a/sass/elements/button.sass
+++ b/sass/elements/button.sass
@@ -79,6 +79,9 @@ $button-static-border-color: $border !default
     &:first-child:last-child
       margin-left: calc(#{-1 / 2 * $button-padding-horizontal} - #{$button-border-width})
       margin-right: calc(#{-1 / 2 * $button-padding-horizontal} - #{$button-border-width})
+  + .icon
+    margin-left: calc(#{-1 / 2 * $button-padding-horizontal} - #{$button-border-width})
+    margin-right: calc(#{-1 / 2 * $button-padding-horizontal} - #{$button-border-width})
   // States
   &:hover,
   &.is-hovered


### PR DESCRIPTION
… to an input

<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **bugfix** about https://github.com/jgthms/bulma/issues/2407.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution

I would suggest to apply the same margin-left and margin-right style as the icons in the buttons for the icons directly next to an input with the ".button" class

Before : 

<img width="230" alt="Capture d’écran 2020-06-26 à 14 26 44" src="https://user-images.githubusercontent.com/66947157/85856919-22dd9080-b7b9-11ea-81d1-6590f88c10a1.png">

After :

<img width="223" alt="Capture d’écran 2020-06-26 à 14 26 55" src="https://user-images.githubusercontent.com/66947157/85856931-296c0800-b7b9-11ea-8063-bf497f68349a.png">


### Tradeoffs

<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->

### Testing Done

None.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

### Changelog updated?

No.

<!-- Thanks! -->
