### PR TITLE
Display .dropdown-content as block by default

### DIFF
--- a/sass/components/dropdown.sass
+++ b/sass/components/dropdown.sass
@@ -51,6 +51,7 @@ $dropdown-divider-background-color: $border-light !default
   background-color: $dropdown-content-background-color
   border-radius: $dropdown-content-radius
   box-shadow: $dropdown-content-shadow
+  display: block
   padding-bottom: $dropdown-content-padding-bottom
   padding-top: $dropdown-content-padding-top
 


### PR DESCRIPTION
This is an **improvement**.

Because .dropdown-content isn't set to display: block; by default, any non-block elements (span for example) would require a user to set display: block manually. Using a span without that addition causes issues (no background color visible).

.dropdown-item does have its display attribute set to block already.

### Proposed solution

Setting the display attribute of .dropdown-content to block by default.

### Tradeoffs

None.

### Testing Done

Tested on block and non-block elements

### Changelog updated?

No.