### PR TITLE
Fixes #3316 | fixes $custom-shades

### DIFF
--- a/sass/helpers/color.sass
+++ b/sass/helpers/color.sass
@@ -33,6 +33,8 @@
       background-color: $color-dark !important
 
 @each $name, $shade in $shades
+  @if type-of($shade) == "list"
+     $shade: nth($shade, 1)
   .has-text-#{$name}
     color: $shade !important
   .has-background-#{$name}

--- a/sass/utilities/derived-variables.sass
+++ b/sass/utilities/derived-variables.sass
@@ -109,6 +109,6 @@ $custom-shades: null !default
 
 $colors: mergeColorMaps(("white": ($white, $black), "black": ($black, $white), "light": ($light, $light-invert), "dark": ($dark, $dark-invert), "primary": ($primary, $primary-invert, $primary-light, $primary-dark), "link": ($link, $link-invert, $link-light, $link-dark), "info": ($info, $info-invert, $info-light, $info-dark), "success": ($success, $success-invert, $success-light, $success-dark), "warning": ($warning, $warning-invert, $warning-light, $warning-dark), "danger": ($danger, $danger-invert, $danger-light, $danger-dark)), $custom-colors) !default
 
-$shades: mergeColorMaps(("black-bis": $black-bis, "black-ter": $black-ter, "grey-darker": $grey-darker, "grey-dark": $grey-dark, "grey": $grey, "grey-light": $grey-light, "grey-lighter": $grey-lighter, "white-ter": $white-ter, "white-bis": $white-bis), $custom-shades) !default
+$shades: mergeColorMaps(("black-bis": $black-bis, "black-ter": $black-ter, "grey-darker": $grey-darker, "grey-dark": $grey-dark, "grey": $grey, "grey-light": $grey-light, "grey-lighter": $grey-lighter, "grey-lightest": $grey-lightest, "white-ter": $white-ter, "white-bis": $white-bis), $custom-shades) !default
 
 $sizes: $size-1 $size-2 $size-3 $size-4 $size-5 $size-6 $size-7 !default


### PR DESCRIPTION
This is a bug fix.

Issue: https://github.com/jgthms/bulma/issues/3316

### Proposed solution

It fixes 1 issue, and adds 1 improvement.

#### The issue:

You can read about the issue here: https://github.com/jgthms/bulma/issues/3316, but the tldr is that the function `mergeColorMaps` wasnt working properly when used with `$shades` and `$custom-shades`.

The function was merging a list for custom shades: `$value: ($color-base, $color-invert, $color-light, $color-dark)`.
So, when it was used in `colors.sass`, and the list was the value of the `background` property, it was breaking.

```
@each $name, $shade in $shades
  .has-text-#{$name}
    color: $shade !important
  .has-background-#{$name}
    background-color: $shade !important
```

The proposed solution is to leave the function `mergeColorMaps` as is, but to take into account that the values could be lists when using it with $shades.

```
@each $name, $shade in $shades
  // NEW
  @if type-of($shade) == "list"
     $shade: nth($shade, 1)

  .has-text-#{$name}
    color: $shade !important
  .has-background-#{$name}
    background-color: $shade !important
```

#### Improvement

Another tiny improvement is the addition of `$grey-lightest` in `$shades`. My guess is that it was an involuntary omission, but if it wasn't I can simply revert that change.

### Tradeoffs

No trade-offs.

### Testing Done

I tested that the generated classes for $custom-shades work properly. I also checked that the classes generated for the default $shades work too.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->

I tested that the generated classes for $custom-shades work properly in my own project by modifying the code in node_modules directly. I also checked that the classes generated for the default $shades work too.

### Changelog updated?

No.

Thanks!
