### PR TITLE
add variables to configure the darken and lighten amounts

### DIFF
--- a/docs/_data/variables/elements/button.json
+++ b/docs/_data/variables/elements/button.json
@@ -170,6 +170,20 @@
       "type": "variable",
       "computed_type": "function",
       "computed_value": "mergeColorMaps((\"white\": ($white, $black), \"black\": ($black, $white), \"light\": ($light, $light-invert), \"dark\": ($dark, $dark-invert), \"primary\": ($primary, $primary-invert, $primary-light, $primary-dark), \"link\": ($link, $link-invert, $link-light, $link-dark), \"info\": ($info, $info-invert, $info-light, $info-dark), \"success\": ($success, $success-invert, $success-light, $success-dark), \"warning\": ($warning, $warning-invert, $warning-light, $warning-dark), \"danger\": ($danger, $danger-invert, $danger-light, $danger-dark)), $custom-colors)"
+    },
+    "$button-darken-half": {
+      "name": "$button-darken-half",
+      "value": "$darken-half",
+      "type": "variable",
+      "computed_type": "color",
+      "computed_value": "2.5%"
+    },
+    "$button-darken-full": {
+      "name": "$button-darken-full",
+      "value": "$darken-full",
+      "type": "variable",
+      "computed_type": "color",
+      "computed_value": "5%"
     }
   },
   "list": [
@@ -199,7 +213,9 @@
     "$button-static-color",
     "$button-static-background-color",
     "$button-static-border-color",
-    "$button-colors"
+    "$button-colors",
+    "$button-darken-full",
+    "$button-darken-half"
   ],
   "file_path": "elements/button.sass"
 }

--- a/docs/_data/variables/utilities/initial-variables.json
+++ b/docs/_data/variables/utilities/initial-variables.json
@@ -100,6 +100,31 @@
       "value": "hsl(348, 86%, 61%)",
       "type": "color"
     },
