### PR TITLE
Fixed disabled file input (#3291)

### DIFF
--- a/sass/form/file.sass
+++ b/sass/form/file.sass
@@ -24,6 +24,18 @@ $file-colors: $form-colors !default
     $color: nth($pair, 1)
     $color-invert: nth($pair, 2)
     &.is-#{$name}
+      .file-input[disabled] ~
+        .file-cta
+          &:active,
+          &:focus,
+          &:hover,
+          &.is-active,
+          &.is-focused,
+          &.is-hovered
+            background-color: whitesmoke
+            border-color: whitesmoke
+            color: #7a7a7a
+
       .file-cta
         background-color: $color
         border-color: transparent
@@ -148,6 +160,17 @@ $file-colors: $form-colors !default
   position: absolute
   top: 0
   width: 100%
+  &[disabled] ~
+    .file-cta,
+    .file-name
+      background-color: whitesmoke
+      border-color: whitesmoke
+      color: #7a7a7a
+
+    .file-cta,
+    .file-cta .file-label,
+    .file-name
+      cursor: not-allowed
 
 .file-cta,
 .file-name


### PR DESCRIPTION
This is a **bugfix**.
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution
The current version doesn't make cursor and visual changes to file input button (`on disabled`) and it appears like the button hasn't been disabled.
This update fix the issue (also with the file-colors)

### Tradeoffs
none

### Testing Done
None.

### Changelog updated?
No.