### PR TITLE
Form groups can have fields as children

### DIFF
--- a/sass/form/tools.sass
+++ b/sass/form/tools.sass
@@ -94,6 +94,10 @@ $label-colors: $form-colors !default
   &.is-grouped
     display: flex
     justify-content: flex-start
+    & > .field
+      &:not(:last-child)
+        margin-bottom: 0
+        +ltr-property("margin", 0.75rem)
     & > .control
       flex-shrink: 0
       &:not(:last-child)


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is an **improvement**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution

The basic form group capability does not space a Form group that has `.field`s as direct children, only `.control`s. This improvement allows one to also use addons on the form elements that are grouped together. The following markup would work for example:
```
<div class="field is-grouped">
  <div class="field has-addons">
    <div class="control">  
      <input class="input" id="expense_type_" name="expense_type[]" type="text">
    </div>
    <div class="control">
      <button type="submit" class="button is-primary">Search</button>
    </div>
  </div>
  <div class="field">
    <div class="control">  
      <button type="submit" class="button is-primary">Clear</button>
    </div>
  </div>
</div>
```

<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

### Tradeoffs

<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->

### Testing Done

Visual.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

### Changelog updated?

No.

<!-- Thanks! -->
