### PR TITLE
Update block.html - Clarify examples

### DIFF
--- a/docs/documentation/elements/block.html
+++ b/docs/documentation/elements/block.html
@@ -28,13 +28,13 @@ meta:
 
 {% capture no_block_example %}
 <div>
-  This text is within a <strong>block</strong>.
+  This text is not within a <strong>block</strong>.
 </div>
 <div>
-  This text is within a longer <strong>second block</strong>. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean efficitur sit amet massa fringilla egestas. Nullam condimentum luctus turpis.
+  This text isn't within a <strong>block</strong> either. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean efficitur sit amet massa fringilla egestas. Nullam condimentum luctus turpis.
 </div>
 <div>
-  This text is within a <strong>third block</strong>. This block has no margin at the bottom.
+  This text is also not within a <strong>block</strong>.
 </div>
 {% endcapture %}
 


### PR DESCRIPTION
The example of text inside `div`s without the `.block` class felt awkward.

This is a **documentation fix**.

### Proposed solution

In the examples where the `.block` class is not used, don't use sample text that says the `block` class is used.

### Tradeoffs

None.

### Testing Done

None.

### Changelog updated?

No.

<!-- Thanks! -->
