### PR TITLE
Enable using em/rem units for breakpoints (in addition to px)

### DIFF
--- a/sass/utilities/mixins.sass
+++ b/sass/utilities/mixins.sass
@@ -75,11 +75,11 @@
     @content
 
 =until($device)
-  @media screen and (max-width: $device - 1px)
+  @media screen and (max-width: calculateMqMaxWidth($device))
     @content
 
 =mobile
-  @media screen and (max-width: $tablet - 1px)
+  @media screen and (max-width: calculateMqMaxWidth($tablet))
     @content
 
 =tablet
@@ -87,11 +87,11 @@
     @content
 
 =tablet-only
-  @media screen and (min-width: $tablet) and (max-width: $desktop - 1px)
+  @media screen and (min-width: $tablet) and (max-width: calculateMqMaxWidth($desktop))
     @content
 
 =touch
-  @media screen and (max-width: $desktop - 1px)
+  @media screen and (max-width: calculateMqMaxWidth($desktop))
     @content
 
 =desktop
@@ -100,12 +100,12 @@
 
 =desktop-only
   @if $widescreen-enabled
-    @media screen and (min-width: $desktop) and (max-width: $widescreen - 1px)
+    @media screen and (min-width: $desktop) and (max-width: calculateMqMaxWidth($widescreen))
       @content
 
 =until-widescreen
   @if $widescreen-enabled
-    @media screen and (max-width: $widescreen - 1px)
+    @media screen and (max-width: calculateMqMaxWidth($widescreen))
       @content
 
 =widescreen
@@ -115,12 +115,12 @@
 
 =widescreen-only
   @if $widescreen-enabled and $fullhd-enabled
-    @media screen and (min-width: $widescreen) and (max-width: $fullhd - 1px)
+    @media screen and (min-width: $widescreen) and (max-width: calculateMqMaxWidth($fullhd))
       @content
 
 =until-fullhd
   @if $fullhd-enabled
-    @media screen and (max-width: $fullhd - 1px)
+    @media screen and (max-width: calculateMqMaxWidth($fullhd))
       @content
 
 =fullhd
@@ -283,3 +283,13 @@
 
 %overlay
   +overlay
+  
+@function calculateMqMaxWidth($width) 
+  @if unit($width) == px 
+    @return $width - 1px 
+  @else if unit($width) == em 
+    @return $width - 0.01em 
+  @else if unit($width) == rem 
+    @return $width - 0.01rem 
+  @else 
+    @warn "Cannot recognize unit of media query width '#{$width}'"

--- a/sass/utilities/mixins.sass
+++ b/sass/utilities/mixins.sass
@@ -292,4 +292,4 @@
   @else if unit($width) == rem 
     @return $width - 0.01rem 
   @else 
-    @warn "Cannot recognize unit of media query width '#{$width}'"
+    @error "Unit of breakpoint value '#{$width}' must be px, em or rem."


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **improvement**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->
Currently the only thing preventing usage of em/rem values for breakpoints is the hardcoded calculation of `max-width` neccessary to create the range.

### Proposed solution

<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->
This PR replaces the `$breakpoint - 1px` calculation when defining media query ranges with a function that adapts to the breakpoint unit and creates an appropriate "a bit smaller than input" value.

### Tradeoffs

<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->
- Breakpoint mixins slightly less readable
- Possible naming conflict with a function named `calculateMqMaxWidth`. The function could be prefixed with `bulma_` to avoid that.

### Testing Done
- Tested output for breakpoints with pixel- and em-units.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
- I've used this code without problems in several live projects.

### Changelog updated?

No.

<!-- Thanks! -->
