### PR TITLE
Change font awesome link and fix anchor link on select docs

### DIFF
--- a/docs/documentation/components/tabs.html
+++ b/docs/documentation/components/tabs.html
@@ -393,7 +393,7 @@ meta:
 {% include elements/anchor.html name="Icons" %}
 
 <div class="content">
-  <p>You can use any of the <a href="http://fontawesome.io/">Font Awesome</a> <strong>icons</strong>.</p>
+  <p>You can use any of the <a href="https://fontawesome.com/">Font Awesome</a> <strong>icons</strong>.</p>
 </div>
 
 {% include elements/snippet.html content=tabs_icons_example horizontal=true more=true %}

--- a/docs/documentation/form/select.html
+++ b/docs/documentation/form/select.html
@@ -189,9 +189,9 @@ meta:
 <div class="content">
   <p>Several <strong>modifiers</strong> are supported which affect:</p>
   <ul>
-    <li>the <strong><a href="#select-color">color</a></strong></li>
-    <li>the <strong><a href="#select-size">size</a></strong></li>
-    <li>the <strong><a href="#select-state">state</a></strong></li>
+    <li>the <strong><a href="#colors">color</a></strong></li>
+    <li>the <strong><a href="#sizes">size</a></strong></li>
+    <li>the <strong><a href="#states">state</a></strong></li>
   </ul>
 </div>
 


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **documentation fix**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution

Changed the `http://fontawesome.io/` to `https://fontawesome.com/` on [tabs documentation](https://bulma.io/documentation/components/tabs/#icons).

Fixed the URL of anchor tag on [select documentation](https://bulma.io/documentation/form/select/).

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

### Changelog updated?

No.

<!-- Thanks! -->
