### PR TITLE
Improve catagories menu scrolling

### DIFF
--- a/docs/_sass/components/categories.scss
+++ b/docs/_sass/components/categories.scss
@@ -34,6 +34,8 @@
 
   padding: var(--docs-side-padding);
   position: sticky;
+  height: 100vh;
+  overflow: hidden;
   top: 0;
 
   &.bd-has-query {


### PR DESCRIPTION
Scrolling through the categories menu, especially on long documentation pages, is very difficult. Allowing overflowing content to scroll will allow users to browser the menu without the need to scroll down to the bottom of the page (or top) to see all items.

This is a **improvement**.

### Proposed solution

- Set the categories menu overflow to scrolling.
- Set the height of the categories menu to 100vh to ensure it scrolls correctly (and so everything can be seen).

### Tradeoffs

There shouldn't be many major tradeoffs. Everything seems to be working fine on desktop and mobile devices.

### Testing Done

Tested on desktop browser (Firefox/Chrome) and mobile browser (Safari).

### Changelog updated?

No.

<!-- Thanks! -->
