### PR TITLE
updated notification javascript guidelines

### DIFF
--- a/docs/documentation/elements/notification.html
+++ b/docs/documentation/elements/notification.html
@@ -55,7 +55,7 @@ meta:
 {% capture notification_js_code %}
 document.addEventListener('DOMContentLoaded', () => {
   (document.querySelectorAll('.notification .delete') || []).forEach(($delete) => {
-    $notification = $delete.parentNode;
+    var $notification = $delete.parentNode;
 
     $delete.addEventListener('click', () => {
       $notification.parentNode.removeChild($notification);


### PR DESCRIPTION
This is a **documentation fix**.

### Proposed solution

The 'notification' component JavaScript Example does not work when there are multiple notifications present within a page as the $notification variable is not scoped. This allows the closing of one notification, and all the subsequent ones do not close as the $notification.parentNode reference no longer exists.
This can be solved by adding a simple var statement in front of the $notification variable. Such a solution would have saved me a lot of time (and many unsuspecting future users) as it is not trivially identified, hence making it significantly easier to use this component.

### Testing Done

None.

### Changelog updated?

No.
