### PR TITLE
Round the top corners on .panel-block:first-child

### DIFF
--- a/sass/components/panel.sass
+++ b/sass/components/panel.sass
@@ -102,6 +102,9 @@ $panel-colors: $colors !default
     color: $panel-block-active-color
     .panel-icon
       color: $panel-block-active-icon-color
+  &:first-child
+    border-top-left-radius: $panel-radius
+    border-top-right-radius: $panel-radius
   &:last-child
     border-bottom-left-radius: $panel-radius
     border-bottom-right-radius: $panel-radius


### PR DESCRIPTION
When there is no `.panel-heading` present, round the top corners of the first `.panel-block`.

<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

This is an improvement.

### Proposed solution

Add `border-top-left-radius` and `border-top-right-radius` rules to `.panel-block:first-child`.

### Tradeoffs

None.  Lets you create a `.panel` without a `.panel-heading`.

### Testing Done

Yes, in a project I'm working on now.

**Before**

![Top corners before](https://user-images.githubusercontent.com/19495149/121189997-9f397a00-c838-11eb-8e27-1f9c5525021d.png)

**After**

![Top Corners After](https://user-images.githubusercontent.com/19495149/121190046-a95b7880-c838-11eb-9b3a-9106d31e5199.png)

### Changelog updated?

No.
