### PR TITLE
Allow each component to have its own colors and default to global ones

### DIFF
--- a/sass/components/navbar.sass
+++ b/sass/components/navbar.sass
@@ -46,6 +46,8 @@ $navbar-bottom-box-shadow-size: 0 -2px 0 0 !default
 
 $navbar-breakpoint: $desktop !default
 
+$navbar-colors: $colors !default
+
 =navbar-fixed
   left: 0
   position: fixed
@@ -57,7 +59,7 @@ $navbar-breakpoint: $desktop !default
   min-height: $navbar-height
   position: relative
   z-index: $navbar-z
-  @each $name, $pair in $colors
+  @each $name, $pair in $navbar-colors
     $color: nth($pair, 1)
     $color-invert: nth($pair, 2)
     &.is-#{$name}

--- a/sass/elements/button.sass
+++ b/sass/elements/button.sass
@@ -33,6 +33,8 @@ $button-static-color: $text-light !default
 $button-static-background-color: $scheme-main-ter !default
 $button-static-border-color: $border !default
 
+$button-colors: $colors !default
+
 // The button sizes use mixins so they can be used at different breakpoints
 =button-small
   border-radius: $radius-small
@@ -115,7 +117,7 @@ $button-static-border-color: $border !default
       background-color: transparent
       border-color: transparent
       box-shadow: none
-  @each $name, $pair in $colors
+  @each $name, $pair in $button-colors
     $color: nth($pair, 1)
     $color-invert: nth($pair, 2)
     &.is-#{$name}

--- a/sass/elements/notification.sass
+++ b/sass/elements/notification.sass
@@ -5,6 +5,8 @@ $notification-padding: 1.25rem 2.5rem 1.25rem 1.5rem !default
 $notification-padding-ltr: 1.25rem 2.5rem 1.25rem 1.5rem !default
 $notification-padding-rtl: 1.25rem 1.5rem 1.25rem 2.5rem !default
 
+$notification-colors: $colors !default
+
 .notification
   @extend %block
   background-color: $notification-background-color
@@ -33,7 +35,7 @@ $notification-padding-rtl: 1.25rem 1.5rem 1.25rem 2.5rem !default
   .content
     color: currentColor
   // Colors
-  @each $name, $pair in $colors
+  @each $name, $pair in $notification-colors
     $color: nth($pair, 1)
     $color-invert: nth($pair, 2)
     &.is-#{$name}

--- a/sass/elements/progress.sass
+++ b/sass/elements/progress.sass
@@ -4,6 +4,8 @@ $progress-border-radius: $radius-rounded !default
 
 $progress-indeterminate-duration: 1.5s !default
 
+$progress-colors: $colors !default
+
 .progress
   @extend %block
   -moz-appearance: none
@@ -25,7 +27,7 @@ $progress-indeterminate-duration: 1.5s !default
     background-color: $progress-value-background-color
     border: none
   // Colors
-  @each $name, $pair in $colors
+  @each $name, $pair in $progress-colors
     $color: nth($pair, 1)
     &.is-#{$name}
       &::-webkit-progress-value

--- a/sass/elements/table.sass
+++ b/sass/elements/table.sass
@@ -23,6 +23,8 @@ $table-row-active-color: $primary-invert !default
 $table-striped-row-even-background-color: $scheme-main-bis !default
 $table-striped-row-even-hover-background-color: $scheme-main-ter !default
 
+$table-colors: $colors !default
+
 .table
   @extend %block
   background-color: $table-background-color
@@ -34,7 +36,7 @@ $table-striped-row-even-hover-background-color: $scheme-main-ter !default
     padding: $table-cell-padding
     vertical-align: top
     // Colors
-    @each $name, $pair in $colors
+    @each $name, $pair in $table-colors
       $color: nth($pair, 1)
       $color-invert: nth($pair, 2)
       &.is-#{$name}

--- a/sass/elements/tag.sass
+++ b/sass/elements/tag.sass
@@ -3,6 +3,8 @@ $tag-color: $text !default
 $tag-radius: $radius !default
 $tag-delete-margin: 1px !default
 
+$tag-colors: $colors !default
+
 .tags
   align-items: center
   display: flex
@@ -71,7 +73,7 @@ $tag-delete-margin: 1px !default
     +ltr-property("margin", 0.25rem, false)
     +ltr-property("margin", -0.375rem)
   // Colors
