### PR TITLE
Fixes #3383 ('Variables' sections on docs page)

### DIFF
--- a/docs/_includes/components/variables.html
+++ b/docs/_includes/components/variables.html
@@ -15,7 +15,7 @@
 
 {% if variables_size != '0' or variables_keys_size != '0' %}
   <div class="bd-vars">
-    {% include elements/anchor.html name="Variables" %}
+    {% include elements/anchor.html name=anchor_name %}
 
     <div class="bd-var bd-is-head">
       <div class="bd-var-name">

--- a/docs/_sass/components/variables.scss
+++ b/docs/_sass/components/variables.scss
@@ -16,6 +16,10 @@
   }
 }
 
+.bd-vars + .bd-vars {
+  margin-top: var(--docs-inner);
+}
+
 .bd-var {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->

<!-- Choose one of the following: -->
This is a **documentation fix**.
<!-- Improvement? Explain how and why. -->
Related to issue  #3383

There are 2 Variables sections on the [variables page](https://bulma.io/documentation/customize/variables/#variables) with the same ID's and no gap between them. The right hand menu shows 2 Variable sections which both take you to the first one of the 2 variable sections.

### Proposed solution

1. Give each variables section a different name, by using the `anchor_name` as the section title
2. Add gap between consecutive variable 'divs' (identified by class="bd-vars")

### Tradeoffs

None that I can see.

### Testing Done

Some...
Fixes problem on the [variables page](https://bulma.io/documentation/customize/variables/#variables), but may cause unintended issues on other pages which use the modified file if they have an `anchor_name` set which should not be used for the section title.

### Changelog updated?

No.

### Screenshot
![image](https://user-images.githubusercontent.com/47078235/165308041-664d6fdc-c635-427c-a9ee-224c6b38badf.png)
