### PR TITLE
Fixes disabled selected checkbox radio

### DIFF
--- a/sass/form/checkbox-radio.sass
+++ b/sass/form/checkbox-radio.sass
@@ -10,8 +10,9 @@
   &[disabled],
   fieldset[disabled] &,
   input[disabled]
-    color: $input-disabled-color
     cursor: not-allowed
+  &:not(.is-selected)
+    color: $input-disabled-color
 
 .checkbox
   @extend %checkbox-radio


### PR DESCRIPTION
Only change the color of disabled non selected checkbox-radio

<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **bugfix**.

Currently changes the color of all disabled checkbox-radio

![current](https://user-images.githubusercontent.com/1422374/178091435-44e87414-febd-442f-9451-18e2a75ba42c.png)


### Proposed solution

Only change the color of checkbox-radio without the class `.is-selected` 

![with fix](https://user-images.githubusercontent.com/1422374/178091441-c27a0a41-958d-42d6-ae23-cc289df0c071.png)
