### PR TITLE
Docs update for gap.html

### DIFF
--- a/docs/documentation/columns/gap.html
+++ b/docs/documentation/columns/gap.html
@@ -111,9 +111,9 @@ breadcrumb:
 
 <div class="content">
   <p>
-    Each column has a <strong>gap</strong> equal to the <strong>variable</strong> <code>$column-gap</code>, which has a default value of <code>0.75rem</code>.
+    Each box has a <strong>gap</strong> equal to the <strong>variable</strong> <code>$column-gap</code>, which has a default value of <code>0.75rem</code>.
     <br>
-    Since the gap is on <em>each side</em> of a column, the gap between two adjacent columns will be twice the value of <code>$column-gap</code>, or <code>1.5rem</code> by default.
+    Since the gap is on <em>each side</em> of a box element, the gap between two boxes within adjacent columns containers will be twice the value of <code>$column-gap</code>, or <code>1.5rem</code> by default.
   </p>
 </div>
 
@@ -123,7 +123,7 @@ breadcrumb:
 
 <div class="content">
   <p>
-    If you want to remove the <strong>space</strong> between the columns, add the <code>is-gapless</code> modifier on the <code>columns</code> container:
+    If you want to remove the <strong>space</strong> between the boxes, add the <code>is-gapless</code> modifier on the <code>columns</code> container:
   </p>
 </div>
 


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **documentation fix**.
<!-- Improvement? Explain how and why. -->
Clarity and intent. Nowhere in the docs does it say you actually apply the gap to the **child of the column element**, which is usually some class of _box_.

### Proposed solution
I want to make it clear to other people starting out with Bulma that the border is actually applied to a child of _column,_ which is usually a _box_ of some kind.
There have been other people who have reported bugs or discussed this documentation:
https://github.com/jgthms/bulma/issues/2095
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

### Changelog updated?

No.

<!-- Thanks! -->
