### PR TITLE
#3024 - Adds not allowed cursor to missing inputs

### DIFF
--- a/sass/form/checkbox-radio.sass
+++ b/sass/form/checkbox-radio.sass
@@ -8,7 +8,8 @@
   &:hover
     color: $input-hover-color
   &[disabled],
-  fieldset[disabled] &
+  fieldset[disabled] &,
+  input[disabled]
     color: $input-disabled-color
     cursor: not-allowed
 


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **bugfix**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution

<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->
Fixes #3024 where `not-allowed` cursor isn't being applied properly when the parent has the class `radio` or `checkbox` and the input has `[disabled]` property.

### Tradeoffs

Two more lines added in the code. No bad tradeoffs.

### Testing Done

Checking the code generated manually.
Testing in a small local project.

### Changelog updated?

No.

<!-- Thanks! -->
