### PR TITLE
Add Flex Helpers

### DIFF
--- a/sass/helpers/flex.sass
+++ b/sass/helpers/flex.sass
@@ -1,52 +1,52 @@
 .is-flex {
-  display: flex
+  display: flex !important
 }
 
 .is-flex-row {
-  flex-direction: row
+  flex-direction: row !important
 }
 
 .is-flex-row-revered {
-  flex-direction: row-reverse
+  flex-direction: row-reverse !important
 }
 
 .is-flex-column {
-  flex-direction: column
+  flex-direction: column !important
 }
 
 .is-flex-column-revered {
-  flex-direction: column-reverse
+  flex-direction: column-reverse !important
 }
 
 .is-justified-start {
-  justify-content: flex-start
+  justify-content: flex-start !important
 }
 
 .is-justified-center {
-  justify-content: center
+  justify-content: center !important
 }
 
 .is-justified-end {
-  justify-content: flex-end
+  justify-content: flex-end !important
 }
 
 .is-justified-around {
-  justify-content: space-around
+  justify-content: space-around !important
 }
 
 .is-justified-between {
-  justify-content: space-between
+  justify-content: space-between !important
 }
 
 .is-aligned-start {
-  align-items: flex-start
+  align-items: flex-start !important
 }
 
 .is-aligned-center {
-  align-items: center
+  align-items: center !important
 }
 
 .is-aligned-end {
-  align-items: flex-end
+  align-items: flex-end !important
 }
 

--- a/sass/helpers/flex.sass
+++ b/sass/helpers/flex.sass
@@ -1,0 +1,52 @@
+.is-flex {
+  display: flex
+}
+
+.is-flex-row {
+  flex-direction: row
+}
+
+.is-flex-row-revered {
+  flex-direction: row-reverse
+}
+
+.is-flex-column {
+  flex-direction: column
+}
+
+.is-flex-column-revered {
+  flex-direction: column-reverse
+}
+
+.is-justified-start {
+  justify-content: flex-start
+}
+
+.is-justified-center {
+  justify-content: center
+}
+
+.is-justified-end {
+  justify-content: flex-end
+}
+
+.is-justified-around {
+  justify-content: space-around
+}
+
+.is-justified-between {
+  justify-content: space-between
+}
+
+.is-aligned-start {
+  align-items: flex-start
+}
+
+.is-aligned-center {
+  align-items: center
+}
+
+.is-aligned-end {
+  align-items: flex-end
+}
+


### PR DESCRIPTION
Add flex helpers

This is a **new feature**.

### Proposed solution

Though flex helpers would be a good addition to the helper sass files. I wanted to align right without using float and prefer using flex. Noticed there were no flex helpers so I've added some.

### Tradeoffs

- Adds more classes

### Testing Done

Built and tested locally

### Changelog updated?

No.

p.s. I've not updated the Changelog or docs yet. I wanted to see what people thought of the new helpers first and wasn't sure about version numbers.