### PR TITLE
Fixes #336, is-gapless unable to be used in conjunction with is-offset-X

### DIFF
--- a/sass/grid/columns.sass
+++ b/sass/grid/columns.sass
@@ -452,7 +452,7 @@ $column-gap: 0.75rem !default
     +ltr-property("margin", 0)
     margin-top: 0
     & > .column
-      margin: 0
+      // margin: 0
       padding: 0 !important
     &:not(:last-child)
       margin-bottom: 1.5rem


### PR DESCRIPTION
This is a **bugfix**.
Using gapless columns and offset at the same time, cancels the offset.  Issue #336 

### Proposed solution
Removing margin: 0 from columns.scss fixes the problem. This was suggested on the issue, but does not seem to have been added yet. I have tested this fix and it is not causing any issues with the grid.

### Tradeoffs
None

###Testing done
Tested on latest Chrome desktop (Mac) and iOS Chrome.

###Changelog updated?
No