### PR TITLE
Fix table modifiers for nested table

### DIFF
--- a/sass/elements/table.sass
+++ b/sass/elements/table.sass
@@ -93,37 +93,40 @@ $table-colors: $colors !default
           border-bottom-width: 0
   // Modifiers
   &.is-bordered
-    td,
-    th
-      border-width: 1px
-    tr
-      &:last-child
-        td,
-        th
-          border-bottom-width: 1px
-  &.is-fullwidth
-    width: 100%
+        > tbody
+            > tr
+                > td,
+                > th
+                    border-width: 1px
+            > tr
+                &:last-child
+                    > td,
+                    > th
+                        border-bottom-width: 1px
   &.is-hoverable
-    tbody
-      tr:not(.is-selected)
-        &:hover
-          background-color: $table-row-hover-background-color
-    &.is-striped
-      tbody
-        tr:not(.is-selected)
-          &:hover
-            background-color: $table-row-hover-background-color
-            &:nth-child(even)
-              background-color: $table-striped-row-even-hover-background-color
+      > tbody
+          > tr:not(.is-selected)
+              &:hover
+                  background-color: $table-row-hover-background-color
+      &.is-striped
+          > tbody
+              > tr:not(.is-selected)
+                  &:hover
+                      background-color: $table-row-hover-background-color
+                      &:nth-child(even)
+                          background-color: $table-striped-row-even-hover-background-color
   &.is-narrow
-    td,
-    th
-      padding: 0.25em 0.5em
+      > tbody,
+          > tr
+              > td,
+              > th
+                  padding: 0.25em 0.5em
   &.is-striped
-    tbody
-      tr:not(.is-selected)
-        &:nth-child(even)
-          background-color: $table-striped-row-even-background-color
+      > tbody
+          > tr:not(.is-selected)
+              &:nth-child(even)
+                  background-color: $table-striped-row-even-background-color
+
 
 .table-container
   @extend %block


### PR DESCRIPTION
This is a improvement.
For nested <table><table></table></table>, when you apply modifier to the parent table, the child table also change behavor.

### Proposed solution
Before: .table.modifier tbody tr td 
After: .table.modifier > tbody > tr >td

### Tradeoffs
In the future <table> tag with ".is-bordered" and ".is-narrow" modifiers must always contain <tbody>.
The same as ".is-hoverable" and ".is-stipped" currently.

### Testing Done
Tested on Laravel project with mix.

### Changelog updated?
No.