### PR TITLE
Add "is-clickable" helper to documentation

### DIFF
--- a/docs/documentation/helpers/other-helpers.html
+++ b/docs/documentation/helpers/other-helpers.html
@@ -49,6 +49,10 @@ breadcrumb:
       <td>Prevents the text from being <strong>selectable</strong></td>
     </tr>
     <tr>
+      <td><code>is-clickable</code></td>
+      <td>Applies <code>cursor: pointer !important</code> to the element.</td>
+    </tr>
+    <tr>
       <td><code>is-relative</code></td>
       <td>Applies <code>position: relative</code> to the element.</td>
     </tr>


### PR DESCRIPTION
This is a **documentation fix**.

### Proposed solution

Adds missing documentation for "is-clickable" helper

### Tradeoffs

None

### Testing Done

None.

### Changelog updated?

No.
