### PR TITLE
Fix stray end tags on website

### DIFF
--- a/docs/_includes/global/navbar-start.html
+++ b/docs/_includes/global/navbar-start.html
@@ -62,7 +62,6 @@
               </div>
               {{ link.subtitle }}
             </div>
-          </span>
         </a>
         {% unless forloop.last %}
           <hr class="navbar-divider {% if forloop.first %}{% endif %}">

--- a/docs/_layouts/documentation.html
+++ b/docs/_layouts/documentation.html
@@ -61,5 +61,5 @@ route: documentation
     {% endif %}
 
     {% include components/anchors.html %}
-  </aide>
+  </aside>
 </div>


### PR DESCRIPTION
Noticed that `</aside>` was misspelled as `</aide>`. Also removed a `</span>` with no opening tag.