### PR TITLE
Display the result of using text transformers

### DIFF
--- a/docs/documentation/helpers/typography-helpers.html
+++ b/docs/documentation/helpers/typography-helpers.html
@@ -320,7 +320,7 @@ breadcrumb:
   <tbody>
   <tr>
     <td><code>is-capitalized</code></td>
-    <td>Transforms <strong>the first character</strong> of each word to <strong>uppercase</strong></td>
+    <td>Transforms <strong>the first character</strong> of each word to <strong>Uppercase</strong></td>
   </tr>
   <tr>
     <td><code>is-lowercase</code></td>
@@ -328,15 +328,15 @@ breadcrumb:
   </tr>
   <tr>
     <td><code>is-uppercase</code></td>
-    <td>Transforms <strong>all characters</strong> to <strong>uppercase</strong></td>
+    <td>Transforms <strong>all characters</strong> to <strong>UPPERCASE</strong></td>
   </tr>
   <tr>
     <td><code>is-italic</code></td>
-    <td>Transforms <strong>all characters</strong> to <strong>italic</strong></td>
+    <td>Transforms <strong>all characters</strong> to <strong class="is-italic">italic</strong></td>
   </tr>
   <tr>
     <td>{% include elements/new-tag.html version="0.9.3" %}<code>is-underlined</code></td>
-    <td><strong>Underlines</strong> the text</td>
+    <td><strong class="is-underlined">Underlines</strong> the text</td>
   </tr>
   </tbody>
 </table>


### PR DESCRIPTION
This is a **documentation fix**.

### Proposed solution

Instead of showing all the transformed text as bold (default styling of `<strong>`) it might be better to use the appropriate class name to show the effect of using that class.

### Testing Done

None.

### Changelog updated?

No.