### PR TITLE
fix-is-wrap.

### DIFF
--- a/docs/_includes/index/fullheight.html
+++ b/docs/_includes/index/fullheight.html
@@ -1,6 +1,6 @@
 {% assign hero_link = site.data.links.by_id['layout-hero'] %}
 
-<section class="bd-index-fullscreen hero is-hidden-mobile is-fullheight is-light">
+<section class="bd-index-fullscreen hero is-fullheight is-light">
   <div class="hero-head">
     <div class="container">
       <div class="tabs is-centered">

--- a/docs/_includes/index/fullheight.html
+++ b/docs/_includes/index/fullheight.html
@@ -1,6 +1,6 @@
 {% assign hero_link = site.data.links.by_id['layout-hero'] %}
 
-<section class="bd-index-fullscreen hero is-fullheight is-light">
+<section class="bd-index-fullscreen hero is-hidden-mobile is-fullheight is-light">
   <div class="hero-head">
     <div class="container">
       <div class="tabs is-centered">

--- a/docs/_includes/index/fullheight.html
+++ b/docs/_includes/index/fullheight.html
@@ -26,7 +26,7 @@
 
       <nav class="buttons is-centered">
         <a
-          class="button is-large is-primary"
+          class="button is-large is-primary is-size-6-mobile"
           href="{{ site.url }}{{ hero_link.path }}"
         >
           <span>Check out the <strong>Hero component</strong></span>

--- a/sass/layout/hero.sass
+++ b/sass/layout/hero.sass
@@ -144,4 +144,5 @@ $hero-colors: $colors !default
 .hero-body
   flex-grow: 1
   flex-shrink: 0
+  overflow: hidden
   padding: $hero-body-padding


### PR DESCRIPTION
This is a **bugfix**.

d | f
-- | --
<a href="https://ipfs.io/ipfs/QmWVe1KmYcHNqG8W9fbqyuNGuE91VNhMMPqkhZJE6Cg3gR"><img src="https://ipfs.io/ipfs/QmWVe1KmYcHNqG8W9fbqyuNGuE91VNhMMPqkhZJE6Cg3gR" alt="overflow:hidden"/></a>| wrap container text
![overflow-x-mobile](https://ipfs.io/ipfs/QmbBDLZsndzzzieZZbVZuYnYnFXJK2SNdUW3vVa7mf7FY9?filename=overflow-x-mobile.jpg) | <section> **not**-mobile custom
