### PR TITLE
Refactor shadow variables.

### DIFF
--- a/sass/components/card.sass
+++ b/sass/components/card.sass
@@ -2,7 +2,7 @@
 
 $card-color: $text !default
 $card-background-color: $scheme-main !default
-$card-shadow: $shadow
+$card-shadow: $shadow !default
 $card-radius: 0.25rem !default
 
 $card-header-background-color: transparent !default

--- a/sass/components/card.sass
+++ b/sass/components/card.sass
@@ -2,7 +2,7 @@
 
 $card-color: $text !default
 $card-background-color: $scheme-main !default
-$card-shadow: 0 0.5em 1em -0.125em rgba($scheme-invert, 0.1), 0 0px 0 1px rgba($scheme-invert, 0.02) !default
+$card-shadow: $shadow
 $card-radius: 0.25rem !default
 
 $card-header-background-color: transparent !default

--- a/sass/components/dropdown.sass
+++ b/sass/components/dropdown.sass
@@ -8,7 +8,7 @@ $dropdown-content-offset: 4px !default
 $dropdown-content-padding-bottom: 0.5rem !default
 $dropdown-content-padding-top: 0.5rem !default
 $dropdown-content-radius: $radius !default
-$dropdown-content-shadow: 0 0.5em 1em -0.125em rgba($scheme-invert, 0.1), 0 0px 0 1px rgba($scheme-invert, 0.02) !default
+$dropdown-content-shadow: $shadow
 $dropdown-content-z: 20 !default
 
 $dropdown-item-color: $text !default

--- a/sass/components/dropdown.sass
+++ b/sass/components/dropdown.sass
@@ -8,7 +8,7 @@ $dropdown-content-offset: 4px !default
 $dropdown-content-padding-bottom: 0.5rem !default
 $dropdown-content-padding-top: 0.5rem !default
 $dropdown-content-radius: $radius !default
-$dropdown-content-shadow: $shadow
+$dropdown-content-shadow: $shadow !default
 $dropdown-content-z: 20 !default
 
 $dropdown-item-color: $text !default

--- a/sass/components/panel.sass
+++ b/sass/components/panel.sass
@@ -3,7 +3,7 @@
 $panel-margin: $block-spacing !default
 $panel-item-border: 1px solid $border-light !default
 $panel-radius: $radius-large !default
-$panel-shadow: 0 0.5em 1em -0.125em rgba($scheme-invert, 0.1), 0 0px 0 1px rgba($scheme-invert, 0.02) !default
+$panel-shadow: $shadow
 
 $panel-heading-background-color: $border-light !default
 $panel-heading-color: $text-strong !default

--- a/sass/components/panel.sass
+++ b/sass/components/panel.sass
@@ -3,7 +3,7 @@
 $panel-margin: $block-spacing !default
 $panel-item-border: 1px solid $border-light !default
 $panel-radius: $radius-large !default
-$panel-shadow: $shadow
+$panel-shadow: $shadow !default
 
 $panel-heading-background-color: $border-light !default
 $panel-heading-color: $text-strong !default

--- a/sass/elements/box.sass
+++ b/sass/elements/box.sass
@@ -3,7 +3,7 @@
 $box-color: $text !default
 $box-background-color: $scheme-main !default
 $box-radius: $radius-large !default
-$box-shadow: 0 0.5em 1em -0.125em rgba($scheme-invert, 0.1), 0 0px 0 1px rgba($scheme-invert, 0.02) !default
+$box-shadow: $shadow
 $box-padding: 1.25rem !default
 
 $box-link-hover-shadow: 0 0.5em 1em -0.125em rgba($scheme-invert, 0.1), 0 0 0 1px $link !default

--- a/sass/elements/box.sass
+++ b/sass/elements/box.sass
@@ -3,7 +3,7 @@
 $box-color: $text !default
 $box-background-color: $scheme-main !default
 $box-radius: $radius-large !default
-$box-shadow: $shadow
+$box-shadow: $shadow !default
 $box-padding: 1.25rem !default
 
 $box-link-hover-shadow: 0 0.5em 1em -0.125em rgba($scheme-invert, 0.1), 0 0 0 1px $link !default

--- a/sass/utilities/derived-variables.sass
+++ b/sass/utilities/derived-variables.sass
@@ -99,6 +99,10 @@ $size-normal: $size-6 !default
 $size-medium: $size-5 !default
 $size-large: $size-4 !default
 
+// Effects
+
+$shadow: 0 0.5em 1em -0.125em rgba($scheme-invert, 0.1), 0 0px 0 1px rgba($scheme-invert, 0.02) !default
+
 // Lists and maps
 $custom-colors: null !default
 $custom-shades: null !default


### PR DESCRIPTION
This is an improvement.

### Proposed solution
Shadows for card, dropdown, panel and box are independently defined using the same value.
```sass
0 0.5em 1em -0.125em rgba($scheme-invert, 0.1), 0 0px 0 1px rgba($scheme-invert, 0.02) !default
```

This PR defines a base `$shadow` variable which the other components defaults to.

### Tradeoffs
None

### Testing Done
`npm run build` successful.

### Changelog updated?
No.