### PR TITLE
Fix expo link on the website's index page

### DIFF
--- a/docs/_includes/index/beautified.html
+++ b/docs/_includes/index/beautified.html
@@ -12,7 +12,7 @@
       See what Bulma developers are bulding
     </div>
 
-    <a class="button bd-fat-button is-expo is-light is-size-4-widescreen" href="{{ site.data.links.by_id.love.path }}">
+    <a class="button bd-fat-button is-expo is-light is-size-4-widescreen" href="{{ site.data.links.by_id.expo.path }}">
       <span class="icon has-text-expo">
         <i class="fas fa-star"></i>
       </span>


### PR DESCRIPTION
Link for expo link was pointing to the wrong page.

<!-- Choose one of the following: -->
This is a **documentation fix**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution

This PR fixes the link on the index page of [bulma.io](https://bulma.io) where the link for `bulma.io/expo` points to `bulma.io/love`

### Tradeoffs

N/A

### Changelog updated?

No.

