### PR TITLE
Add phone breakpoint

### DIFF
--- a/docs/_data/breakpoints.json
+++ b/docs/_data/breakpoints.json
@@ -1,8 +1,14 @@
 {
+  "phone": {
+    "id": "phone",
+    "name": "Phone",
+    "from": 0,
+    "to": 480
+  },
   "mobile": {
     "id": "mobile",
     "name": "Mobile",
-    "from": 0,
+    "from": 481,
     "to": 768
   },
   "tablet": {

--- a/docs/_data/variables/utilities/initial-variables.json
+++ b/docs/_data/variables/utilities/initial-variables.json
@@ -185,6 +185,11 @@
       "value": "32px",
       "type": "size"
     },
+    "$mobile": {
+      "name": "$mobile",
+      "value": "481px",
+      "type": "size"
+    },
     "$tablet": {
       "name": "$tablet",
       "value": "769px",
@@ -289,6 +294,7 @@
     "$weight-bold",
     "$block-spacing",
     "$gap",
+    "$mobile",
     "$tablet",
     "$desktop",
     "$widescreen",

--- a/docs/documentation/columns/gap.html
+++ b/docs/documentation/columns/gap.html
@@ -85,7 +85,7 @@ breadcrumb:
 {% endcapture %}
 
 {% capture columns_variable_responsive_gaps %}
-<div class="columns is-variable is-1-mobile is-0-tablet is-3-desktop is-8-widescreen is-2-fullhd">
+<div class="columns is-variable is-4-phone is-1-mobile is-0-tablet is-3-desktop is-8-widescreen is-2-fullhd">
   <div class="column">
     Column
   </div>
@@ -246,14 +246,14 @@ breadcrumb:
   </p>
 </div>
 
-For example, here's how it looks with the following modifiers: <code>is-variable is-2-mobile is-0-tablet is-3-desktop is-8-widescreen is-1-fullhd</code>
+For example, here's how it looks with the following modifiers: <code>is-variable is-4-phone is-2-mobile is-0-tablet is-3-desktop is-8-widescreen is-1-fullhd</code>
 
 <div class="highlight-full">
   {% highlight html %}{{ columns_variable_responsive_gaps }}{% endhighlight %}
 </div>
 
 
-<div class="columns is-variable is-1-mobile is-0-tablet is-3-desktop is-8-widescreen is-2-fullhd">
+<div class="columns is-variable is-4-phone is-1-mobile is-0-tablet is-3-desktop is-8-widescreen is-2-fullhd">
   <div class="column">
     <p class="bd-notification is-primary">Column</p>
   </div>

--- a/docs/documentation/columns/responsiveness.html
+++ b/docs/documentation/columns/responsiveness.html
@@ -30,7 +30,8 @@ breadcrumb:
 
 {% capture columns_multiple_breakpoints %}
 <div class="columns is-mobile">
-  <div class="column is-three-quarters-mobile is-two-thirds-tablet is-half-desktop is-one-third-widescreen is-one-quarter-fullhd">
+  <div class="column is-four-fifths-phone is-three-quarters-mobile is-two-thirds-tablet is-half-desktop is-one-third-widescreen is-one-quarter-fullhd">
+    <code>is-four-fifths-phone</code><br>
     <code>is-three-quarters-mobile</code><br>
     <code>is-two-thirds-tablet</code><br>
     <code>is-half-desktop</code><br>
@@ -106,12 +107,13 @@ breadcrumb:
 {% include elements/anchor.html name="Different column sizes per breakpoint" %}
 
 <div class="content">
-  <p>You can define a <strong>column size</strong> for <em>each</em> viewport size: mobile, tablet, and desktop.</p>
+  <p>You can define a <strong>column size</strong> for <em>each</em> viewport size: phone, mobile, tablet, desktop, widescreen and fullhd.</p>
 </div>
 
 <div class="columns is-mobile">
-  <div class="column is-three-quarters-mobile is-two-thirds-tablet is-half-desktop is-one-third-widescreen is-one-quarter-fullhd">
+  <div class="column is-four-fifths-phone is-three-quarters-mobile is-two-thirds-tablet is-half-desktop is-one-third-widescreen is-one-quarter-fullhd">
     <p class="bd-notification is-primary">
+      <code>is-four-fifths-phone</code><br>
       <code>is-three-quarters-mobile</code><br>
       <code>is-two-thirds-tablet</code><br>
       <code>is-half-desktop</code><br>

--- a/docs/documentation/customize/concepts.html
+++ b/docs/documentation/customize/concepts.html
@@ -14,7 +14,7 @@ breadcrumb:
 
 <div class="content">
   <p>
-    Bulma is highly customizable thanks to <strong>419 Sass variables</strong> living across <strong>28 files</strong>.
+    Bulma is highly customizable thanks to <strong>420 Sass variables</strong> living across <strong>28 files</strong>.
   </p>
 
   <p>

--- a/docs/documentation/customize/variables.html
+++ b/docs/documentation/customize/variables.html
@@ -77,7 +77,7 @@ breadcrumb:
     <tbody>
     {% for variable_name in initial_variables.list %}
       {% assign variable = initial_vars[variable_name] %}
-      {% include elements/variable-row.html variable=variable hide_computed =true%}
+      {% include elements/variable-row.html variable = variable hide_computed = true %}
     {% endfor %}
     <tbody>
   </table>

--- a/docs/documentation/helpers/typography-helpers.html
+++ b/docs/documentation/helpers/typography-helpers.html
@@ -100,7 +100,17 @@ breadcrumb:
     {{ thead }}
     <tbody>
       <tr>
+        <td class="is-narrow"><code>is-size-1-phone</code></td>
+        {{ size1 }}
+        {{ unchanged }}
+        {{ unchanged }}
+        {{ unchanged }}
+        {{ unchanged }}
+        {{ unchanged }}
+      </tr>
+      <tr>
         <td class="is-narrow"><code>is-size-1-mobile</code></td>
+        {{ unchanged }}
         {{ size1 }}
         {{ unchanged }}
         {{ unchanged }}
@@ -111,12 +121,14 @@ breadcrumb:
         <td class="is-narrow"><code>is-size-1-touch</code></td>
         {{ size1 }}
         {{ size1 }}
+        {{ size1 }}
         {{ unchanged }}
         {{ unchanged }}
         {{ unchanged }}
       </tr>
       <tr>
         <td class="is-narrow"><code>is-size-1-tablet</code></td>
+        {{ unchanged }}
         {{ unchanged }}
         {{ size1 }}
         {{ size1 }}
@@ -125,6 +137,7 @@ breadcrumb:
       </tr>
       <tr>
         <td class="is-narrow"><code>is-size-1-desktop</code></td>
+        {{ unchanged }}
         {{ unchanged }}
         {{ unchanged }}
         {{ size1 }}
@@ -136,11 +149,13 @@ breadcrumb:
         {{ unchanged }}
         {{ unchanged }}
         {{ unchanged }}
+        {{ unchanged }}
         {{ size1 }}
         {{ size1 }}
       </tr>
       <tr>
         <td class="is-narrow"><code>is-size-1-fullhd</code></td>
+        {{ unchanged }}
         {{ unchanged }}
         {{ unchanged }}
         {{ unchanged }}
@@ -213,7 +228,26 @@ breadcrumb:
     {{ thead }}
     <tbody>
       <tr>
+        <td class="is-narrow"><code>has-text-left-phone</code></td>
+        {{ left }}
+        {{ unchanged }}
+        {{ unchanged }}
+        {{ unchanged }}
+        {{ unchanged }}
+        {{ unchanged }}
+      </tr>
+      <tr>
+        <td class="is-narrow"><code>has-text-left-mobile-only</code></td>
+        {{ unchanged }}
+        {{ left }}
+        {{ unchanged }}
+        {{ unchanged }}
+        {{ unchanged }}
+        {{ unchanged }}
+      </tr>
+      <tr>
         <td class="is-narrow"><code>has-text-left-mobile</code></td>
+        {{ left }}
         {{ left }}
         {{ unchanged }}
         {{ unchanged }}
@@ -224,12 +258,14 @@ breadcrumb:
         <td class="is-narrow"><code>has-text-left-touch</code></td>
         {{ left }}
         {{ left }}
+        {{ left }}
         {{ unchanged }}
         {{ unchanged }}
         {{ unchanged }}
       </tr>
       <tr>
         <td class="is-narrow"><code>has-text-left-tablet-only</code></td>
+        {{ unchanged }}
         {{ unchanged }}
         {{ left }}
         {{ unchanged }}
@@ -238,6 +274,7 @@ breadcrumb:
       </tr>
       <tr>
         <td class="is-narrow"><code>has-text-left-tablet</code></td>
+        {{ unchanged }}
         {{ unchanged }}
         {{ left }}
         {{ left }}
@@ -248,12 +285,14 @@ breadcrumb:
         <td class="is-narrow"><code>has-text-left-desktop-only</code></td>
         {{ unchanged }}
         {{ unchanged }}
+        {{ unchanged }}
         {{ left }}
         {{ unchanged }}
         {{ unchanged }}
       </tr>
       <tr>
         <td class="is-narrow"><code>has-text-left-desktop</code></td>
+        {{ unchanged }}
         {{ unchanged }}
         {{ unchanged }}
         {{ left }}
@@ -265,6 +304,7 @@ breadcrumb:
         {{ unchanged }}
         {{ unchanged }}
         {{ unchanged }}
+        {{ unchanged }}
         {{ left }}
         {{ unchanged }}
       </tr>
@@ -273,11 +313,13 @@ breadcrumb:
         {{ unchanged }}
         {{ unchanged }}
         {{ unchanged }}
+        {{ unchanged }}
         {{ left }}
         {{ left }}
       </tr>
       <tr>
         <td class="is-narrow"><code>has-text-left-fullhd</code></td>
+        {{ unchanged }}
         {{ unchanged }}
         {{ unchanged }}
         {{ unchanged }}

--- a/docs/documentation/helpers/visibility-helpers.html
+++ b/docs/documentation/helpers/visibility-helpers.html
@@ -20,7 +20,7 @@ breadcrumb:
       {% assign breakpoint = breakpoint_hash[1] %}
       <th>
         {{ breakpoint.name }}<br>
-        {% if breakpoint.id == 'mobile' %}
+        {% if breakpoint.id == 'phone' %}
           Up to <code>{{ breakpoint.to }}px</code>
         {% elsif breakpoint.id == 'fullhd' %}
           <code>{{ breakpoint.from }}px</code> and above
@@ -79,8 +79,20 @@ breadcrumb:
     <tbody>
       <tr>
         <td class="is-narrow">
-          <code>is-flex-mobile</code>
+          <code>is-flex-phone</code>
         </td>
+        {{ flex }}
+        {{ unchanged }}
+        {{ unchanged }}
+        {{ unchanged }}
+        {{ unchanged }}
+        {{ unchanged }}
+      </tr>
+      <tr>
+        <td class="is-narrow">
+          <code>is-flex-mobile-only</code>
+        </td>
+        {{ unchanged }}
         {{ flex }}
         {{ unchanged }}
         {{ unchanged }}
@@ -91,6 +103,7 @@ breadcrumb:
         <td class="is-narrow">
           <code>is-flex-tablet-only</code>
         </td>
+        {{ unchanged }}
         {{ unchanged }}
         {{ flex }}
         {{ unchanged }}
@@ -103,6 +116,7 @@ breadcrumb:
         </td>
         {{ unchanged }}
         {{ unchanged }}
+        {{ unchanged }}
         {{ flex }}
         {{ unchanged }}
         {{ unchanged }}
@@ -111,6 +125,7 @@ breadcrumb:
         <td class="is-narrow">
           <code>is-flex-widescreen-only</code>
         </td>
+        {{ unchanged }}
         {{ unchanged }}
         {{ unchanged }}
         {{ unchanged }}
@@ -128,6 +143,7 @@ breadcrumb:
         </td>
         {{ flex }}
         {{ flex }}
+        {{ flex }}
         {{ unchanged }}
         {{ unchanged }}
         {{ unchanged }}
@@ -136,6 +152,7 @@ breadcrumb:
         <td class="is-narrow">
           <code>is-flex-tablet</code>
         </td>
+        {{ unchanged }}
         {{ unchanged }}
         {{ flex }}
         {{ flex }}
@@ -146,6 +163,7 @@ breadcrumb:
         <td class="is-narrow">
           <code>is-flex-desktop</code>
         </td>
+        {{ unchanged }}
         {{ unchanged }}
         {{ unchanged }}
         {{ flex }}
@@ -159,6 +177,7 @@ breadcrumb:
         {{ unchanged }}
         {{ unchanged }}
         {{ unchanged }}
+        {{ unchanged }}
         {{ flex }}
         {{ flex }}
       </tr>
@@ -166,6 +185,7 @@ breadcrumb:
         <td class="is-narrow">
           <code>is-flex-fullhd</code>
         </td>
+        {{ unchanged }}
         {{ unchanged }}
         {{ unchanged }}
         {{ unchanged }}
@@ -190,8 +210,20 @@ breadcrumb:
     <tbody>
       <tr>
         <td class="is-narrow">
-          <code>is-hidden-mobile</code>
+          <code>is-hidden-phone</code>
         </td>
+        {{ hidden }}
+        {{ visible }}
+        {{ visible }}
+        {{ visible }}
+        {{ visible }}
+        {{ visible }}
+      </tr>
+      <tr>
+        <td class="is-narrow">
+          <code>is-hidden-mobile-only</code>
+        </td>
+        {{ visible }}
         {{ hidden }}
         {{ visible }}
         {{ visible }}
@@ -203,6 +235,7 @@ breadcrumb:
           <code>is-hidden-tablet-only</code>
         </td>
         {{ visible }}
+        {{ visible }}
         {{ hidden }}
         {{ visible }}
         {{ visible }}
@@ -212,6 +245,7 @@ breadcrumb:
         <td class="is-narrow">
           <code>is-hidden-desktop-only</code>
         </td>
+        {{ visible }}
         {{ visible }}
         {{ visible }}
         {{ hidden }}
@@ -225,6 +259,7 @@ breadcrumb:
         {{ visible }}
         {{ visible }}
         {{ visible }}
+        {{ visible }}
         {{ hidden }}
         {{ visible }}
       </tr>
@@ -235,8 +270,20 @@ breadcrumb:
       </tr>
       <tr>
         <td class="is-narrow">
+          <code>is-hidden-mobile</code>
+        </td>
+        {{ hidden }}
+        {{ hidden }}
+        {{ visible }}
+        {{ visible }}
+        {{ visible }}
+        {{ visible }}
+      </tr>
+      <tr>
+        <td class="is-narrow">
           <code>is-hidden-touch</code>
         </td>
+        {{ hidden }}
         {{ hidden }}
         {{ hidden }}
         {{ visible }}
@@ -248,6 +295,7 @@ breadcrumb:
           <code>is-hidden-tablet</code>
         </td>
         {{ visible }}
+        {{ visible }}
         {{ hidden }}
         {{ hidden }}
         {{ hidden }}
@@ -257,6 +305,7 @@ breadcrumb:
         <td class="is-narrow">
           <code>is-hidden-desktop</code>
         </td>
+        {{ visible }}
         {{ visible }}
         {{ visible }}
         {{ hidden }}
@@ -270,6 +319,7 @@ breadcrumb:
         {{ visible }}
         {{ visible }}
         {{ visible }}
+        {{ visible }}
         {{ hidden }}
         {{ hidden }}
       </tr>
@@ -277,6 +327,7 @@ breadcrumb:
         <td class="is-narrow">
           <code>is-hidden-fullhd</code>
         </td>
+        {{ visible }}
         {{ visible }}
         {{ visible }}
         {{ visible }}

--- a/docs/documentation/overview/responsiveness.html
+++ b/docs/documentation/overview/responsiveness.html
@@ -10,6 +10,7 @@ breadcrumb:
 - overview-responsiveness
 variables_keys:
 - $gap
+- $mobile
 - $tablet
 - $desktop
 - $widescreen
@@ -40,24 +41,24 @@ $fullhd-enabled: false
 
 {% include elements/anchor.html name="Breakpoints" %}
 
-{% assign variables_file_url = "/blob/master/sass/utilities/initial-variables.sass#L56,L64" | prepend: site.data.meta.github %}
-{% assign mixins_file_url = "/blob/master/sass/utilities/mixins.sass#L81,L129" | prepend: site.data.meta.github %}
+{% assign variables_file_url = "/blob/master/sass/utilities/initial-variables.sass#L56,L65" | prepend: site.data.meta.github %}
+{% assign mixins_file_url = "/blob/master/sass/utilities/mixins.sass#L81,L137" | prepend: site.data.meta.github %}
 
 <div class="content">
-  <p>Bulma has <a href="{{ variables_file_url }}" target="_blank">5 breakpoints</a>:</p>
+  <p>Bulma has <a href="{{ variables_file_url }}" target="_blank">6 breakpoints</a>:</p>
   <ul>
     {% for breakpoint_hash in site.data.breakpoints %}
       {% assign breakpoint = breakpoint_hash[1] %}
-      <li><code>{{ breakpoint.id }}</code>: {% if breakpoint.id == 'mobile' %}up to <code>{{ breakpoint.to }}px</code>{% else %}from <code>{{ breakpoint.from }}px</code>{% endif %}</li>
+      <li><code>{{ breakpoint.id }}</code>: {% if breakpoint.id == 'phone' %}up to <code>{{ breakpoint.to }}px</code>{% else %}from <code>{{ breakpoint.from }}px</code>{% endif %}</li>
     {% endfor %}
   </ul>
 
-  <p>Bulma uses <a href="{{ mixins_file_url }}" target="_blank">9 responsive mixins</a>:</p>
+  <p>Bulma uses <a href="{{ mixins_file_url }}" target="_blank">11 responsive mixins</a>:</p>
   <ul>
     {% for breakpoint_hash in site.data.breakpoints %}
       {% assign breakpoint = breakpoint_hash[1] %}
       {% case breakpoint.id %}
-        {% when 'mobile' %}
+        {% when 'phone' %}
           <li>
             <code>={{ breakpoint.id }}</code><br>
             until <code>{{ breakpoint.to }}px</code>
@@ -95,7 +96,7 @@ $fullhd-enabled: false
           {% assign breakpoint = breakpoint_hash[1] %}
           <th style="width: 20%;">
             {{ breakpoint.name }}<br>
-            {% if breakpoint.id == 'mobile' %}
+            {% if breakpoint.id == 'phone' %}
               Up to <code>{{ breakpoint.to }}px</code>
             {% elsif breakpoint.id == 'fullhd' %}
               <code>{{ breakpoint.from }}px</code> and above
@@ -109,6 +110,14 @@ $fullhd-enabled: false
     <tbody>
       <tr>
         <td>
+          <p class="notification is-success">phone</p>
+        </td>
+        <td colspan="5">
+          <p class="notification">-</p>
+        </td>
+      </tr>
+      <tr>
+        <td colspan="2">
           <p class="notification is-success">mobile</p>
         </td>
         <td colspan="4">
@@ -116,7 +125,7 @@ $fullhd-enabled: false
         </td>
       </tr>
       <tr>
-        <td>
+        <td colspan="2">
           <p class="notification">-</p>
         </td>
         <td colspan="4">
@@ -124,7 +133,7 @@ $fullhd-enabled: false
         </td>
       </tr>
       <tr>
-        <td colspan="2">
+        <td colspan="3">
           <p class="notification">-</p>
         </td>
         <td colspan="3">
@@ -132,7 +141,7 @@ $fullhd-enabled: false
         </td>
       </tr>
       <tr>
-        <td colspan="3">
+        <td colspan="4">
           <p class="notification">-</p>
         </td>
         <td colspan="2">
@@ -140,7 +149,7 @@ $fullhd-enabled: false
         </td>
       </tr>
       <tr>
-        <td colspan="4">
+        <td colspan="5">
           <p class="notification">-</p>
         </td>
         <td>
@@ -152,6 +161,17 @@ $fullhd-enabled: false
           <p class="notification">-</p>
         </td>
         <td>
+          <p class="notification is-success">mobile-only</p>
+        </td>
+        <td colspan="4">
+          <p class="notification">-</p>
+        </td>
+      </tr>
+      <tr>
+        <td colspan="2">
+          <p class="notification">-</p>
+        </td>
+        <td>
           <p class="notification is-success">tablet-only</p>
         </td>
         <td colspan="3">
@@ -159,7 +179,7 @@ $fullhd-enabled: false
         </td>
       </tr>
       <tr>
-        <td colspan="2">
+        <td colspan="3">
           <p class="notification">-</p>
         </td>
         <td>
@@ -170,7 +190,7 @@ $fullhd-enabled: false
         </td>
       </tr>
       <tr>
-        <td colspan="3">
+        <td colspan="4">
           <p class="notification">-</p>
         </td>
         <td>
@@ -181,7 +201,7 @@ $fullhd-enabled: false
         </td>
       </tr>
       <tr>
-        <td colspan="2">
+        <td colspan="3">
           <p class="notification is-success">touch</p>
         </td>
         <td colspan="3">
@@ -189,7 +209,7 @@ $fullhd-enabled: false
         </td>
       </tr>
       <tr>
-        <td colspan="3">
+        <td colspan="4">
           <p class="notification is-success">until-widescreen</p>
         </td>
         <td colspan="2">
@@ -197,7 +217,7 @@ $fullhd-enabled: false
         </td>
       </tr>
       <tr>
-        <td colspan="4">
+        <td colspan="5">
           <p class="notification is-success">until-fullhd</p>
         </td>
         <td colspan="1">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bulma",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/sass/grid/columns.sass
+++ b/sass/grid/columns.sass
@@ -6,6 +6,65 @@ $column-gap: 0.75rem !default
   flex-grow: 1
   flex-shrink: 1
   padding: $column-gap
+
+  .columns.is-phone > &.is-narrow
+    flex: none
+  .columns.is-phone > &.is-full
+    flex: none
+    width: 100%
+  .columns.is-phone > &.is-three-quarters
+    flex: none
+    width: 75%
+  .columns.is-phone > &.is-two-thirds
+    flex: none
+    width: 66.6666%
+  .columns.is-phone > &.is-half
+    flex: none
+    width: 50%
+  .columns.is-phone > &.is-one-third
+    flex: none
+    width: 33.3333%
+  .columns.is-phone > &.is-one-quarter
+    flex: none
+    width: 25%
+  .columns.is-phone > &.is-one-fifth
+    flex: none
+    width: 20%
+  .columns.is-phone > &.is-two-fifths
+    flex: none
+    width: 40%
+  .columns.is-phone > &.is-three-fifths
+    flex: none
+    width: 60%
+  .columns.is-phone > &.is-four-fifths
+    flex: none
+    width: 80%
+  .columns.is-phone > &.is-offset-three-quarters
+    margin-left: 75%
+  .columns.is-phone > &.is-offset-two-thirds
+    margin-left: 66.6666%
+  .columns.is-phone > &.is-offset-half
+    margin-left: 50%
+  .columns.is-phone > &.is-offset-one-third
+    margin-left: 33.3333%
+  .columns.is-phone > &.is-offset-one-quarter
+    margin-left: 25%
+  .columns.is-phone > &.is-offset-one-fifth
+    margin-left: 20%
+  .columns.is-phone > &.is-offset-two-fifths
+    margin-left: 40%
+  .columns.is-phone > &.is-offset-three-fifths
+    margin-left: 60%
+  .columns.is-phone > &.is-offset-four-fifths
+    margin-left: 80%
+
+  @for $i from 0 through 12
+    .columns.is-phone > &.is-#{$i}
+      flex: none
+      width: percentage($i / 12)
+    .columns.is-phone > &.is-offset-#{$i}
+      margin-left: percentage($i / 12)
+
   .columns.is-mobile > &.is-narrow
     flex: none
   .columns.is-mobile > &.is-full
@@ -56,12 +115,72 @@ $column-gap: 0.75rem !default
     margin-left: 60%
   .columns.is-mobile > &.is-offset-four-fifths
     margin-left: 80%
+
   @for $i from 0 through 12
     .columns.is-mobile > &.is-#{$i}
       flex: none
       width: percentage($i / 12)
     .columns.is-mobile > &.is-offset-#{$i}
       margin-left: percentage($i / 12)
+
+  +phone
+    &.is-narrow-phone
+      flex: none
+    &.is-full-phone
+      flex: none
+      width: 100%
+    &.is-three-quarters-phone
+      flex: none
+      width: 75%
+    &.is-two-thirds-phone
+      flex: none
+      width: 66.6666%
+    &.is-half-phone
+      flex: none
+      width: 50%
+    &.is-one-third-phone
+      flex: none
+      width: 33.3333%
+    &.is-one-quarter-phone
+      flex: none
+      width: 25%
+    &.is-one-fifth-phone
+      flex: none
+      width: 20%
+    &.is-two-fifths-phone
+      flex: none
+      width: 40%
+    &.is-three-fifths-phone
+      flex: none
+      width: 60%
+    &.is-four-fifths-phone
+      flex: none
+      width: 80%
+    &.is-offset-three-quarters-phone
+      margin-left: 75%
+    &.is-offset-two-thirds-phone
+      margin-left: 66.6666%
+    &.is-offset-half-phone
+      margin-left: 50%
+    &.is-offset-one-third-phone
+      margin-left: 33.3333%
+    &.is-offset-one-quarter-phone
+      margin-left: 25%
+    &.is-offset-one-fifth-phone
+      margin-left: 20%
+    &.is-offset-two-fifths-phone
+      margin-left: 40%
+    &.is-offset-three-fifths-phone
+      margin-left: 60%
+    &.is-offset-four-fifths-phone
+      margin-left: 80%
+    @for $i from 0 through 12
+      &.is-#{$i}-phone
+        flex: none
+        width: percentage($i / 12)
+      &.is-offset-#{$i}-phone
+        margin-left: percentage($i / 12)
+
   +mobile
     &.is-narrow-mobile
       flex: none
@@ -119,6 +238,7 @@ $column-gap: 0.75rem !default
         width: percentage($i / 12)
       &.is-offset-#{$i}-mobile
         margin-left: percentage($i / 12)
+
   +tablet
     &.is-narrow,
     &.is-narrow-tablet
@@ -198,6 +318,7 @@ $column-gap: 0.75rem !default
       &.is-offset-#{$i},
       &.is-offset-#{$i}-tablet
         margin-left: percentage($i / 12)
+
   +touch
     &.is-narrow-touch
       flex: none
@@ -255,6 +376,7 @@ $column-gap: 0.75rem !default
         width: percentage($i / 12)
       &.is-offset-#{$i}-touch
         margin-left: percentage($i / 12)
+
   +desktop
     &.is-narrow-desktop
       flex: none
@@ -312,6 +434,7 @@ $column-gap: 0.75rem !default
         width: percentage($i / 12)
       &.is-offset-#{$i}-desktop
         margin-left: percentage($i / 12)
+
   +widescreen
     &.is-narrow-widescreen
       flex: none
@@ -369,6 +492,7 @@ $column-gap: 0.75rem !default
         width: percentage($i / 12)
       &.is-offset-#{$i}-widescreen
         margin-left: percentage($i / 12)
+
   +fullhd
     &.is-narrow-fullhd
       flex: none
@@ -449,6 +573,8 @@ $column-gap: 0.75rem !default
       margin-bottom: 1.5rem
     &:last-child
       margin-bottom: 0
+  &.is-phone
+    display: flex
   &.is-mobile
     display: flex
   &.is-multiline
@@ -475,8 +601,14 @@ $column-gap: 0.75rem !default
     @for $i from 0 through 8
       &.is-#{$i}
         --columnGap: #{$i * 0.25rem}
+      +phone
+        &.is-#{$i}-phone
+          --columnGap: #{$i * 0.25rem}
       +mobile
         &.is-#{$i}-mobile
+          --columnGap: #{$i * 0.25rem}
+      +mobile-only
+        &.is-#{$i}-mobile-only
           --columnGap: #{$i * 0.25rem}
       +tablet
         &.is-#{$i}-tablet

--- a/sass/helpers/typography.sass
+++ b/sass/helpers/typography.sass
@@ -6,6 +6,9 @@
 
 +typography-size()
 
++phone
+  +typography-size('phone')
+
 +mobile
   +typography-size('mobile')
 
@@ -31,8 +34,14 @@ $alignments: ('centered': 'center', 'justified': 'justify', 'left': 'left', 'rig
     text-align: #{$text-align} !important
 
 @each $alignment, $text-align in $alignments
+  +phone
+    .has-text-#{$alignment}-phone
+      text-align: #{$text-align} !important
   +mobile
     .has-text-#{$alignment}-mobile
+      text-align: #{$text-align} !important
+  +mobile-only
+    .has-text-#{$alignment}-mobile-only
       text-align: #{$text-align} !important
   +tablet
     .has-text-#{$alignment}-tablet

--- a/sass/helpers/visibility.sass
+++ b/sass/helpers/visibility.sass
@@ -5,8 +5,14 @@ $displays: 'block' 'flex' 'inline' 'inline-block' 'inline-flex'
 @each $display in $displays
   .is-#{$display}
     display: #{$display} !important
+  +phone
+    .is-#{$display}-phone
+      display: #{$display} !important
   +mobile
     .is-#{$display}-mobile
+      display: #{$display} !important
+  +mobile-only
+    .is-#{$display}-mobile-only
       display: #{$display} !important
   +tablet
     .is-#{$display}-tablet
@@ -46,8 +52,16 @@ $displays: 'block' 'flex' 'inline' 'inline-block' 'inline-flex'
   white-space: nowrap !important
   width: 0.01em !important
 
++phone
+  .is-hidden-phone
+    display: none !important
+
 +mobile
   .is-hidden-mobile
+    display: none !important
+
++mobile-only
+  .is-hidden-mobile-only
     display: none !important
 
 +tablet
@@ -85,8 +99,16 @@ $displays: 'block' 'flex' 'inline' 'inline-block' 'inline-flex'
 .is-invisible
   visibility: hidden !important
 
++phone
+  .is-invisible-phone
+    visibility: hidden !important
+
 +mobile
   .is-invisible-mobile
+    visibility: hidden !important
+
++mobile-only
+  .is-invisible-mobile-only
     visibility: hidden !important
 
 +tablet

--- a/sass/utilities/initial-variables.sass
+++ b/sass/utilities/initial-variables.sass
@@ -52,7 +52,8 @@ $block-spacing: 1.5rem !default
 
 // The container horizontal gap, which acts as the offset for breakpoints
 $gap: 32px !default
-// 960, 1152, and 1344 have been chosen because they are divisible by both 12 and 16
+// 480, 960, 1152, and 1344 have been chosen because they are divisible by both 12 and 16
+$mobile: 481px !default
 $tablet: 769px !default
 // 960px container + 4rem
 $desktop: 960px + (2 * $gap) !default

--- a/sass/utilities/mixins.sass
+++ b/sass/utilities/mixins.sass
@@ -78,8 +78,16 @@
   @media screen and (max-width: $device - 1px)
     @content
 
+=phone
+  @media screen and (max-width: $mobile - 1px)
+    @content
+
 =mobile
   @media screen and (max-width: $tablet - 1px)
+    @content
+
+=mobile-only
+  @media screen and (min-width: $mobile) and (max-width: $tablet - 1px)
     @content
 
 =tablet


### PR DESCRIPTION
This is an improvement in the way that the PR adds another breakpoint called `phone` which reaches from 0 to 480 px and redefines `mobile` to reach from 481 to 768 px. It enables users to differentiate between tablets in portrait mode and phones in portrait mode. Almost every smartphone at the time of the writing has not more than 480 px width in portrait mode.

### Proposed solution

The PR adds a new variable `$mobile` to base all the breakpoint-related rules on it.

### Tradeoffs

I might have missed a logical rule in `sass/grid/columns.sass` lines 576 to 579 to enable `mobile-only` classes. In my own extension of Bulma 0.9.0 I used the following rules:

```sass
.columns
  &.is-phone
    display: flex
  +mobile-only
    &.is-mobile-only
      display: flex
  +phone
    &.is-mobile-only
      display: block
    &.is-phone
      display: flex
```

### Testing Done

None.

### Changelog updated?

No.