### PR TITLE
Fixes #3554 issue in Utilities/Responsive mixins guide

### DIFF
--- a/docs/documentation/utilities/responsive-mixins.html
+++ b/docs/documentation/utilities/responsive-mixins.html
@@ -222,7 +222,7 @@ breadcrumb:
 {% endcapture %}
 
 {% capture inc-until-fullhd %}
-@include until {
+@include until-fullhd {
   // Styles applied
   // below $fullhd
 }


### PR DESCRIPTION
This is a **documentation fix**. As mentioned in #3554 issue, the doc mention mixins named until while it should be until-fullhd.

### Proposed solution

Solves the problem of typo in doumentation.

### Tradeoffs

None.

### Testing Done

None.

### Changelog updated?

No.

Thanks!
