### PR TITLE
Add support for inline SVG images

### DIFF
--- a/sass/elements/image.sass
+++ b/sass/elements/image.sass
@@ -5,7 +5,8 @@ $dimensions: 16 24 32 48 64 96 128 !default
 .image
   display: block
   position: relative
-  img
+  img,
+  svg
     display: block
     height: auto
     width: 100%
@@ -31,6 +32,7 @@ $dimensions: 16 24 32 48 64 96 128 !default
   &.is-1by2,
   &.is-1by3
     img,
+    svg,
     .has-ratio
       @extend %overlay
       height: 100%


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **improvement**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution

The `.image` class adds display, height, and width styles to child `img` elements.  If those styles get applied to child `svg` elements, inline SVG can take advantage of those styles too.

### Tradeoffs

None that I can think of.

### Testing Done

Added the styles to my own stylesheets with good results.

**Before**

![Before](https://user-images.githubusercontent.com/19495149/180247660-252052a1-bc39-48a7-8669-6471fb6358a6.png)

**After**

![svgAfter](https://user-images.githubusercontent.com/19495149/180247766-91b7edc4-ac52-4ed3-b669-4e80805d4497.png)

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

### Changelog updated?

No.

<!-- Thanks! -->
