### PR TITLE
Typo: Missing "and"

### DIFF
--- a/docs/documentation/utilities/control-mixins.html
+++ b/docs/documentation/utilities/control-mixins.html
@@ -60,7 +60,7 @@ breadcrumb:
 
 <div class="content">
   <p>
-    Controls have a default font size of <code>$size-normal</code> also come in <strong>3 additional sizes</strong>, which can be accessed via 3 additional mixins:
+    Controls have a default font size of <code>$size-normal</code> and also come in <strong>3 additional sizes</strong>, which can be accessed via 3 additional mixins:
   </p>
 
   <ul>


### PR DESCRIPTION
This is a **documentation fix**.

### Proposed solution

There was just a typo.

### Testing Done

None.

### Changelog updated?

No.