### PR TITLE
Fix usage of ltr/rtl padding for notifications (Fixes #3025)

### DIFF
--- a/sass/elements/notification.sass
+++ b/sass/elements/notification.sass
@@ -3,10 +3,14 @@
 $notification-background-color: $background !default
 $notification-code-background-color: $scheme-main !default
 $notification-radius: $radius !default
-$notification-padding: 1.25rem 2.5rem 1.25rem 1.5rem !default
 $notification-padding-ltr: 1.25rem 2.5rem 1.25rem 1.5rem !default
 $notification-padding-rtl: 1.25rem 1.5rem 1.25rem 2.5rem !default
 
+$default-notification-padding: $notification-padding-ltr
+@if $rtl
+  $default-notification-padding: $notification-padding-rtl
+
+$notification-padding: $_default-notification-padding !default
 $notification-colors: $colors !default
 
 .notification
@@ -14,10 +18,7 @@ $notification-colors: $colors !default
   background-color: $notification-background-color
   border-radius: $notification-radius
   position: relative
-  +ltr
-    padding: $notification-padding-ltr
-  +rtl
-    padding: $notification-padding-rtl
+  padding: $notification-padding
   a:not(.button):not(.dropdown-item)
     color: currentColor
     text-decoration: underline


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **bugfix**. Addresses #3025 

### Proposed solution

Unify the usage of ltr and rtl padding values behind one variable, `$notification-padding`.

Currently, `$notification-padding` is set, but isn't used at all. The real padding is written using `+ltr` / `+rtl` mixins, and using the specific values `$notification-padding-ltr` and `$notification-padding-rtl`. 

This obscures what we really want to do: __Offer a configurable value for padding, and set an appropriate default based on the value of `$rtl`.__

To correct this, we create a 4th variable, `$default-notification-padding`, which is populated by `@if $rtl`, then set the default (replaceable) value of `$notification-padding` with this new variable.

### Tradeoffs

- Add a new variable that isn't necessarily worth documenting, and makes this definition more verbose
- Add an insignificant amount of compute time during render

### Testing Done

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
- [x] Pull the latest `master` branch
- [x] Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide)
- [x] Make sure your PR only affects `.sass` or documentation files
- [x] [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes).

The following code blocks are pairs of (test case `bulma.sass`, and the output of `grep -A4 "\.notification {" css/bulma.css` after running `npm run build`):

```bulma.sass
@charset "utf-8"
/*! bulma.io v0.9.4 | MIT License | github.com/jgthms/bulma */
@import "sass/utilities/_all"
@import "sass/elements/notification.sass"
```
```css/bulma.css
.notification {
  background-color: whitesmoke;
  border-radius: 4px;
  position: relative;
  padding: 1.25rem 2.5rem 1.25rem 1.5rem;
```

Here we see the default still stays ready for ltr with a delete button on the right.

```bulma.sass
@charset "utf-8"
/*! bulma.io v0.9.4 | MIT License | github.com/jgthms/bulma */
@import "sass/utilities/_all"
$rtl: true
@import "sass/elements/notification.sass"
```

```css/bulma.css
.notification {
  background-color: whitesmoke;
  border-radius: 4px;
  position: relative;
  padding: 1.25rem 1.5rem 1.25rem 2.5rem;
```

When `$rtl` is enabled, the padding is now updated without any other changes.

```bulma.sass
@charset "utf-8"
/*! bulma.io v0.9.4 | MIT License | github.com/jgthms/bulma */
@import "sass/utilities/_all"
$rtl: true
$notification-padding: 0px
@import "sass/elements/notification.sass"
```

```css/bulma.css
.notification {
  background-color: whitesmoke;
  border-radius: 4px;
  position: relative;
  padding: 0px;
```

Now even with `$rtl` enabled, the output is still the specified value of `$notification-padding`.

### Changelog updated?

No.

<!-- Thanks! -->
