### PR TITLE
Remove duplicate link

### DIFF
--- a/docs/_includes/footer/links.html
+++ b/docs/_includes/footer/links.html
@@ -53,9 +53,6 @@
       {% assign link = site.data.links.by_id['expo'] %}
       {% include footer/link.html %}
 
-      {% assign link = site.data.links.by_id['love'] %}
-      {% include footer/link.html %}
-
       {% for link_id in site.data.links.more %}
         {% assign link = site.data.links.by_id[link_id] %}
         {% include footer/link.html %}


### PR DESCRIPTION
Fix for the duplicate 'love' link in footer:

<img width="672" alt="image" src="https://user-images.githubusercontent.com/6129517/168401890-b300ee69-29e9-463e-addc-a89f05cd2d77.png">


The `site.data.links.more` array already includes 'love':
https://github.com/jgthms/bulma/blob/a170216c6cd356cb89b1bdc31e0da1472cbfd2b2/docs/_data/links.json#L694

<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **documentation fix**.