### PR TITLE
Do not override is-rounded with button-small. Fixes #3163.

### DIFF
--- a/sass/elements/button.sass
+++ b/sass/elements/button.sass
@@ -47,7 +47,8 @@ $button-colors: $colors !default
 
 // The button sizes use mixins so they can be used at different breakpoints
 =button-small
-  border-radius: $radius-small
+  &:not(.is-rounded)
+    border-radius: $radius-small
   font-size: $size-small
 =button-normal
   font-size: $size-normal


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a bugfix for #3163.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution

`button-small` currently assumes the button is not rounded and overrides its border-radius from `$radius` to `$radius-small`. This is not valid however if `is-rounded` is applied to the button. 

This PR adds `&:not(.is-rounded)` to avoid this. This solution is preferable to #3164 which uses `!important`.

<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

### Tradeoffs

None

<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->

### Testing Done

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

Tested with the following code:

```html
<p>This button should be small and rounded:</p>
<div class="buttons are-small">
  <button class="button is-rounded">Hello</button>
</div>
```

Bulma `v0.9.1` incorrectly renders the button not rounded. Test and confirmed that this PR causes the button to be correctly rendered small and rounded.

### Changelog updated?

No.

<!-- Thanks! -->
