### PR TITLE
Fixes #3437

### DIFF
--- a/sass/components/tabs.sass
+++ b/sass/components/tabs.sass
@@ -94,10 +94,7 @@ $tabs-toggle-link-active-color: $link-invert !default
   &.is-boxed
     a
       border: 1px solid transparent
-      +ltr
-        border-radius: $tabs-boxed-link-radius $tabs-boxed-link-radius 0 0
-      +rtl
-        border-radius: 0 0 $tabs-boxed-link-radius $tabs-boxed-link-radius
+      border-radius: $tabs-boxed-link-radius $tabs-boxed-link-radius 0 0
       &:hover
         background-color: $tabs-boxed-link-hover-background-color
         border-bottom-color: $tabs-boxed-link-hover-border-bottom-color


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a bugfix.
<!-- Bugfix? Reference that issue as well. -->
Bugfix of issue #3437

### Proposed solution

<!-- Which specific problem does this PR solve and how?  -->
As I mentioned it in the referenced issue, it's better to have only a single border-radius for both **RLT** and **LTR** versions.
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

### Tradeoffs

<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->
The intension of this fix is to remove duplication of `border-radius` and it sure makes a performance improvement.

### Testing Done
Demonstration of fix, tested on chrome Version 91.0.4472.114 (Official Build) (64-bit):
![Screenshot-20211101161401-1201x555](https://user-images.githubusercontent.com/53313989/139676891-1c26c047-15c0-4fe9-85cc-4ba3104c8aab.png)

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

**How have you confirmed this feature works?**
<!-- Please explain more than "Yes". -->
Yes, this bug fix works prefectly with the master branch and have been tested on Chrome browser, And demonstrated with screenshots, And I thank you all for taking time to review this pull request.
### Changelog updated?

No.

<!-- Thanks! -->