### PR TITLE
Docs: Corrected sample text in typography examples

### DIFF
--- a/docs/documentation/helpers/typography-helpers.html
+++ b/docs/documentation/helpers/typography-helpers.html
@@ -82,7 +82,7 @@ breadcrumb:
         {% assign key = '$size-' | append: forloop.index %}
         <td><code>is-size-{{ forloop.index }}</code></td>
         <td><code>{{ initial_vars[key].value }}</code></td>
-        <td><span class="{{ initial_vars[key].value }}">Example</span></td>
+        <td><span class="is-size-{{forloop.index}}">Example</span></td>
       </tr>
     {% endfor %}
   </tbody>


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a documentation fix

### Proposed solution
Examples in typography helpers reference the font-size value and not the appropriate size class. Corrected so example text shows up properly.

### Tradeoffs
Nearly inconsequential amount of additional maintenance if changes are made to typography going forward. Otherwise, none.

### Testing Done

None. Can't figure out how to build documentation locally, but since the class will use the appropriate class value now.

### Changelog updated?

No.

<!-- Thanks! -->
