### PR TITLE
Fix #3188 Inconsistent grouped button border behavior

### DIFF
--- a/sass/elements/button.sass
+++ b/sass/elements/button.sass
@@ -45,6 +45,8 @@ $button-static-border-color: $border !default
 
 $button-colors: $colors !default
 
+$button-borderless-colors: ('white','light','black','text','primary','link','info','succes','warning','danger') !default
+
 // The button sizes use mixins so they can be used at different breakpoints
 =button-small
   border-radius: $radius-small
@@ -307,6 +309,10 @@ $button-colors: $colors !default
       +button-large
   &.has-addons
     .button
+      z-index: 2
+      @each $name, $pair in $button-borderless-colors
+        &.is-#{$name}
+          z-index: 1
       &:not(:first-child)
         border-bottom-left-radius: 0
         border-top-left-radius: 0
@@ -318,15 +324,15 @@ $button-colors: $colors !default
         +ltr-property("margin", 0)
       &:hover,
       &.is-hovered
-        z-index: 2
+        z-index: 3
       &:focus,
       &.is-focused,
       &:active,
       &.is-active,
       &.is-selected
-        z-index: 3
+        z-index: 4
         &:hover
-          z-index: 4
+          z-index: 5
       &.is-expanded
         flex-grow: 1
         flex-shrink: 1

--- a/sass/form/tools.sass
+++ b/sass/form/tools.sass
@@ -7,6 +7,8 @@ $help-size: $size-small !default
 
 $label-colors: $form-colors !default
 
+$button-borderless-colors: ('white','light','black','text','primary','link','info','succes','warning','danger') !default
+
 .label
   color: $label-color
   display: block
@@ -71,17 +73,22 @@ $label-colors: $form-colors !default
       .button,
       .input,
       .select select
+        z-index: 2
         &:not([disabled])
           &:hover,
           &.is-hovered
-            z-index: 2
+            z-index: 3
           &:focus,
           &.is-focused,
           &:active,
           &.is-active
-            z-index: 3
+            z-index: 4
             &:hover
-              z-index: 4
+              z-index: 5
+      .button
+        @each $name, $pair in $button-borderless-colors
+          &.is-#{$name}
+            z-index: 1
       &.is-expanded
         flex-grow: 1
         flex-shrink: 1


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **bugfix**.

Fixes https://github.com/jgthms/bulma/issues/3188 which is an issue where we concluded that the z-index of borderless, grouped buttons should be lower than the z-index of grouped, bordered buttons.

### Proposed solution

Set the z-index of grouped, borderless buttons to a lower value than grouped, bordered buttons. While bumping the z-index values of :hover and :focus states etc.

### Tradeoffs

None that I'm currently aware of.

### Testing Done

Tested with example from issue https://github.com/jgthms/bulma/issues/3188 and different grouped button combinations.

### Changelog updated?

No.

<!-- Thanks! -->
