### PR TITLE
Allow custom tile denominator

### DIFF
--- a/sass/grid/tiles.sass
+++ b/sass/grid/tiles.sass
@@ -1,5 +1,6 @@
 @import "../utilities/mixins"
 
+$tile-denominator: 12 !default
 $tile-spacing: 0.75rem !default
 
 .tile
@@ -30,7 +31,7 @@ $tile-spacing: 0.75rem !default
   +tablet
     &:not(.is-child)
       display: flex
-    @for $i from 1 through 12
+    @for $i from 1 through $tile-denominator
       &.is-#{$i}
         flex: none
-        width: ($i / 12) * 100%
+        width: ($i / $tile-denominator) * 100%


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **improvement**.
The default tile denominator is 12, but that can be a limiting factor. The ability to set it to 24 (or any other value) would allow us to use Bulma for front-end projects where a designer wouldn't be limited to 12 tiles (without having to split tiles in the same row into multiple groups of 12).

<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution
Make the tile denominator adjustable by moving the value to a sass variable.

### Tradeoffs

None

### Testing Done

Tested by adjusting the value to various values that aren't 12 and verified the results.

### Changelog updated?

No.
