### PR TITLE
Flexbox helpers

### DIFF
--- a/sass/helpers/_all.sass
+++ b/sass/helpers/_all.sass
@@ -1,7 +1,7 @@
 @charset "utf-8"
 
 @import "color.sass"
-@import "flex.sass"
+@import "flexbox.sass"
 @import "float.sass"
 @import "other.sass"
 @import "overflow.sass"

--- a/sass/helpers/_all.sass
+++ b/sass/helpers/_all.sass
@@ -1,6 +1,7 @@
 @charset "utf-8"
 
 @import "color.sass"
+@import "flex.sass"
 @import "float.sass"
 @import "other.sass"
 @import "overflow.sass"

--- a/sass/helpers/flex.sass
+++ b/sass/helpers/flex.sass
@@ -1,0 +1,30 @@
+$flex-directions: row, row-reverse, column, column-reverse
+@each $value in $flex-directions
+    .is-flex-direction-#{$value}
+        flex-direction: $value !important
+
+$justify-content-values: flex-start, flex-end, center, space-between, space-around, space-evenly, start, end, left, right
+@each $value in $justify-content-values
+    .is-justify-content-#{$value}
+        justify-content: $value !important
+
+$align-items-values: stretch, flex-start, flex-end, center, baseline, start, end, self-start, self-end
+@each $value in $align-items-values
+    .is-align-items-#{$value}
+        align-items: $value !important
+
+$align-content-values: flex-start, flex-end, center, space-between, space-around, space-evenly, stretch, start, end, baseline
+@each $value in $align-content-values
+    .is-align-content-#{$value}
+        align-content: $value !important
+
+$align-self-values: auto, flex-start, flex-end, center, baseline, stretch
+@each $value in $align-self-values
+    .is-align-self-#{$value}
+        align-self: $value !important
+
+$flex-operators: grow, shrink
+@each $operator in $flex-operators
+    @for $i from 1 through 5
+        .is-flex-#{$operator}-#{$i}
+            flex-#{$operator}: $i !important

--- a/sass/helpers/flex.sass
+++ b/sass/helpers/flex.sass
@@ -1,5 +1,5 @@
-$flex-directions: row, row-reverse, column, column-reverse
-@each $value in $flex-directions
+$flex-directions-values: row, row-reverse, column, column-reverse
+@each $value in $flex-directions-values
     .is-flex-direction-#{$value}
         flex-direction: $value !important
 
@@ -25,6 +25,6 @@ $align-self-values: auto, flex-start, flex-end, center, baseline, stretch
 
 $flex-operators: grow, shrink
 @each $operator in $flex-operators
-    @for $i from 1 through 5
+    @for $i from 0 through 5
         .is-flex-#{$operator}-#{$i}
             flex-#{$operator}: $i !important

--- a/sass/helpers/flex.sass
+++ b/sass/helpers/flex.sass
@@ -1,26 +1,31 @@
 $flex-directions-values: row, row-reverse, column, column-reverse
 @each $value in $flex-directions-values
-    .is-flex-direction-#{$value}
+    .is-flex-#{$value}
         flex-direction: $value !important
+
+$flex-wrap-values: nowrap, wrap, wrap-reverse
+@each $value in $flex-wrap-values
+    .is-flex-#{$value}
+        flex-wrap: $value !important
 
 $justify-content-values: flex-start, flex-end, center, space-between, space-around, space-evenly, start, end, left, right
 @each $value in $justify-content-values
-    .is-justify-content-#{$value}
+    .is-justify-#{$value}
         justify-content: $value !important
 
 $align-content-values: flex-start, flex-end, center, space-between, space-around, space-evenly, stretch, start, end, baseline
 @each $value in $align-content-values
-    .is-align-content-#{$value}
+    .is-content-#{$value}
         align-content: $value !important
 
 $align-items-values: stretch, flex-start, flex-end, center, baseline, start, end, self-start, self-end
 @each $value in $align-items-values
-    .is-align-items-#{$value}
+    .is-items-#{$value}
         align-items: $value !important
 
 $align-self-values: auto, flex-start, flex-end, center, baseline, stretch
 @each $value in $align-self-values
-    .is-align-self-#{$value}
+    .is-self-#{$value}
         align-self: $value !important
 
 $flex-operators: grow, shrink

--- a/sass/helpers/flex.sass
+++ b/sass/helpers/flex.sass
@@ -8,15 +8,15 @@ $justify-content-values: flex-start, flex-end, center, space-between, space-arou
     .is-justify-content-#{$value}
         justify-content: $value !important
 
-$align-items-values: stretch, flex-start, flex-end, center, baseline, start, end, self-start, self-end
-@each $value in $align-items-values
-    .is-align-items-#{$value}
-        align-items: $value !important
-
 $align-content-values: flex-start, flex-end, center, space-between, space-around, space-evenly, stretch, start, end, baseline
 @each $value in $align-content-values
     .is-align-content-#{$value}
         align-content: $value !important
+
+$align-items-values: stretch, flex-start, flex-end, center, baseline, start, end, self-start, self-end
+@each $value in $align-items-values
+    .is-align-items-#{$value}
+        align-items: $value !important
 
 $align-self-values: auto, flex-start, flex-end, center, baseline, stretch
 @each $value in $align-self-values

--- a/sass/helpers/flexbox.sass
+++ b/sass/helpers/flexbox.sass
@@ -1,31 +1,31 @@
 $flex-directions-values: row, row-reverse, column, column-reverse
 @each $value in $flex-directions-values
-    .is-flex-#{$value}
+    .is-flex-direction-#{$value}
         flex-direction: $value !important
 
 $flex-wrap-values: nowrap, wrap, wrap-reverse
 @each $value in $flex-wrap-values
-    .is-flex-#{$value}
+    .is-flex-wrap-#{$value}
         flex-wrap: $value !important
 
 $justify-content-values: flex-start, flex-end, center, space-between, space-around, space-evenly, start, end, left, right
 @each $value in $justify-content-values
-    .is-justify-#{$value}
+    .is-justify-content-#{$value}
         justify-content: $value !important
 
 $align-content-values: flex-start, flex-end, center, space-between, space-around, space-evenly, stretch, start, end, baseline
 @each $value in $align-content-values
-    .is-content-#{$value}
+    .is-align-content-#{$value}
         align-content: $value !important
 
 $align-items-values: stretch, flex-start, flex-end, center, baseline, start, end, self-start, self-end
 @each $value in $align-items-values
-    .is-items-#{$value}
+    .is-align-items-#{$value}
         align-items: $value !important
 
 $align-self-values: auto, flex-start, flex-end, center, baseline, stretch
 @each $value in $align-self-values
-    .is-self-#{$value}
+    .is-align-self-#{$value}
         align-self: $value !important
 
 $flex-operators: grow, shrink


### PR DESCRIPTION
<!-- Choose one of the following: -->
This is a **new feature**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->
When using Bulma I often use `is-flex` but the modifiers you'll want to use are missing such as `justify-content: space-between`. I found a couple of issues/PRs such as the most recent #3008 which suggest adding flexbox helpers. 

### Proposed solution

I've added most flexbox options such as `is-justify-content-space-between`. Perhaps naming can be improved as some are quite long (the suggested `is-justified-space-between` or `{has-,is-}justify-between` are probably be better), and perhaps some hardly used values can be removed.

So it's not done yet, but wanted to get some feedback early on.

### Tradeoffs

<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->

### Testing Done

None.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

### Changelog updated?

No.

<!-- Thanks! -->
