### PR TITLE
[Add] explicit self-closing tags to inputs

### DIFF
--- a/docs/documentation/form/file.html
+++ b/docs/documentation/form/file.html
@@ -30,7 +30,7 @@ meta:
 {% capture file %}
 <div class="file">
   <label class="file-label">
-    <input class="file-input" type="file" name="resume">
+    <input class="file-input" type="file" name="resume" />
     <span class="file-cta">
       <span class="file-icon">
         <i class="fas fa-upload"></i>
@@ -46,7 +46,7 @@ meta:
 {% capture file_name %}
 <div class="file has-name">
   <label class="file-label">
-    <input class="file-input" type="file" name="resume">
+    <input class="file-input" type="file" name="resume" />
     <span class="file-cta">
       <span class="file-icon">
         <i class="fas fa-upload"></i>
@@ -65,7 +65,7 @@ meta:
 {% capture file_name_right %}
 <div class="file has-name is-right">
   <label class="file-label">
-    <input class="file-input" type="file" name="resume">
+    <input class="file-input" type="file" name="resume" />
     <span class="file-cta">
       <span class="file-icon">
         <i class="fas fa-upload"></i>
@@ -84,7 +84,7 @@ meta:
 {% capture file_name_fullwidth %}
 <div class="file has-name is-fullwidth">
   <label class="file-label">
-    <input class="file-input" type="file" name="resume">
+    <input class="file-input" type="file" name="resume" />
     <span class="file-cta">
       <span class="file-icon">
         <i class="fas fa-upload"></i>
@@ -103,7 +103,7 @@ meta:
 {% capture file_boxed %}
 <div class="file is-boxed">
   <label class="file-label">
-    <input class="file-input" type="file" name="resume">
+    <input class="file-input" type="file" name="resume" />
     <span class="file-cta">
       <span class="file-icon">
         <i class="fas fa-upload"></i>
@@ -119,7 +119,7 @@ meta:
 {% capture file_boxed_name %}
 <div class="file has-name is-boxed">
   <label class="file-label">
-    <input class="file-input" type="file" name="resume">
+    <input class="file-input" type="file" name="resume" />
     <span class="file-cta">
       <span class="file-icon">
         <i class="fas fa-upload"></i>
@@ -138,7 +138,7 @@ meta:
 {% capture file_colors_a %}
 <div class="file is-primary">
   <label class="file-label">
-    <input class="file-input" type="file" name="resume">
+    <input class="file-input" type="file" name="resume" />
     <span class="file-cta">
       <span class="file-icon">
         <i class="fas fa-upload"></i>
@@ -154,7 +154,7 @@ meta:
 {% capture file_colors_b %}
 <div class="file is-info has-name">
   <label class="file-label">
-    <input class="file-input" type="file" name="resume">
+    <input class="file-input" type="file" name="resume" />
     <span class="file-cta">
       <span class="file-icon">
         <i class="fas fa-upload"></i>
@@ -173,7 +173,7 @@ meta:
 {% capture file_colors_c %}
 <div class="file is-warning is-boxed">
   <label class="file-label">
-    <input class="file-input" type="file" name="resume">
+    <input class="file-input" type="file" name="resume" />
     <span class="file-cta">
       <span class="file-icon">
         <i class="fas fa-cloud-upload-alt"></i>
@@ -189,7 +189,7 @@ meta:
 {% capture file_colors_d %}
 <div class="file is-danger has-name is-boxed">
   <label class="file-label">
-    <input class="file-input" type="file" name="resume">
+    <input class="file-input" type="file" name="resume" />
     <span class="file-cta">
       <span class="file-icon">
         <i class="fas fa-cloud-upload-alt"></i>
@@ -208,7 +208,7 @@ meta:
 {% capture file_centered %}
 <div class="file is-centered is-boxed is-success has-name">
   <label class="file-label">
-    <input class="file-input" type="file" name="resume">
+    <input class="file-input" type="file" name="resume" />
     <span class="file-cta">
       <span class="file-icon">
         <i class="fas fa-upload"></i>
@@ -227,7 +227,7 @@ meta:
 {% capture file_right %}
 <div class="file is-right is-info">
   <label class="file-label">
-    <input class="file-input" type="file" name="resume">
+    <input class="file-input" type="file" name="resume" />
     <span class="file-cta">
       <span class="file-icon">
         <i class="fas fa-upload"></i>
@@ -246,7 +246,7 @@ meta:
 {% capture file_javascript %}
 <div id="file-js-example" class="file has-name">
   <label class="file-label">
-    <input class="file-input" type="file" name="resume">
+    <input class="file-input" type="file" name="resume" />
     <span class="file-cta">
       <span class="file-icon">
         <i class="fas fa-upload"></i>


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a improvement documentation fix.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution

<!-- Which specific problem does this PR solve and how?  -->
Add self-closing tags to inputs. Code snippets from current documentation doesn't work in React.
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

### Tradeoffs

<!-- What are the drawbacks of this solution? Are there alternative ones? -->
Instead of: ```<input>```
It should be: ```<input />```
<!-- Think of performance, build time, usability, complexity, coupling…) -->

### Testing Done

None.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

### Changelog updated?

No.

<!-- Thanks! -->