-  @each $name, $pair in $colors
+  @each $name, $pair in $tag-colors
     $color: nth($pair, 1)
     $color-invert: nth($pair, 2)
     &.is-#{$name}

--- a/sass/form/file.sass
+++ b/sass/form/file.sass
@@ -11,6 +11,8 @@ $file-name-border-style: solid !default
 $file-name-border-width: 1px 1px 1px 0 !default
 $file-name-max-width: 16em !default
 
+$file-colors: $form-colors !default
+
 .file
   @extend %unselectable
   align-items: stretch
@@ -18,7 +20,7 @@ $file-name-max-width: 16em !default
   justify-content: flex-start
   position: relative
   // Colors
-  @each $name, $pair in $colors
+  @each $name, $pair in $file-colors
     $color: nth($pair, 1)
     $color-invert: nth($pair, 2)
     &.is-#{$name}

--- a/sass/form/input-textarea.sass
+++ b/sass/form/input-textarea.sass
@@ -2,6 +2,8 @@ $textarea-padding: $control-padding-horizontal !default
 $textarea-max-height: 40em !default
 $textarea-min-height: 8em !default
 
+$textarea-colors: $form-colors !default
+
 %input-textarea
   @extend %input
   box-shadow: $input-shadow
@@ -10,7 +12,7 @@ $textarea-min-height: 8em !default
   &[readonly]
     box-shadow: none
   // Colors
-  @each $name, $pair in $colors
+  @each $name, $pair in $textarea-colors
     $color: nth($pair, 1)
     &.is-#{$name}
       border-color: $color

--- a/sass/form/select.sass
+++ b/sass/form/select.sass
@@ -1,3 +1,5 @@
+$select-colors: $form-colors !default
+
 .select
   display: inline-block
   max-width: 100%
@@ -39,7 +41,7 @@
     &::after
       border-color: $input-hover-color
   // Colors
-  @each $name, $pair in $colors
+  @each $name, $pair in $select-colors
     $color: nth($pair, 1)
     &.is-#{$name}
       &:not(:hover)::after

--- a/sass/form/shared.sass
+++ b/sass/form/shared.sass
@@ -1,3 +1,5 @@
+$form-colors: $colors !default
+
 $input-color: $text-strong !default
 $input-background-color: $scheme-main !default
 $input-border-color: $border !default

--- a/sass/form/tools.sass
+++ b/sass/form/tools.sass
@@ -3,6 +3,8 @@ $label-weight: $weight-bold !default
 
 $help-size: $size-small !default
 
+$label-colors: $form-colors !default
+
 .label
   color: $label-color
   display: block
@@ -22,7 +24,7 @@ $help-size: $size-small !default
   display: block
   font-size: $help-size
   margin-top: 0.25rem
-  @each $name, $pair in $colors
+  @each $name, $pair in $label-colors
     $color: nth($pair, 1)
     &.is-#{$name}
       color: $color

--- a/sass/layout/hero.sass
+++ b/sass/layout/hero.sass
@@ -3,6 +3,8 @@ $hero-body-padding-small: 1.5rem !default
 $hero-body-padding-medium: 9rem 1.5rem !default
 $hero-body-padding-large: 18rem 1.5rem !default
 
+$hero-colors: $colors !default
+
 // Main container
 .hero
   align-items: stretch
@@ -15,7 +17,7 @@ $hero-body-padding-large: 18rem 1.5rem !default
     ul
       border-bottom: none
   // Colors
-  @each $name, $pair in $colors
+  @each $name, $pair in $hero-colors
     $color: nth($pair, 1)
     $color-invert: nth($pair, 2)
     &.is-#{$name}


### PR DESCRIPTION
This is a **new feature**.

### Proposed solution

Tags and buttons did not have enough contrast for our use case, and we wanted to use a dark grey body text in most situations such as messages, not a darker flavor of the background color. It is simple enough to add intermediate variables as customization points for the colors of each element or component, allowing us to do this. It's not perfect — buttons still make more assumptions about how colors are related than we'd like — but it goes a long way toward making Bulma customizable for our uses.

### Tradeoffs

- It adds more variables
- It's not complete. Buttons in particular have a lot of assumptions about how colors relate for use in various states. They're a complex element!

### Testing Done

- Base build and confirm colors work as they did
- Patched bulma as we use it (via sass include and our own build) and noted that we can customize the colors for each component

### Changelog updated?

No. It's unclear how to do so for unreleased changes, and it appears it's maintained more periodically in practice than with each PR.