### PR TITLE
Fix icon-text icon margin for rtl

### DIFF
--- a/sass/elements/icon.sass
+++ b/sass/elements/icon.sass
@@ -32,9 +32,15 @@ $icon-text-spacing: 0.25em !default
     flex-grow: 0
     flex-shrink: 0
     &:not(:last-child)
-      margin-right: $icon-text-spacing
+      +ltr
+        margin-right: $icon-text-spacing
+      +rtl
+        margin-left: $icon-text-spacing
     &:not(:first-child)
-      margin-left: $icon-text-spacing
+      +ltr
+        margin-left: $icon-text-spacing
+      +rtl
+        margin-right: $icon-text-spacing
 
 div.icon-text
   display: flex


### PR DESCRIPTION
This is a **improvement**.

### Proposed solution

This PR fixes icon-text icon margin for RTL.

### Tradeoffs

None.
 
### Testing Done

I ran `npm run rtll` and checked `css/bulma-rtl.min.css css/bulma-rtl.css` file.

### Changelog updated?

No.