### PR TITLE
Box Supports Variables

### DIFF
--- a/docs/documentation/elements/box.html
+++ b/docs/documentation/elements/box.html
@@ -11,7 +11,7 @@ breadcrumb:
 meta:
   colors: false
   sizes: false
-  variables: false
+  variables: true
 ---
 
 {% capture box_example %}


### PR DESCRIPTION
Hey there. I noticed that on the documentation page it says the box element does not support variables when it actually does.

<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **documentation fix**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution

<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

### Tradeoffs

<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->

### Testing Done

None.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

### Changelog updated?

No.

<!-- Thanks! -->
