### PR TITLE
Update generic.sass

### DIFF
--- a/sass/base/generic.sass
+++ b/sass/base/generic.sass
@@ -4,7 +4,7 @@ $body-min-width: 300px !default
 $body-rendering: optimizeLegibility !default
 $body-family: $family-primary !default
 $body-overflow-x: hidden !default
-$body-overflow-y: scroll !default
+$body-overflow-y: auto !default
 
 $body-color: $text !default
 $body-font-size: 1em !default


### PR DESCRIPTION
updated $body-overflow-y to 'auto'. 


<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a improvement

<!-- Improvement? Explain how and why. -->
The previous value  for 'overflow-y' was 'scroll' which causes a scroll bar to appear even in there is no need to scroll.  When the property is set to 'auto' , the scroll bar will automatically appear if there is an overflow.
Having a scrollbar when it is not need is annoying and does not look good


### Tradeoffs

there are no drawbacks to this solution

### Testing Done

None.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

### Changelog updated?

No.

<!-- Thanks! -->
