### PR TITLE
make the default text color of code listings more accessible

### DIFF
--- a/sass/utilities/derived-variables.scss
+++ b/sass/utilities/derived-variables.scss
@@ -62,7 +62,7 @@ $text-strong: $grey-darker !default;
 
 // Code colors
 
-$code           : $red !default;
+$code           : darken($red, 15%) !default;
 $code-background: $background !default;
 
 $pre            : $text !default;


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **bugfix** supporting #53.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution

The original red code text on grey background doesn't pass the https://webaim.org/resources/contrastchecker/ on background #F5F5F5
This change fixes this by changing text color #f14668 to #da1039

### Tradeoffs

None

### Testing Done

NPM Build. Screenshot constract checker below:

Before: https://webaim.org/resources/contrastchecker/?fcolor=F14668&bcolor=F5F5F5

![image](https://user-images.githubusercontent.com/3957921/88458554-31d66200-ce8f-11ea-9c31-9106c3bc40a8.png)

After: https://webaim.org/resources/contrastchecker/?fcolor=DA1039&bcolor=F5F5F5

![image](https://user-images.githubusercontent.com/3957921/88458572-46b2f580-ce8f-11ea-856a-ef8efc32ae4a.png)


### Changelog updated?

No. 

Suggested text: "Darken text color of code element to pass AA accessibility" 
