### PR TITLE
Fix typography helpers "size"

### DIFF
--- a/docs/documentation/helpers/typography-helpers.html
+++ b/docs/documentation/helpers/typography-helpers.html
@@ -82,7 +82,7 @@ breadcrumb:
         {% assign key = '$size-' | append: forloop.index %}
         <td><code>is-size-{{ forloop.index }}</code></td>
         <td><code>{{ initial_vars[key].value }}</code></td>
-        <td><span class="{{ initial_vars[key].value }}">Example</span></td>
+        <td><span class="is-size-{{ forloop.index }}">Example</span></td>
       </tr>
     {% endfor %}
   </tbody>


### PR DESCRIPTION
This is a **documentation fix**.

Currently, the [size examples in Typography Helpers](https://bulma.io/documentation/helpers/typography-helpers/#size) displays each example as the same size, due to incorrect class being applied.

### Proposed solution

Apply the correct class to each example span i.e. instead of `3rem` use class `is-size-1`. 

### Tradeoffs

None.

### Testing Done

Tested changing class in CSS debug tools on live documentation.

### Changelog updated?

No.

<!-- Thanks! -->
