### PR TITLE
New variables: tag focus/active background colors

### DIFF
--- a/sass/elements/tag.sass
+++ b/sass/elements/tag.sass
@@ -1,6 +1,8 @@
 @import "../utilities/mixins"
 
 $tag-background-color: $background !default
+$tag-background-color-dark: darken($tag-background-color, 5%) !default
+$tag-background-color-darker: darken($tag-background-color, 10%) !default
 $tag-color: $text !default
 $tag-radius: $radius !default
 $tag-delete-margin: 1px !default
@@ -129,9 +131,9 @@ $tag-colors: $colors !default
       width: 1px
     &:hover,
     &:focus
-      background-color: darken($tag-background-color, 5%)
+      background-color: $tag-background-color-dark
     &:active
-      background-color: darken($tag-background-color, 10%)
+      background-color: $tag-background-color-darker
   &.is-rounded
     border-radius: $radius-rounded
 


### PR DESCRIPTION
This is an **improvement**.
<!-- Improvement? Explain how and why. -->
The background colors for focused/active tags were moved to variables.

### Proposed solution

The proposed variables contain the former hard-coded values, so the compiled CSS has no changes.
This enables changing the background colors for focused/active tags using ```!default``` like most other colors. Also, removing the hardcoded ```darken()``` call will allow using a CSS custom variable instead of a color.

### Tradeoffs

Two new variables.

### Testing Done

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->
Compiled all right to CSS.

### Changelog updated?

No.

<!-- Thanks! -->
