### PR TITLE
Update variables.html

### DIFF
--- a/docs/documentation/customize/variables.html
+++ b/docs/documentation/customize/variables.html
@@ -96,7 +96,7 @@ breadcrumb:
 %}
 
 {% capture custom_message %}
-  You can use the following <a href="{{ site.data.variables.base.generic.file_url }}" target="_blank">generic variables</a> for general <strong>customization</strong>. Simply set one or multiple of these variables <em>before</em> importing Bulma. <a href="{{ site.url }}/documentation/overview/customize/">Learn how</a>.
+  You can use the following <a href="{{ site.data.variables.base.generic.file_url }}" target="_blank">generic variables</a> for general <strong>customization</strong>. Simply set one or multiple of these variables <em>before</em> importing Bulma. <a href="https://sass-lang.com/documentation/variables">Learn how</a>.
 {% endcapture %}
 
 {%


### PR DESCRIPTION
This is a **documentation fix/improvement**.

### The Problem

The "Learn how" link on the [Customize/Variables#generic-variables](https://bulma.io/documentation/customize/variables/#generic-variables) page/section should send to a page that teaches how to change variables, but it just sends back to the root of the Customize branch in the docs.

### Proposed Solution

This PR changes the link to direct the user to sass doc on variables. (https://sass-lang.com/documentation/variables)

### Testing Done

None.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

### Changelog updated?

No.

<!-- Thanks! -->
