### PR TITLE
Add underline helper

### DIFF
--- a/sass/helpers/typography.sass
+++ b/sass/helpers/typography.sass
@@ -72,6 +72,9 @@ $alignments: ('centered': 'center', 'justified': 'justify', 'left': 'left', 'rig
 
 .is-italic
   font-style: italic !important
+  
+.is-underlined
+  text-decoration: underline !important
 
 .has-text-weight-light
   font-weight: $weight-light !important


### PR DESCRIPTION
This is a **new feature**.

### Proposed solution
I found that there is a helper class for italics, but not for underlines. I think such a simple helper should be available, for example to use on simple anchor tags. You simply add `is-underlined` to it and you'll get a fancy line under it.

### Tradeoffs
Can't think of any, please let me now if there are any.

### Testing Done
None. This'll work ;)

### Changelog updated?
Soon
