### PR TITLE
Remove full width inconsistency

### DIFF
--- a/docs/documentation/layout/container.html
+++ b/docs/documentation/layout/container.html
@@ -1,7 +1,6 @@
 ---
 title: Container
 layout: documentation
-fullwidth: true
 hide_categories: true
 doc-tab: layout
 doc-subtab: container

--- a/docs/documentation/layout/hero.html
+++ b/docs/documentation/layout/hero.html
@@ -1,7 +1,6 @@
 ---
 title: Hero
 layout: documentation
-fullwidth: true
 hide_categories: true
 hide_fortyfour: true
 doc-tab: layout

--- a/docs/documentation/layout/section.html
+++ b/docs/documentation/layout/section.html
@@ -1,7 +1,6 @@
 ---
 title: Section
 layout: documentation
-fullwidth: true
 doc-tab: layout
 doc-subtab: section
 breadcrumb:


### PR DESCRIPTION
This is a **documentation fix**.


This was / is annoying the hell out of me when browsing the documentation, when I would go to "hero" or "section" pages, the whole layout would break because it was fullwidth.

Very tiny PR, but also very annoying problem.