### PR TITLE
Fixes wrong import path in page customize with sass-cli #3489

### DIFF
--- a/docs/_includes/steps/add-custom-styles.html
+++ b/docs/_includes/steps/add-custom-styles.html
@@ -1,4 +1,16 @@
-{% assign imported_files = "/sass/utilities/_all.sass;/sass/base/_all.sass;/sass/elements/button.sass;/sass/elements/container.sass;/sass/elements/title.sass;/sass/form/_all.sass;/sass/components/navbar.sass;/sass/layout/hero.sass;/sass/layout/section.sass" | split: ";" %}
+{% capture imported_files_string %}
+/sass/utilities/_all.sass;
+/sass/base/_all.sass;
+/sass/elements/button.sass;
+/sass/elements/container.sass;
+/sass/elements/title.sass;
+/sass/form/_all.sass;
+/sass/components/navbar.sass;
+/sass/layout/hero.sass;
+/sass/layout/section.sass
+{% endcapture %}
+
+{% assign imported_files_array = imported_files_string | strip_newlines | split: ";" %}
 
 {% capture mystyles %}
 @charset "utf-8";
@@ -29,7 +41,7 @@ $input-border-color: transparent;
 $input-shadow: none;
 
 // Import only what you need from Bulma
-{% for file in imported_files -%}
+{% for file in imported_files_array -%}
 {{ file | prepend: include.path | prepend: '@import "' | append: '";' }}
 {% endfor -%}
 {% endcapture %}

--- a/docs/_includes/steps/add-custom-styles.html
+++ b/docs/_includes/steps/add-custom-styles.html
@@ -1,3 +1,5 @@
+{% assign imported_files = "/sass/utilities/_all.sass;/sass/base/_all.sass;/sass/elements/button.sass;/sass/elements/container.sass;/sass/elements/title.sass;/sass/form/_all.sass;/sass/components/navbar.sass;/sass/layout/hero.sass;/sass/layout/section.sass" | split: ";" %}
+
 {% capture mystyles %}
 @charset "utf-8";
 
@@ -27,15 +29,9 @@ $input-border-color: transparent;
 $input-shadow: none;
 
 // Import only what you need from Bulma
-@import "../node_modules/bulma/sass/utilities/_all.sass";
-@import "../node_modules/bulma/sass/base/_all.sass";
-@import "../node_modules/bulma/sass/elements/button.sass";
-@import "../node_modules/bulma/sass/elements/container.sass";
-@import "../node_modules/bulma/sass/elements/title.sass";
-@import "../node_modules/bulma/sass/form/_all.sass";
-@import "../node_modules/bulma/sass/components/navbar.sass";
-@import "../node_modules/bulma/sass/layout/hero.sass";
-@import "../node_modules/bulma/sass/layout/section.sass";
+{% for file in imported_files -%}
+{{ file | prepend: include.path | prepend: '@import "' | append: '";' }}
+{% endfor -%}
 {% endcapture %}
 
 {% capture step_6 %}

--- a/docs/documentation/customize/with-node-sass.html
+++ b/docs/documentation/customize/with-node-sass.html
@@ -165,4 +165,5 @@ npm start
 
 {% include steps/add-custom-styles.html
   number="6"
+  path="../node_modules/bulma"
 %}

--- a/docs/documentation/customize/with-sass-cli.html
+++ b/docs/documentation/customize/with-sass-cli.html
@@ -119,11 +119,12 @@ sass --watch --sourcemap=none sass/mystyles.scss:css/mystyles.css
 
 <hr>
 
-{% assign bulma_path = site.data.meta.version | prepend: "../bulma-" | append: "/bulma/bulma.sass" %}
+{% assign bulma_folder_path = site.data.meta.version | prepend: "../bulma-" | append: "/bulma" %}
+{% assign bulma_sass_path = bulma_folder_path | append: "/bulma.sass" %}
 
 {% include steps/create-sass-file.html
   number="3"
-  path=bulma_path
+  path=bulma_sass_path
 %}
 
 <hr>
@@ -143,4 +144,5 @@ sass --watch --sourcemap=none sass/mystyles.scss:css/mystyles.css
 
 {% include steps/add-custom-styles.html
   number="6"
+  path=bulma_folder_path
 %}

--- a/docs/documentation/customize/with-sass-cli.html
+++ b/docs/documentation/customize/with-sass-cli.html
@@ -119,7 +119,7 @@ sass --watch --sourcemap=none sass/mystyles.scss:css/mystyles.css
 
 <hr>
 
-{% assign bulma_path = site.data.meta.version | prepend: "../bulma-" | append: "/bulma.sass" %}
+{% assign bulma_path = site.data.meta.version | prepend: "../bulma-" | append: "/bulma/bulma.sass" %}
 
 {% include steps/create-sass-file.html
   number="3"

--- a/docs/documentation/customize/with-webpack.html
+++ b/docs/documentation/customize/with-webpack.html
@@ -281,5 +281,6 @@ Wrote CSS to /path/to/mybulma/css/mystyles.css
 {% include steps/add-custom-styles.html
   number="9"
   build=true
+  path="../node_modules/bulma"
 %}
 


### PR DESCRIPTION
This is a **documentation fix**.
Fixes #3489

### Proposed solution

Two changes:
1. Fix bulma folder path for unzipped releases, adding the intermediate `/bulma` folder
2. Replace hardcoded paths in `docs\_includes\steps\add-custom-styles.html` with a variable "path" and a for loop. Pages `with-webpack.html` and `with-node-sass.html` pages assign path to `../node_modules/bulma` and page `with-sass-cli.html` sets it to `../bulma-{version}/bulma`

### Tradeoffs

The for loop adds a tiny bit of complexity.

### Testing Done

None.

### Changelog updated?

No.