### PR TITLE
Add variable for modal breakpoint

### DIFF
--- a/sass/components/modal.sass
+++ b/sass/components/modal.sass
@@ -28,6 +28,8 @@ $modal-card-foot-border-top: 1px solid $border !default
 $modal-card-body-background-color: $scheme-main !default
 $modal-card-body-padding: 20px !default
 
+$modal-breakpoint: $tablet !default
+
 .modal
   @extend %overlay
   align-items: center
@@ -53,7 +55,7 @@ $modal-card-body-padding: 20px !default
   position: relative
   width: 100%
   // Responsiveness
-  +tablet
+  +from($modal-breakpoint)
     margin: 0 auto
     max-height: calc(100vh - #{$modal-content-spacing-tablet})
     width: $modal-content-width


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is an improvement.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
I've added a `$modal-breakpoint` variable, allowing developers to choose when the modal width changes from `$modal-content-width` to `100%`. This allows for setting `$modal-content-width` to values larger than the tablet breakpoint without the content getting cut off when the viewport is smaller than that value.
<!-- Bugfix? Reference that issue as well. -->

### Testing Done

I ensured that setting the `$modal-breakpoint` variable affects the point at which the modal width changes.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

### Changelog updated?

No.

<!-- Thanks! -->
