### PR TITLE
Remove auto padding spacing helpers

### DIFF
--- a/sass/helpers/spacing.sass
+++ b/sass/helpers/spacing.sass
@@ -12,20 +12,23 @@ $spacing-values: ("0": 0, "1": 0.25rem, "2": 0.5rem, "3": 0.75rem, "4": 1rem, "5
 
 @each $property, $shortcut in $spacing-shortcuts
   @each $name, $value in $spacing-values
-    // All directions
-    .#{$shortcut}-#{$name}
-      #{$property}: $value !important
-    // Cardinal directions
-    @each $direction, $suffix in $spacing-directions
-      .#{$shortcut}#{$suffix}-#{$name}
-        #{$property}-#{$direction}: $value !important
-    // Horizontal axis
-    @if $spacing-horizontal != null
-      .#{$shortcut}#{$spacing-horizontal}-#{$name}
-        #{$property}-left: $value !important
-        #{$property}-right: $value !important
-    // Vertical axis
-    @if $spacing-vertical != null
-      .#{$shortcut}#{$spacing-vertical}-#{$name}
-        #{$property}-top: $value !important
-        #{$property}-bottom: $value !important
+    @if $property == 'padding' and $value == 'auto'
+      // Exclude padding value auto
+    @else
+      // All directions
+      .#{$shortcut}-#{$name}
+        #{$property}: $value !important
+      // Cardinal directions
+      @each $direction, $suffix in $spacing-directions
+        .#{$shortcut}#{$suffix}-#{$name}
+          #{$property}-#{$direction}: $value !important
+      // Horizontal axis
+      @if $spacing-horizontal != null
+        .#{$shortcut}#{$spacing-horizontal}-#{$name}
+          #{$property}-left: $value !important
+          #{$property}-right: $value !important
+      // Vertical axis
+      @if $spacing-vertical != null
+        .#{$shortcut}#{$spacing-vertical}-#{$name}
+          #{$property}-top: $value !important
+          #{$property}-bottom: $value !important


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **bugfix**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->
I came across this issue while working on https://github.com/jgthms/bulma/pull/3184
The bulma css output contains spacing helpers for padding with the value of 'auto'.
This is not a valid value, as it should be either a length or a percentage.

### Proposed solution

This pull request makes sure that the spacing SASS skips spacing helper generation for auto padding spacing helpers. I'm not 100% convinced that this is the cleanest solution, so I'm of course open to improvements.
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

### Tradeoffs

None
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->

### Testing Done

Build works, outputs are identical, with the exception of the invalid helpers.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

### Changelog updated?

No.

<!-- Thanks! -->
