### PR TITLE
Docs - Updated YouTube embed code: removed showinfo - a deprecated paramater

### DIFF
--- a/docs/documentation/elements/image.html
+++ b/docs/documentation/elements/image.html
@@ -42,7 +42,7 @@ meta:
 
 {% capture iframe_ratio %}
 <figure class="image is-16by9">
-  <iframe class="has-ratio" width="640" height="360" src="https://www.youtube.com/embed/YE7VzlLtp-4?showinfo=0" frameborder="0" allowfullscreen></iframe>
+  <iframe class="has-ratio" width="640" height="360" src="https://www.youtube.com/embed/YE7VzlLtp-4" frameborder="0" allowfullscreen></iframe>
 </figure>
 {% endcapture %}
 


### PR DESCRIPTION
This is a **documentation fix**.

### Proposed solution

[showinfo was deprecated by YouTube](https://developers.google.com/youtube/player_parameters#release_notes_08_23_2018) two years ago. Since it is redundant now, I just removed it from docs.

### Tradeoffs

None.

### Testing Done

None.

### Changelog updated?

No.