### PR TITLE
Support button .is-light .is-outlined hover state

### DIFF
--- a/sass/elements/button.sass
+++ b/sass/elements/button.sass
@@ -226,6 +226,10 @@ $button-colors: $colors !default
             background-color: bulmaDarken($color-light, 5%)
             border-color: transparent
             color: $color-dark
+          &.is-outlined
+            &:hover,
+            &.is-hovered
+              border-color: $color
   // Sizes
   &.is-small
     +button-small


### PR DESCRIPTION
This is a **bugfix**.

### Proposed solution

A button which has both .is-light and .is-outlined equiped (not an official feature I suppose) looks fine in its normal state, but loses its border when hovered. This PR fixes that issue.

### Tradeoffs

None

### Testing Done

Works fine in separate and grouped buttons

### Changelog updated?

No.
