### PR TITLE
Add until-widescreen/fullhd class generations for display, hidden and typography 

### DIFF
--- a/sass/helpers/typography.sass
+++ b/sass/helpers/typography.sass
@@ -26,6 +26,12 @@
 +fullhd
   +typography-size('fullhd')
 
++until-widescreen
+  +typography-size('until-widescreen')
+
++until-fullhd
+  +typography-size('until-fullhd')
+
 $alignments: ('centered': 'center', 'justified': 'justify', 'left': 'left', 'right': 'right')
 
 @each $alignment, $text-align in $alignments
@@ -59,6 +65,12 @@ $alignments: ('centered': 'center', 'justified': 'justify', 'left': 'left', 'rig
       text-align: #{$text-align} !important
   +fullhd
     .has-text-#{$alignment}-fullhd
+      text-align: #{$text-align} !important
+  +until-widescreen
+    .has-text-#{$alignment}-until-widescreen
+      text-align: #{$text-align} !important
+  +until-fullhd
+    .has-text-#{$alignment}-until-fullhd
       text-align: #{$text-align} !important
 
 .is-capitalized

--- a/sass/helpers/visibility.sass
+++ b/sass/helpers/visibility.sass
@@ -1,6 +1,6 @@
 @import "../utilities/mixins"
 
-$displays: 'block' 'flex' 'inline' 'inline-block' 'inline-flex' 'hidden'
+$displays: 'block' 'flex' 'inline' 'inline-block' 'inline-flex'
 
 @each $display in $displays
   .is-#{$display}
@@ -51,6 +51,50 @@ $displays: 'block' 'flex' 'inline' 'inline-block' 'inline-flex' 'hidden'
   position: absolute !important
   white-space: nowrap !important
   width: 0.01em !important
+
++mobile
+  .is-hidden-mobile
+    display: none !important
+
++tablet
+  .is-hidden-tablet
+    display: none !important
+
++tablet-only
+  .is-hidden-tablet-only
+    display: none !important
+
++touch
+  .is-hidden-touch
+    display: none !important
+
++desktop
+  .is-hidden-desktop
+    display: none !important
+
++desktop-only
+  .is-hidden-desktop-only
+    display: none !important
+
++widescreen
+  .is-hidden-widescreen
+    display: none !important
+
++widescreen-only
+  .is-hidden-widescreen-only
+    display: none !important
+
++fullhd
+  .is-hidden-fullhd
+    display: none !important
+
++until-widescreen
+  .is-hidden-until-widescreen
+    display: none !important
+
++until-fullhd
+  .is-hidden-until-fullhd
+    display: none !important
 
 .is-invisible
   visibility: hidden !important

--- a/sass/helpers/visibility.sass
+++ b/sass/helpers/visibility.sass
@@ -1,6 +1,6 @@
 @import "../utilities/mixins"
 
-$displays: 'block' 'flex' 'inline' 'inline-block' 'inline-flex'
+$displays: 'block' 'flex' 'inline' 'inline-block' 'inline-flex' 'hidden'
 
 @each $display in $displays
   .is-#{$display}
@@ -32,6 +32,12 @@ $displays: 'block' 'flex' 'inline' 'inline-block' 'inline-flex'
   +fullhd
     .is-#{$display}-fullhd
       display: #{$display} !important
+  +until-widescreen
+    .is-#{$display}-until-widescreen
+      display: #{$display} !important
+  +until-fullhd
+    .is-#{$display}-until-fullhd
+      display: #{$display} !important
 
 .is-hidden
   display: none !important
@@ -45,42 +51,6 @@ $displays: 'block' 'flex' 'inline' 'inline-block' 'inline-flex'
   position: absolute !important
   white-space: nowrap !important
   width: 0.01em !important
-
-+mobile
-  .is-hidden-mobile
-    display: none !important
-
-+tablet
-  .is-hidden-tablet
-    display: none !important
-
-+tablet-only
-  .is-hidden-tablet-only
-    display: none !important
-
-+touch
-  .is-hidden-touch
-    display: none !important
-
-+desktop
-  .is-hidden-desktop
-    display: none !important
-
-+desktop-only
-  .is-hidden-desktop-only
-    display: none !important
-
-+widescreen
-  .is-hidden-widescreen
-    display: none !important
-
-+widescreen-only
-  .is-hidden-widescreen-only
-    display: none !important
-
-+fullhd
-  .is-hidden-fullhd
-    display: none !important
 
 .is-invisible
   visibility: hidden !important


### PR DESCRIPTION
This is a **improvement**.
In the responsive documentation there is a **until-widescreen** and **until-fullhd** but there were no classes for responsive typography/display for this breakpoints.

### Proposed solution
This PR add is-**block|flex|inline|hidden**-until-breakpoint classes also the same classes for has-text and is-size typegraphy


### Tradeoffs

None that I can think of

### Testing Done

Tested the classes using a css generated from the build on the branch.

- tested is-hidden-until-widescreen/fullhd
- tested is-size-X-until-widescreen/fullhd
- tested has-text-X-until-widescreen/fullhd

### Changelog updated?
No

