### PR TITLE
Adds is-required to label

### DIFF
--- a/sass/form/tools.sass
+++ b/sass/form/tools.sass
@@ -21,6 +21,9 @@ $label-colors: $form-colors !default
     font-size: $size-medium
   &.is-large
     font-size: $size-large
+  &.is-required:before
+    content: "*"
+    color: $danger
 
 .help
   display: block


### PR DESCRIPTION
Adds .is-required class to label adding a required star. 
Uses the $danger color variable.

<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **improvement**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution

Add a required class option to form labels

<img width="382" alt="Screen Shot 2020-11-11 at 8 20 39 AM" src="https://user-images.githubusercontent.com/1104139/98836990-3fd8d000-23f7-11eb-9752-2b6643e2e007.png">

<img width="532" alt="Screen Shot 2020-11-11 at 8 25 44 AM" src="https://user-images.githubusercontent.com/1104139/98837193-829aa800-23f7-11eb-8fe0-d448ea26ee4a.png">


<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

### Tradeoffs

May want to style your required labels differently than the classic star pattern and or move the star as an :after element. 

<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->

### Testing Done

Tested on Standard and Horizontal form labels.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

### Changelog updated?

No.

<!-- Thanks! -->
