### PR TITLE
Replace disabled attr on pagination anchor elements with is-disabled …

### DIFF
--- a/docs/documentation/components/pagination.html
+++ b/docs/documentation/components/pagination.html
@@ -46,7 +46,7 @@ meta:
 
 {% capture pagination_options_example %}
 <nav class="pagination" role="navigation" aria-label="pagination">
-  <a class="pagination-previous" title="This is the first page" disabled>Previous</a>
+  <a class="pagination-previous is-disabled" title="This is the first page">Previous</a>
   <a class="pagination-next">Next page</a>
   <ul class="pagination-list">
     <li>

--- a/sass/components/pagination.sass
+++ b/sass/components/pagination.sass
@@ -88,7 +88,8 @@ $pagination-shadow-inset: inset 0 1px 2px rgba($scheme-invert, 0.2) !default
     border-color: $pagination-focus-border-color
   &:active
     box-shadow: $pagination-shadow-inset
-  &[disabled]
+  &[disabled],
+  &.is-disabled
     background-color: $pagination-disabled-background-color
     border-color: $pagination-disabled-border-color
     box-shadow: none


### PR DESCRIPTION
…class (#3296)

<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **bugfix**.
#3296

### Proposed solution

Since the `disabled` boolean attribute is not valid on an anchor element, we extend the &[disabled] selector to include &.is-disabled. The docs are updated, with the **invalid HTML replaced**. This is not a breaking change, because the original selector is still in place.

### Tradeoffs

The only drawback I can think of is that the `disabled` is still used in other places in the framework (since it is valid on `button` tags), there is a slightly higher cognitive load on devs. However, ability to write compliant HTML would seem to outweight this.

Possibly, maintainers could consider whether `.is-disabled` can be used as an alternative throughout the entire framework as a utility class. 

### Testing Done

I'm currently building a gatsby site with Bulma and I tested that I can use this class via building the project and symlinking Bulma.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

### Changelog updated?

No.

<!-- Thanks! -->
