### PR TITLE
Update the link for additional Font Awesome sizing

### DIFF
--- a/docs/documentation/elements/icon.html
+++ b/docs/documentation/elements/icon.html
@@ -111,7 +111,7 @@ meta:
 
 <div class="content">
   <p>
-    The Bulma <code>icon</code> container comes in <strong>4 sizes</strong>. It should always be <em>slightly bigger</em> than the icon it contains. For example, Font Awesome 5 icons use a font-size of <code>1em</code> by default (since it inherits the font size), but provides <a href="https://fontawesome.com/how-to-use/svg-with-js#additional-styling" target="_blank">additional sizes</a>.
+    The Bulma <code>icon</code> container comes in <strong>4 sizes</strong>. It should always be <em>slightly bigger</em> than the icon it contains. For example, Font Awesome 5 icons use a font-size of <code>1em</code> by default (since it inherits the font size), but provides <a href="https://fontawesome.com/how-to-use/on-the-web/styling/sizing-icons" target="_blank">additional sizes</a>.
   </p>
 </div>
 


### PR DESCRIPTION
This is a **documentation fix**.

### Proposed solution
The old link for additional Font Awesome sizing was no longer valid and opening the Font Awesome start page.
This update points to the new page for sizing icons.

### Tradeoffs
N/A

### Testing Done
Built and ran documentation.

### Changelog updated?
No.