### PR TITLE
Fix typo anchor tag on modal documentation

### DIFF
--- a/docs/documentation/components/modal.html
+++ b/docs/documentation/components/modal.html
@@ -169,7 +169,7 @@ document.addEventListener('DOMContentLoaded', () => {
     JavaScript implementation example
   </div>
   <div class="message-body">
-    Bulma does not include any JavaScript. However, this documentation provides a <a href="#javascript-implementation-pexample">JS implementation example</a> that you are free to use.
+    Bulma does not include any JavaScript. However, this documentation provides a <a href="#javascript-implementation-example">JS implementation example</a> that you are free to use.
   </div>
 </div>
 


### PR DESCRIPTION
This is a **documentation fix**.
It's just a small typo on modal documentation. The `javascript-implementation-pexample` anchor tag should be `javascript-implementation-example`.