### PR TITLE
Given names to the 2 'Variable' sections

### DIFF
--- a/docs/documentation/form/general.html
+++ b/docs/documentation/form/general.html
@@ -1095,6 +1095,7 @@ variables_keys:
 {% include elements/snippet.html content=disabled_fields_example %}
 
 {% include components/variables.html
+  anchor_name='Control variables'
   type='element'
   variables_keys=page.variables_control_keys
   custom_message=custom_message
@@ -1103,6 +1104,7 @@ variables_keys:
 %}
 
 {% include components/variables.html
+  anchor_name='Form variables'
   type='element'
   variables_keys=page.variables_keys
   folder='elements'


### PR DESCRIPTION
This is a **documentation fix**.
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->
Similar to #3513
There are 2 'Variables' sections on the [Forms>General Page](https://bulma.io/documentation/form/general/#variables), both with the same title.

### Proposed solution
Set `anchor_name` for both sections.

### Tradeoffs

The names may not be obvious to what it is. It may be better to combine the 2 sets of variables into one.

### Testing Done

Yes, fix works on my system.

### Changelog updated?

No.