### PR TITLE
add missing semi-colon to css import commands

### DIFF
--- a/docs/documentation/overview/start.html
+++ b/docs/documentation/overview/start.html
@@ -44,7 +44,7 @@ breadcrumb:
       </p>
 
       {% capture jsdelivr_a %}
-        {% highlight css %}@import "https://cdn.jsdelivr.net/npm/bulma@{{ site.data.meta.version }}/css/bulma.min.css"{% endhighlight %}
+        {% highlight css %}@import "https://cdn.jsdelivr.net/npm/bulma@{{ site.data.meta.version }}/css/bulma.min.css;"{% endhighlight %}
       {% endcapture %}
 
       {% capture jsdelivr_b %}
@@ -64,7 +64,7 @@ breadcrumb:
       </p>
 
       {% capture jsdelivr_rtl_a %}
-        {% highlight css %}@import "https://cdn.jsdelivr.net/npm/bulma@{{ site.data.meta.version }}/css/bulma-rtl.min.css"{% endhighlight %}
+        {% highlight css %}@import "https://cdn.jsdelivr.net/npm/bulma@{{ site.data.meta.version }}/css/bulma-rtl.min.css;"{% endhighlight %}
       {% endcapture %}
 
       {% capture jsdelivr_rtl_b %}

--- a/docs/documentation/overview/start.html
+++ b/docs/documentation/overview/start.html
@@ -44,7 +44,7 @@ breadcrumb:
       </p>
 
       {% capture jsdelivr_a %}
-        {% highlight css %}@import "https://cdn.jsdelivr.net/npm/bulma@{{ site.data.meta.version }}/css/bulma.min.css;"{% endhighlight %}
+        {% highlight css %}@import "https://cdn.jsdelivr.net/npm/bulma@{{ site.data.meta.version }}/css/bulma.min.css";{% endhighlight %}
       {% endcapture %}
 
       {% capture jsdelivr_b %}
@@ -64,7 +64,7 @@ breadcrumb:
       </p>
 
       {% capture jsdelivr_rtl_a %}
-        {% highlight css %}@import "https://cdn.jsdelivr.net/npm/bulma@{{ site.data.meta.version }}/css/bulma-rtl.min.css;"{% endhighlight %}
+        {% highlight css %}@import "https://cdn.jsdelivr.net/npm/bulma@{{ site.data.meta.version }}/css/bulma-rtl.min.css";{% endhighlight %}
       {% endcapture %}
 
       {% capture jsdelivr_rtl_b %}


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a self-explanatory  **documentation fix**.