### PR TITLE
Fix path to style property in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "description": "Modern CSS framework based on Flexbox",
   "main": "bulma.sass",
   "unpkg": "css/bulma.css",
-  "style": "bulma/css/bulma.min.css",
+  "style": "css/bulma.min.css",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/jgthms/bulma.git"


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **bugfix**.

### Proposed solution

Fix the path to the `bulma.min.css` file in the `package.json`'s `style` property. Happens to fix usage with [ViteJs](https://vitejs.dev/)

### Changelog updated?

No.

<!-- Thanks! -->
