### PR TITLE
Add missing variables for content customization

### DIFF
--- a/sass/elements/content.sass
+++ b/sass/elements/content.sass
@@ -4,6 +4,8 @@ $content-heading-color: $text-strong !default
 $content-heading-weight: $weight-semibold !default
 $content-heading-line-height: 1.125 !default
 
+$content-block-margin-bottom: 1em !default
+
 $content-blockquote-background-color: $background !default
 $content-blockquote-border-left: 5px solid $border !default
 $content-blockquote-padding: 1.25em 1.5em !default
@@ -16,6 +18,7 @@ $content-table-cell-padding: 0.5em 0.75em !default
 $content-table-cell-heading-color: $text-strong !default
 $content-table-head-cell-border-width: 0 0 2px !default
 $content-table-head-cell-color: $text-strong !default
+$content-table-body-last-row-cell-border-bottom-width: 0 !default
 $content-table-foot-cell-border-width: 2px 0 0 !default
 $content-table-foot-cell-color: $text-strong !default
 
@@ -33,7 +36,7 @@ $content-table-foot-cell-color: $text-strong !default
   pre,
   table
     &:not(:last-child)
-      margin-bottom: 1em
+      margin-bottom: $content-block-margin-bottom
   h1,
   h2,
   h3,
@@ -144,7 +147,7 @@ $content-table-foot-cell-color: $text-strong !default
         &:last-child
           td,
           th
-            border-bottom-width: 0
+            border-bottom-width: $content-table-body-last-row-cell-border-bottom-width
   .tabs
     li + li
       margin-top: 0


### PR DESCRIPTION
<!-- Choose one of the following: -->
This is a **improvement**.
<!-- Improvement? Explain how and why. -->
This introduces 2 variables to customize some parts of the `<table>` in "content"

### Proposed solution

<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->
This introduces 2 variables to customize some parts of the `<table>` in "content":
  * `$content-block-margin-bottom`: To customize bottom margin of "block" elements (especially tables in our case)
  * `$content-table-body-last-row-cell-border-bottom-width`: To customize the size of the bottom border of the body last row cells

As I'm not completely familiar with your naming conventions, variables name might be renamed, just let me know.

### Tradeoffs

<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->
I don't think there is any tradeoff.

### Testing Done

  * Checked contributing guide
  * Modified .sass file locally
  * Compiled without vars overload => Ok, same style as before
  * Compiled with vars overload => Ok, expected style for me

### Changelog updated?

No.

<!-- Thanks! -->
