### PR TITLE
Add underline helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Bulma Changelog
 
+## 0.9.3
+
+### New features
+
+- New `is-underlined` class for underlined text and links
+
 ## 0.9.2
 
 ### Breaking change

--- a/sass/helpers/typography.sass
+++ b/sass/helpers/typography.sass
@@ -72,6 +72,9 @@ $alignments: ('centered': 'center', 'justified': 'justify', 'left': 'left', 'rig
 
 .is-italic
   font-style: italic !important
+  
+.is-underlined
+  text-decoration: underline !important
 
 .has-text-weight-light
   font-weight: $weight-light !important


### PR DESCRIPTION
This is a **new feature**.

### Proposed solution
I found that there is a helper class for italics, but not for underlines. I think such a simple helper should be available, for example to use on simple anchor tags. You simply add `is-underlined` to it and you'll get a fancy line under it.

### Tradeoffs
Can't think of any, please let me now if there are any.

### Testing Done
Tested it locally. Works like a charm!

![image](https://user-images.githubusercontent.com/15019582/120543113-38593280-c3ec-11eb-839e-f979d755695e.png)

```html
<section class="section content">
  <h1 class="is-underlined">Header</h1>
  <p class="is-underlined">Normal paragraph</p>
  <a href="#" class="is-underlined">Anchor tag</a>
</section>
```

### Changelog updated?
Yes, added to version 0.9.3