### PR TITLE
Added typography examples

### DIFF
--- a/docs/documentation/helpers/typography-helpers.html
+++ b/docs/documentation/helpers/typography-helpers.html
@@ -71,6 +71,9 @@ breadcrumb:
       <th>
         Font-size
       </th>
+      <th>
+        Size
+      </th>
     </tr>
   </thead>
   <tbody>
@@ -79,6 +82,7 @@ breadcrumb:
         {% assign key = '$size-' | append: forloop.index %}
         <td><code>is-size-{{ forloop.index }}</code></td>
         <td><code>{{ initial_vars[key].value }}</code></td>
+        <td><span class="{{ initial_vars[key].value }}">Example</span></td>
       </tr>
     {% endfor %}
   </tbody>

--- a/docs/documentation/helpers/typography-helpers.html
+++ b/docs/documentation/helpers/typography-helpers.html
@@ -316,19 +316,19 @@ breadcrumb:
   <tbody>
   <tr>
     <td><code>is-capitalized</code></td>
-    <td>Transforms <strong>the first character</strong> of each word to <strong class="is-capitalized">uppercase</strong></td>
+    <td>Transforms <strong>the first character</strong> of each word to <span class="is-capitalized">uppercase</span></td>
   </tr>
   <tr>
     <td><code>is-lowercase</code></td>
-    <td>Transforms <strong>all characters</strong> to <strong class="is-lowercase">lowercase</strong></td>
+    <td>Transforms <strong>all characters</strong> to <span class="is-lowercase">lowercase</span></td>
   </tr>
   <tr>
     <td><code>is-uppercase</code></td>
-    <td>Transforms <strong>all characters</strong> to <strong class="is-uppercase">uppercase</strong></td>
+    <td>Transforms <strong>all characters</strong> to <span class="is-uppercase">uppercase</span></td>
   </tr>
   <tr>
     <td><code>is-italic</code></td>
-    <td>Transforms <strong>all characters</strong> to <strong class="is-italic">italic</strong></td>
+    <td>Transforms <strong>all characters</strong> to <span class="is-italic">italic</span></td>
   </tr>
   </tbody>
 </table>
@@ -355,23 +355,23 @@ breadcrumb:
   <tbody>
   <tr>
     <td><code>has-text-weight-light</code></td>
-    <td>Transforms text weight to <strong>light</strong></td>
+    <td>Transforms text weight to <span class="has-text-weight-light">light</span></td>
   </tr>
   <tr>
     <td><code>has-text-weight-normal</code></td>
-    <td>Transforms text weight to <strong>normal</strong></td>
+    <td>Transforms text weight to <span class="has-text-weight-normal">normal</span></td>
   </tr>
   <tr>
     <td><code>has-text-weight-medium</code></td>
-    <td>Transforms text weight to <strong>medium</strong></td>
+    <td>Transforms text weight to <span class="has-text-weight-medium">medium</span></td>
   </tr>
   <tr>
     <td><code>has-text-weight-semibold</code></td>
-    <td>Transforms text weight to <strong>semi-bold</strong></td>
+    <td>Transforms text weight to <span class="has-text-weight-semibold">semi-bold</span></td>
   </tr>
   <tr>
     <td><code>has-text-weight-bold</code></td>
-    <td>Transforms text weight to <strong>bold</strong></td>
+    <td>Transforms text weight to <span class="has-text-weight-bold">bold</span></td>
   </tr>
   </tbody>
 </table>

--- a/docs/documentation/helpers/typography-helpers.html
+++ b/docs/documentation/helpers/typography-helpers.html
@@ -316,19 +316,19 @@ breadcrumb:
   <tbody>
   <tr>
     <td><code>is-capitalized</code></td>
-    <td>Transforms <strong>the first character</strong> of each word to <strong>uppercase</strong></td>
+    <td>Transforms <strong>the first character</strong> of each word to <strong class="is-capitalized">uppercase</strong></td>
   </tr>
   <tr>
     <td><code>is-lowercase</code></td>
-    <td>Transforms <strong>all characters</strong> to <strong>lowercase</strong></td>
+    <td>Transforms <strong>all characters</strong> to <strong class="is-lowercase">lowercase</strong></td>
   </tr>
   <tr>
     <td><code>is-uppercase</code></td>
-    <td>Transforms <strong>all characters</strong> to <strong>uppercase</strong></td>
+    <td>Transforms <strong>all characters</strong> to <strong class="is-uppercase">uppercase</strong></td>
   </tr>
   <tr>
     <td><code>is-italic</code></td>
-    <td>Transforms <strong>all characters</strong> to <strong>italic</strong></td>
+    <td>Transforms <strong>all characters</strong> to <strong class="is-italic">italic</strong></td>
   </tr>
   </tbody>
 </table>


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is an **improvement**.

Just as a number of the other documentation pages reflect examples of what each class does, I've added examples to the typography size, transformation and weight subsections.

### Proposed solution

#### Typography -> Size
Added another column reflecting the size of the text.

#### Typography -> Text Transformation
Modified the sample transformation text to reflect text in an example.

#### Typography -> Text Weight
Modified the sample weight text to reflect the weight in an example.

### Tradeoffs

Ever so slightly higher maintenance to accommodate updated examples as new functionality is added, but such implementation would be minimal.

### Testing Done

Only updated documentation. It wasn't clear how the docs are built, but tested the CSS changes against your live site (via Chrome DevTools).


### Changelog updated?

No.

<!-- Thanks! -->
