### PR TITLE
Allow input colors on contenteditable

### DIFF
--- a/sass/form/input-textarea.sass
+++ b/sass/form/input-textarea.sass
@@ -4,14 +4,7 @@ $textarea-min-height: 8em !default
 
 $textarea-colors: $form-colors !default
 
-%input-textarea
-  @extend %input
-  box-shadow: $input-shadow
-  max-width: 100%
-  width: 100%
-  &[readonly]
-    box-shadow: none
-  // Colors
+@mixin input-color-border
   @each $name, $pair in $textarea-colors
     $color: nth($pair, 1)
     &.is-#{$name}
@@ -21,6 +14,15 @@ $textarea-colors: $form-colors !default
       &:active,
       &.is-active
         box-shadow: $input-focus-box-shadow-size bulmaRgba($color, 0.25)
+
+%input-textarea
+  @extend %input
+  @include input-color-border
+  box-shadow: $input-shadow
+  max-width: 100%
+  width: 100%
+  &[readonly]
+    box-shadow: none
   // Sizes
   &.is-small
     +control-small
@@ -64,3 +66,6 @@ $textarea-colors: $form-colors !default
   // Modifiers
   &.has-fixed-size
     resize: none
+
+[contenteditable]
+  @include input-color-border


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **bugfix**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution

<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

[Input color classes](https://bulma.io/documentation/form/input/#colors) like `is-danger` should also apply to [contenteditable](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/contenteditable) elements, which are functionally similar to inputs and textareas.

This solution only applies the border color and does not assume anything else about how the contenteditable is styled.

### Tradeoffs

<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->

It is possible that existing developers would be using `is-danger` on a `contenteditable` with different semantics.

### Testing Done

Tested:

```html
<div class="is-danger" contenteditable>Hello</div>
```

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

### Changelog updated?

I can add a changelog and update documentation upon request.

<!-- Thanks! -->
