### PR TITLE
Add optgroup to the list of tags that have font-family set

### DIFF
--- a/sass/base/generic.sass
+++ b/sass/base/generic.sass
@@ -52,6 +52,7 @@ section
 body,
 button,
 input,
+optgroup,
 select,
 textarea
   font-family: $body-family


### PR DESCRIPTION
In the latest version of Firefox (and possibly other browsers), the `font-family` is respected for `option`s in a `select`, but not for `option`s in an `optgroup` is a `select`.  This fixes that.

This is a **bugfix**.

### Proposed solution

Add `optgroup` to the list of tags that have font-family set.

### Tradeoffs

None.

### Testing Done

In my own project.  Note that I'm using the Barlow font in my project.

**Before**

![optgroup-before](https://user-images.githubusercontent.com/19495149/92785953-d8aa8b00-f375-11ea-8e7c-3f29bf4899b9.png)

**After**

![optgroup-after](https://user-images.githubusercontent.com/19495149/92785975-dcd6a880-f375-11ea-8bce-3b89e10ce964.png)


### Changelog updated?

No.
