### PR TITLE
Add inset shadows to cards — partially fixes #2423

### DIFF
--- a/sass/components/card.sass
+++ b/sass/components/card.sass
@@ -5,6 +5,7 @@ $card-radius: 0 !default
 $card-shadow-wide: 0 0.5em 1em -0.125em rgba($scheme-invert, 0.1) !default
 $card-shadow-slim: 0 0px 0 1px rgba($scheme-invert, 0.02) !default
 $card-shadow: $card-shadow-wide, $card-shadow-slim !default
+$card-shadow-inset: inset $card-shadow-wide, inset $card-shadow-slim !default
 
 $card-header-background-color: transparent !default
 $card-header-color: $text-strong !default

--- a/sass/components/card.sass
+++ b/sass/components/card.sass
@@ -1,7 +1,10 @@
 $card-color: $text !default
 $card-background-color: $scheme-main !default
-$card-shadow: 0 0.5em 1em -0.125em rgba($scheme-invert, 0.1), 0 0px 0 1px rgba($scheme-invert, 0.02) !default
 $card-radius: 0 !default
+
+$card-shadow-wide: 0 0.5em 1em -0.125em rgba($scheme-invert, 0.1) !default
+$card-shadow-slim: 0 0px 0 1px rgba($scheme-invert, 0.02) !default
+$card-shadow: $card-shadow-wide, $card-shadow-slim !default
 
 $card-header-background-color: transparent !default
 $card-header-color: $text-strong !default

--- a/sass/components/card.sass
+++ b/sass/components/card.sass
@@ -30,6 +30,8 @@ $card-media-margin: $block-spacing !default
   position: relative
   border-radius: $card-radius
   overflow: hidden
+  &.is-inset
+    box-shadow: $card-shadow-inset
 
 .card-header
   background-color: $card-header-background-color


### PR DESCRIPTION
This is a **new feature**.

I wanted to make a card with an inset shadow. To be thematically-consistent, I wanted to use the inverse of Bulma's shadow. However, no such option was available.

### Proposed solution

This PR adds the option to replace a card's default shadow with an inset shadow using the `is-inset` modifier.

I have added the `is-inset` class to cards, which replaces the default shadow with its inverse.

![image](https://user-images.githubusercontent.com/29130152/90246186-ef6bc980-de2b-11ea-995f-905bf8cd1e3a.png)

This addresses but does not fix #2423, which makes a request for inset shadows. This PR adds inset shadows only to cards. It does not add any anywhere else.

### Tradeoffs

* A user may wish to have both a regular shadow and an inset shadow on their card, which this does not allow.
* If a user overrides `$card-shadow`, `$card-shadow-inset` is unaffected. They would need to modify `$card-shadow-wide` and `$card-shadow-slim` instead.
* It is possible to inset the first of the two shadows simply with `box-shadow: inset $card-shadow`. However, this does not inset the second shadow. Although the second shadow appears to be used as simply a border, in which case whether or not it is inset doesn't really matter visually, in my opinion it is better to build for the long term and account for any additional shadows in the future by creating a variable for each of them (for example, Materialize.css uses combinations of shadows).

-----

- [x] Added feature
- [ ] Changelog updated
- [ ] Docs updated