### PR TITLE
Update with-sass-cli.html

### DIFF
--- a/docs/documentation/customize/with-sass-cli.html
+++ b/docs/documentation/customize/with-sass-cli.html
@@ -64,11 +64,11 @@ Sass 3.5.3 (Bleeding Edge)
 {% endcapture %}
 
 {% capture build_sass %}
-sass --sourcemap=none sass/mystyles.scss:css/mystyles.css
+sass sass/mystyles.scss:css/mystyles.css
 {% endcapture %}
 
 {% capture watch_sass %}
-sass --watch --sourcemap=none sass/mystyles.scss:css/mystyles.css
+sass --watch sass/mystyles.scss:css/mystyles.css
 {% endcapture %}
 
 {% capture step_5 %}


### PR DESCRIPTION
Using flag option "source-map" results in error using sass --version 1.43.3

Expected: "Watch" and "Build" process of sass to run without errors.
What Actually Happens: The console throws an error: flag option "source-map" should not be given a value. 
Solution: When running the command for "Watch" and "Build" remove the flag option "source-map"

<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a  documentation fix.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution

<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

### Tradeoffs

<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->

### Testing Done

None.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

### Changelog updated?

No.

<!-- Thanks! -->
