### PR TITLE
Fixes #3098 dropdown item color on hero sections

### DIFF
--- a/sass/layout/hero.sass
+++ b/sass/layout/hero.sass
@@ -39,12 +39,21 @@ $hero-colors: $colors !default
       .navbar-item,
       .navbar-link
         color: bulmaRgba($color-invert, 0.7)
+      .navbar-dropdown
+        .navbar-item
+          color: $scheme-invert
       a.navbar-item,
       .navbar-link
         &:hover,
         &.is-active
           background-color: bulmaDarken($color, 5%)
           color: $color-invert
+      .navbar-item.has-dropdown
+        &:hover,
+        &.is-active
+          .navbar-link
+            background-color: bulmaDarken($color, 5%)
+            color: $color-invert
       .tabs
         a
           color: $color-invert


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **new feature | improvement | bugfix | documentation fix**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution

<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

Fixes #3098 when you have a navbar with dropdown inside a hero section with is-$color

### Tradeoffs

<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->
None.

### Testing Done

None.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

### Changelog updated?

No.

<!-- Thanks! -->
