### PR TITLE
Responsive spacing helpers

### DIFF
--- a/sass/helpers/spacing.sass
+++ b/sass/helpers/spacing.sass
@@ -15,17 +15,143 @@ $spacing-values: ("0": 0, "1": 0.25rem, "2": 0.5rem, "3": 0.75rem, "4": 1rem, "5
     // All directions
     .#{$shortcut}-#{$name}
       #{$property}: $value !important
+    +mobile
+      .#{$shortcut}-#{$name}-mobile
+        #{$property}: $value !important
+    +tablet
+      .#{$shortcut}-#{$name}-tablet
+        #{$property}: $value !important
+    +tablet-only
+      .#{$shortcut}-#{$name}-tablet-only
+        #{$property}: $value !important
+    +touch
+      .#{$shortcut}-#{$name}-touch
+        #{$property}: $value !important
+    +desktop
+      .#{$shortcut}-#{$name}-desktop
+        #{$property}: $value !important
+    +desktop-only
+      .#{$shortcut}-#{$name}-desktop-only
+        #{$property}: $value !important
+    +widescreen
+      .#{$shortcut}-#{$name}-widescreen
+        #{$property}: $value !important
+    +widescreen-only
+      .#{$shortcut}-#{$name}-widescreen-only
+        #{$property}: $value !important
+    +fullhd
+      .#{$shortcut}-#{$name}-fullhd
+        #{$property}: $value !important
     // Cardinal directions
     @each $direction, $suffix in $spacing-directions
       .#{$shortcut}#{$suffix}-#{$name}
         #{$property}-#{$direction}: $value !important
+      +mobile
+        .#{$shortcut}#{$suffix}-#{$name}-mobile
+          #{$property}-#{$direction}: $value !important
+      +tablet
+        .#{$shortcut}#{$suffix}-#{$name}-tablet
+          #{$property}-#{$direction}: $value !important
+      +tablet-only
+        .#{$shortcut}#{$suffix}-#{$name}-tablet-only
+          #{$property}-#{$direction}: $value !important
+      +touch
+        .#{$shortcut}#{$suffix}-#{$name}-touch
+          #{$property}-#{$direction}: $value !important
+      +desktop
+        .#{$shortcut}#{$suffix}-#{$name}-desktop
+          #{$property}-#{$direction}: $value !important
+      +desktop-only
+        .#{$shortcut}#{$suffix}-#{$name}-desktop-only
+          #{$property}-#{$direction}: $value !important
+      +widescreen
+        .#{$shortcut}#{$suffix}-#{$name}-widescreen
+          #{$property}-#{$direction}: $value !important
+      +widescreen-only
+        .#{$shortcut}#{$suffix}-#{$name}-widescreen-only
+          #{$property}-#{$direction}: $value !important
+      +fullhd
+        .#{$shortcut}#{$suffix}-#{$name}-fullhd
+          #{$property}-#{$direction}: $value !important
     // Horizontal axis
     @if $spacing-horizontal != null
       .#{$shortcut}#{$spacing-horizontal}-#{$name}
         #{$property}-left: $value !important
         #{$property}-right: $value !important
+      +mobile
+        .#{$shortcut}#{$spacing-horizontal}-#{$name}-mobile
+          #{$property}-left: $value !important
+          #{$property}-right: $value !important
+      +tablet
+        .#{$shortcut}#{$spacing-horizontal}-#{$name}-tablet
+          #{$property}-left: $value !important
+          #{$property}-right: $value !important
+      +tablet-only
+        .#{$shortcut}#{$spacing-horizontal}-#{$name}-tablet-only
+          #{$property}-left: $value !important
+          #{$property}-right: $value !important
+      +touch
+        .#{$shortcut}#{$spacing-horizontal}-#{$name}-touch
+          #{$property}-left: $value !important
+          #{$property}-right: $value !important
+      +desktop
+        .#{$shortcut}#{$spacing-horizontal}-#{$name}-desktop
+          #{$property}-left: $value !important
+          #{$property}-right: $value !important
+      +desktop-only
+        .#{$shortcut}#{$spacing-horizontal}-#{$name}-desktop-only
+          #{$property}-left: $value !important
+          #{$property}-right: $value !important
+      +widescreen
+        .#{$shortcut}#{$spacing-horizontal}-#{$name}-widescreen
+          #{$property}-left: $value !important
+          #{$property}-right: $value !important
+      +widescreen-only
+        .#{$shortcut}#{$spacing-horizontal}-#{$name}-widescreen-only
+          #{$property}-left: $value !important
+          #{$property}-right: $value !important
+      +fullhd
+        .#{$shortcut}#{$spacing-horizontal}-#{$name}-fullhd
+          #{$property}-left: $value !important
+          #{$property}-right: $value !important
     // Vertical axis
     @if $spacing-vertical != null
       .#{$shortcut}#{$spacing-vertical}-#{$name}
         #{$property}-top: $value !important
         #{$property}-bottom: $value !important
+      +mobile
+        .#{$shortcut}#{$spacing-vertical}-#{$name}-mobile
+          #{$property}-top: $value !important
+          #{$property}-bottom: $value !important
+      +tablet
+        .#{$shortcut}#{$spacing-vertical}-#{$name}-tablet
+          #{$property}-top: $value !important
+          #{$property}-bottom: $value !important
+      +tablet-only
+        .#{$shortcut}#{$spacing-vertical}-#{$name}-tablet-only
+          #{$property}-top: $value !important
+          #{$property}-bottom: $value !important
+      +touch
+        .#{$shortcut}#{$spacing-vertical}-#{$name}-touch
+          #{$property}-top: $value !important
+          #{$property}-bottom: $value !important
+      +desktop
+        .#{$shortcut}#{$spacing-vertical}-#{$name}-desktop
+          #{$property}-top: $value !important
+          #{$property}-bottom: $value !important
+      +desktop-only
+        .#{$shortcut}#{$spacing-vertical}-#{$name}-desktop-only
+          #{$property}-top: $value !important
+          #{$property}-bottom: $value !important
+      +widescreen
+        .#{$shortcut}#{$spacing-vertical}-#{$name}-widescreen
+          #{$property}-top: $value !important
+          #{$property}-bottom: $value !important
+      +widescreen-only
+        .#{$shortcut}#{$spacing-vertical}-#{$name}-widescreen-only
+          #{$property}-top: $value !important
+          #{$property}-bottom: $value !important
+      +fullhd
+        .#{$shortcut}#{$spacing-vertical}-#{$name}-fullhd
+          #{$property}-top: $value !important
+          #{$property}-bottom: $value !important


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is an **improvement**.

### Proposed solution

Responsive spacing helpers are a much desired improvement.
https://github.com/jgthms/bulma/issues/3016
https://github.com/jgthms/bulma/issues/451#issuecomment-647723514

This pull request adds responsive spacing helpers for all the current spacing helpers.

Example of use:
.is-sidebar-menu has a default padding of 2.5 rem. If I want a more compact menu on a certain range of screen sizes, by reducing the padding, I'd immediately have to start writing exceptions in my css. I'd much rather add a single class to the component, like: .p-2-tablet, to get the desired result. If I want similar behaviour on 3 components, I'd have 3 exceptions in my css, when that could be replaced by simply adding classes. If I want different behaviour in a one case I can simply remove the class on that specific page instead of having to create an exception on the already created exception.

### Tradeoffs

The only trade-off I see, is potentially bloating the bulma css output. I personally think the improvement outweighs this drawback, but I'm very eager to hear more opinions.

### Testing Done

I've tested multiple responsive spacing helpers per spacing type and direction (or axis).

### Changelog updated?

No.
