### PR TITLE
Fixes #3315 Add has-shadow to navbar documentation

### DIFF
--- a/docs/documentation/components/navbar.html
+++ b/docs/documentation/components/navbar.html
@@ -1292,6 +1292,11 @@ $(document).ready(function() {
           <br> <strong>Left</strong> and <strong>Right</strong> paddings with <strong>2rem</strong>
       </td>
     </tr>
+    <tr>
+      <th rowspan="1">Shading</th>
+      <td><code>has-shadow</code></td>
+      <td>Adds a small amount of box-shadow around the navbar</td>
+    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
This is a **documentation fix**.

See issue #3315 

### Proposed solution

Adds a line mentioning the `has-shadow` helper class to the Navbar Helper Classes table.

Screenshot:

![image](https://user-images.githubusercontent.com/19559137/120434900-06dc5a80-c34b-11eb-8075-c58220dabca0.png)



### Tradeoffs

No tradeoffs. Short and sweet to let people know the helper class exists.

### Testing Done

None, other than spinning up the docs with Jekyll.

Docs were updated when Jekyll spun up the docs app with the changes.

### Changelog updated?

No.
