### PR TITLE
refactor: split out responsiveness mixins

### DIFF
--- a/sass/utilities/_all.sass
+++ b/sass/utilities/_all.sass
@@ -6,4 +6,5 @@
 @import "derived-variables.scss"
 @import "animations.sass"
 @import "mixins.sass"
+@import "mixins-responsiveness.sass"
 @import "controls.sass"

--- a/sass/utilities/mixins-responsiveness.sass
+++ b/sass/utilities/mixins-responsiveness.sass
@@ -1,0 +1,61 @@
+// Responsiveness
+
+=from($device)
+  @media screen and (min-width: $device)
+    @content
+
+=until($device)
+  @media screen and (max-width: $device - 1px)
+    @content
+
+=mobile
+  @media screen and (max-width: $tablet - 1px)
+    @content
+
+=tablet
+  @media screen and (min-width: $tablet), print
+    @content
+
+=tablet-only
+  @media screen and (min-width: $tablet) and (max-width: $desktop - 1px)
+    @content
+
+=touch
+  @media screen and (max-width: $desktop - 1px)
+    @content
+
+=desktop
+  @media screen and (min-width: $desktop)
+    @content
+
+=desktop-only
+  @if $widescreen-enabled
+    @media screen and (min-width: $desktop) and (max-width: $widescreen - 1px)
+      @content
+
+=until-widescreen
+  @if $widescreen-enabled
+    @media screen and (max-width: $widescreen - 1px)
+      @content
+
+=widescreen
+  @if $widescreen-enabled
+    @media screen and (min-width: $widescreen)
+      @content
+
+=widescreen-only
+  @if $widescreen-enabled and $fullhd-enabled
+    @media screen and (min-width: $widescreen) and (max-width: $fullhd - 1px)
+      @content
+
+=until-fullhd
+  @if $fullhd-enabled
+    @media screen and (max-width: $fullhd - 1px)
+      @content
+
+=fullhd
+  @if $fullhd-enabled
+    @media screen and (min-width: $fullhd)
+      @content
+
+

--- a/sass/utilities/mixins.sass
+++ b/sass/utilities/mixins.sass
@@ -68,66 +68,6 @@
     &:#{$placeholder}-placeholder
       @content
 
-// Responsiveness
-
-=from($device)
-  @media screen and (min-width: $device)
-    @content
-
-=until($device)
-  @media screen and (max-width: $device - 1px)
-    @content
-
-=mobile
-  @media screen and (max-width: $tablet - 1px)
-    @content
-
-=tablet
-  @media screen and (min-width: $tablet), print
-    @content
-
-=tablet-only
-  @media screen and (min-width: $tablet) and (max-width: $desktop - 1px)
-    @content
-
-=touch
-  @media screen and (max-width: $desktop - 1px)
-    @content
-
-=desktop
-  @media screen and (min-width: $desktop)
-    @content
-
-=desktop-only
-  @if $widescreen-enabled
-    @media screen and (min-width: $desktop) and (max-width: $widescreen - 1px)
-      @content
-
-=until-widescreen
-  @if $widescreen-enabled
-    @media screen and (max-width: $widescreen - 1px)
-      @content
-
-=widescreen
-  @if $widescreen-enabled
-    @media screen and (min-width: $widescreen)
-      @content
-
-=widescreen-only
-  @if $widescreen-enabled and $fullhd-enabled
-    @media screen and (min-width: $widescreen) and (max-width: $fullhd - 1px)
-      @content
-
-=until-fullhd
-  @if $fullhd-enabled
-    @media screen and (max-width: $fullhd - 1px)
-      @content
-
-=fullhd
-  @if $fullhd-enabled
-    @media screen and (min-width: $fullhd)
-      @content
-
 =ltr
   @if not $rtl
     @content


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is an improvement.

<!-- Improvement? Explain how and why. -->
This allow to make the grid be usable as standalone element by just
including

@import "utilities/initial-variables";
@import "utilities/mixins-responsiveness";
@import "grid/columns";

### Tradeoffs

I don't see any since from my point of view the `utilities/_all.sass` would be used anyways for every one who wants to use the whole framework.

### Testing Done

Manually.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->

I imported the relevant files in my sass. The grid system could be generated and used without dragging in more dependencies than necessary. The build worked as well.

### Changelog updated?

No.

<!-- Thanks! -->