+    "$darken-half": {
+      "name": "$darken-half",
+      "value": "2.5%",
+      "type": "percent"
+    },
+    "$darken-full": {
+      "name": "$darken-full",
+      "value": "5%",
+      "type": "percent"
+    },
+    "$darken-double": {
+      "name": "$darken-double",
+      "value": "10%",
+      "type": "percent"
+    },
+    "$lighten-full": {
+      "name": "$lighten-full",
+      "value": "5%",
+      "type": "percent"
+    },
+    "$lighten-double": {
+      "name": "$lighten-double",
+      "value": "10%",
+      "type": "percent"
+    },
     "$family-sans-serif": {
       "name": "$family-sans-serif",
       "value": "BlinkMacSystemFont, -apple-system, \"Segoe UI\", \"Roboto\", \"Oxygen\", \"Ubuntu\", \"Cantarell\", \"Fira Sans\", \"Droid Sans\", \"Helvetica Neue\", \"Helvetica\", \"Arial\", sans-serif",
@@ -277,6 +302,11 @@
     "$blue",
     "$purple",
     "$red",
+    "$darken-half",
+    "$darken-full",
+    "$darken-double",
+    "$lighten-full",
+    "$lighten-double",
     "$family-sans-serif",
     "$family-monospace",
     "$render-mode",

--- a/docs/_sass/book.sass
+++ b/docs/_sass/book.sass
@@ -79,12 +79,12 @@ $book-beige: #FFEDD7
       background-color: $bleeding-green
       border-color: transparent
       &:hover
-        background-color: darken($bleeding-green, 5%)
+        background-color: darken($bleeding-green, $darken-full)
     &.bd-is-amazon
       background-color: $amazon
       border-color: transparent
       &:hover
-        background-color: darken($amazon, 5%)
+        background-color: darken($amazon, $darken-full)
       img
         margin-bottom: -11px
 

--- a/docs/_sass/global.sass
+++ b/docs/_sass/global.sass
@@ -59,9 +59,9 @@ $github-pink: #ea4aaa
     margin: -1px -8px 0 7px
   &:hover,
   &:focus
-    background-color: darken($github-pink, 5%)
+    background-color: darken($github-pink, $darken-full)
   &:active
-    background-color: darken($github-pink, 10%)
+    background-color: darken($github-pink, $darken-double)
   &:hover,
   &:focus,
   &:active

--- a/docs/_sass/header.sass
+++ b/docs/_sass/header.sass
@@ -11,11 +11,11 @@
   color: $scheme-main
   border-color: transparent !important
   &:hover
-    background-color: darken($twitter, 2.5%)
+    background-color: darken($twitter, $darken-half)
     color: $scheme-main
   &:active,
   &:focus
-    background-color: darken($twitter, 5%)
+    background-color: darken($twitter, $darken-full)
     color: $scheme-main
 
 #moreDropdown

--- a/docs/_sass/index.sass
+++ b/docs/_sass/index.sass
@@ -87,16 +87,16 @@
       background-color: $mauve
       color: $scheme-main
       &:hover
-        background-color: darken($mauve, 2.5%)
+        background-color: darken($mauve, $darken-half)
       &:active
-        background-color: darken($mauve, 5%)
+        background-color: darken($mauve, $darken-full)
     &.is-link
       background-color: $pink
       color: $scheme-main
       &:hover
-        background-color: darken($pink, 2.5%)
+        background-color: darken($pink, $darken-half)
       &:active
-        background-color: darken($pink, 5%)
+        background-color: darken($pink, $darken-full)
   +selection
     background-color: $pink
     color: $scheme-main

--- a/docs/_sass/specific.sass
+++ b/docs/_sass/specific.sass
@@ -250,9 +250,9 @@
   border-color: transparent
   color: #fff
   &:hover
-    background-color: darken($rss, 5%)
+    background-color: darken($rss, $darken-full)
   &:active
-    background-color: darken($rss, 10%)
+    background-color: darken($rss, $darken-double)
 
 .bd-view-all-versions
   color: $text-light

--- a/docs/_scripts/plugins/utils.js
+++ b/docs/_scripts/plugins/utils.js
@@ -53,6 +53,8 @@ let utils = {
       return 'size';
     } else if (value.includes('$')) {
       return 'compound';
+    } else if (value.endsWith('%')) {
+      return 'percent';
     } else if (value.match(regex_unitless)) {
       return 'unitless';
     }

--- a/sass/components/navbar.sass
+++ b/sass/components/navbar.sass
@@ -74,7 +74,7 @@ $navbar-colors: $colors !default
           &:focus,
           &:hover,
           &.is-active
-            background-color: bulmaDarken($color, 5%)
+            background-color: bulmaDarken($color, $darken-full)
             color: $color-invert
         .navbar-link
           &::after
@@ -92,7 +92,7 @@ $navbar-colors: $colors !default
             &:focus,
             &:hover,
             &.is-active
-              background-color: bulmaDarken($color, 5%)
+              background-color: bulmaDarken($color, $darken-full)
               color: $color-invert
           .navbar-link
             &::after
@@ -100,7 +100,7 @@ $navbar-colors: $colors !default
         .navbar-item.has-dropdown:focus .navbar-link,
         .navbar-item.has-dropdown:hover .navbar-link,
         .navbar-item.has-dropdown.is-active .navbar-link
-          background-color: bulmaDarken($color, 5%)
+          background-color: bulmaDarken($color, $darken-full)
           color: $color-invert
         .navbar-dropdown
           a.navbar-item

--- a/sass/elements/button.sass
+++ b/sass/elements/button.sass
@@ -35,6 +35,7 @@ $button-static-border-color: $border !default
 
 $button-colors: $colors !default
 
+// how much to darken the buttons when they are in hover or active state
 $button-darken-half: $darken-half !default
 $button-darken-full: $darken-full !default
 

--- a/sass/elements/button.sass
+++ b/sass/elements/button.sass
@@ -113,7 +113,7 @@ $button-darken-full: $darken-full !default
       color: $button-text-hover-color
     &:active,
     &.is-active
-      background-color: bulmaDarken($button-text-hover-background-color, 5%)
+      background-color: bulmaDarken($button-text-hover-background-color, $button-darken-full)
       color: $button-text-hover-color
     &[disabled],
     fieldset[disabled] &
@@ -129,7 +129,7 @@ $button-darken-full: $darken-full !default
       color: $color-invert
       &:hover,
       &.is-hovered
-        background-color: bulmaDarken($color, 2.5%)
+        background-color: bulmaDarken($color, $button-darken-half)
         border-color: transparent
         color: $color-invert
       &:focus,
@@ -140,7 +140,7 @@ $button-darken-full: $darken-full !default
           box-shadow: $button-focus-box-shadow-size bulmaRgba($color, 0.25)
       &:active,
       &.is-active
-        background-color: bulmaDarken($color, 5%)
+        background-color: bulmaDarken($color, $button-darken-full)
         border-color: transparent
         color: $color-invert
       &[disabled],
@@ -153,7 +153,7 @@ $button-darken-full: $darken-full !default
         color: $color
         &:hover,
         &.is-hovered
-          background-color: bulmaDarken($color-invert, 5%)
+          background-color: bulmaDarken($color-invert, $button-darken-full)
         &[disabled],
         fieldset[disabled] &
           background-color: $color-invert
@@ -221,12 +221,12 @@ $button-darken-full: $darken-full !default
           color: $color-dark
           &:hover,
           &.is-hovered
-            background-color: bulmaDarken($color-light, 2.5%)
+            background-color: bulmaDarken($color-light, $button-darken-half)
             border-color: transparent
             color: $color-dark
           &:active,
           &.is-active
-            background-color: bulmaDarken($color-light, 5%)
+            background-color: bulmaDarken($color-light, $button-darken-full)
             border-color: transparent
             color: $color-dark
   // Sizes

--- a/sass/elements/button.sass
+++ b/sass/elements/button.sass
@@ -35,6 +35,9 @@ $button-static-border-color: $border !default
 
 $button-colors: $colors !default
 
+$button-darken-half: $darken-half !default
+$button-darken-full: $darken-full !default
+
 // The button sizes use mixins so they can be used at different breakpoints
 =button-small
   border-radius: $radius-small

--- a/sass/elements/tag.sass
+++ b/sass/elements/tag.sass
@@ -127,9 +127,9 @@ $tag-colors: $colors !default
       width: 1px
     &:hover,
     &:focus
-      background-color: darken($tag-background-color, 5%)
+      background-color: darken($tag-background-color, $darken-full)
     &:active
-      background-color: darken($tag-background-color, 10%)
+      background-color: darken($tag-background-color, $darken-double)
   &.is-rounded
     border-radius: $radius-rounded
 

--- a/sass/form/file.sass
+++ b/sass/form/file.sass
@@ -31,7 +31,7 @@ $file-colors: $form-colors !default
       &:hover,
       &.is-hovered
         .file-cta
-          background-color: bulmaDarken($color, 2.5%)
+          background-color: bulmaDarken($color, $darken-half)
           border-color: transparent
           color: $color-invert
       &:focus,
@@ -43,7 +43,7 @@ $file-colors: $form-colors !default
       &:active,
       &.is-active
         .file-cta
-          background-color: bulmaDarken($color, 5%)
+          background-color: bulmaDarken($color, $darken-full)
           border-color: transparent
           color: $color-invert
   // Sizes
@@ -127,16 +127,16 @@ $file-colors: $form-colors !default
   position: relative
   &:hover
     .file-cta
-      background-color: bulmaDarken($file-cta-background-color, 2.5%)
+      background-color: bulmaDarken($file-cta-background-color, $darken-half)
       color: $file-cta-hover-color
     .file-name
-      border-color: bulmaDarken($file-name-border-color, 2.5%)
+      border-color: bulmaDarken($file-name-border-color, $darken-half)
   &:active
     .file-cta
-      background-color: bulmaDarken($file-cta-background-color, 5%)
+      background-color: bulmaDarken($file-cta-background-color, $darken-full)
       color: $file-cta-active-color
     .file-name
-      border-color: bulmaDarken($file-name-border-color, 5%)
+      border-color: bulmaDarken($file-name-border-color, $darken-full)
 
 .file-input
   height: 100%

--- a/sass/form/select.sass
+++ b/sass/form/select.sass
@@ -50,7 +50,7 @@ $select-colors: $form-colors !default
         border-color: $color
         &:hover,
         &.is-hovered
-          border-color: bulmaDarken($color, 5%)
+          border-color: bulmaDarken($color, $darken-full)
         &:focus,
         &.is-focused,
         &:active,

--- a/sass/helpers/color.sass
+++ b/sass/helpers/color.sass
@@ -5,7 +5,7 @@
   a.has-text-#{$name}
     &:hover,
     &:focus
-      color: bulmaDarken($color, 10%) !important
+      color: bulmaDarken($color, $darken-double) !important
   .has-background-#{$name}
     background-color: $color !important
   @if length($pair) >= 4
@@ -17,7 +17,7 @@
     a.has-text-#{$name}-light
       &:hover,
       &:focus
-        color: bulmaDarken($color-light, 10%) !important
+        color: bulmaDarken($color-light, $darken-double) !important
     .has-background-#{$name}-light
       background-color: $color-light !important
     // Dark
@@ -26,7 +26,7 @@
     a.has-text-#{$name}-dark
       &:hover,
       &:focus
-        color: bulmaLighten($color-dark, 10%) !important
+        color: bulmaLighten($color-dark, $lighten-double) !important
     .has-background-#{$name}-dark
       background-color: $color-dark !important
 

--- a/sass/layout/hero.sass
+++ b/sass/layout/hero.sass
@@ -43,7 +43,7 @@ $hero-colors: $colors !default
       .navbar-link
         &:hover,
         &.is-active
-          background-color: bulmaDarken($color, 5%)
+          background-color: bulmaDarken($color, $darken-full)
           color: $color-invert
       .tabs
         a
@@ -69,8 +69,8 @@ $hero-colors: $colors !default
       // Modifiers
       @if type-of($color) == 'color'
         &.is-bold
-          $gradient-top-left: darken(saturate(adjust-hue($color, -10deg), 10%), 10%)
-          $gradient-bottom-right: lighten(saturate(adjust-hue($color, 10deg), 5%), 5%)
+          $gradient-top-left: darken(saturate(adjust-hue($color, -10deg), 10%), $darken-double)
+          $gradient-bottom-right: lighten(saturate(adjust-hue($color, 10deg), 5%), $lighten-full)
           background-image: linear-gradient(141deg, $gradient-top-left 0%, $color 71%, $gradient-bottom-right 100%)
           +mobile
             .navbar-menu

--- a/sass/utilities/initial-variables.sass
+++ b/sass/utilities/initial-variables.sass
@@ -24,6 +24,15 @@ $blue:         hsl(217, 71%,  53%) !default
 $purple:       hsl(271, 100%, 71%) !default
 $red:          hsl(348, 86%, 61%) !default
 
+// Darken Amounts
+$darken-half: 2.5% !default
+$darken-full: 5% !default
+$darken-double: 10% !default
+
+// Lighten Amounts
+$lighten-full: 5% !default
+$lighten-double: 10% !default
+
 // Typography
 
 $family-sans-serif: BlinkMacSystemFont, -apple-system, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif !default


### PR DESCRIPTION
This is an improvement. I wanted to be able to make the hover and active colors of Bulma buttons a darker shade. I found that this is done with a 2.5% and 5% static value, so I made them configurable variables like almost everything else in Bulma. I did a search through the code and found a few more of these static percentages, along with a few 10% values, so I created initial variables to cover all of these values.

### Proposed solution

Solution is to create and use variables to make the darken and lighten amounts used in Bulma configurable.

### Tradeoffs

I really can't think of any tradeoffs here. The only other alternative is to overwrite some SASS in the project that is using Bulma, but I feel like this is supposed to be in the Bulma code base.

### Testing Done

I started from the main (master) branch, ran `npm install` and `npm run build` to make sure it builds normally. I also tested the values in my project to make sure they worked as initial values and when configured to a different value.


### Changelog updated?

No - I was not sure how to add content to changelog without it being in a new version section. But it would be like this:

### New features

* New variables `$darken-half`, `$darken-full`, `$darken-double`, `$lighten-full`, `$lighten-double`, `$button-darken-half`, `$button-darken-full`
