### PR TITLE
navbar documentation closing tag added

### DIFF
--- a/docs/documentation/components/navbar.html
+++ b/docs/documentation/components/navbar.html
@@ -18,7 +18,7 @@ meta:
 <nav class="navbar" role="navigation" aria-label="main navigation">
   <div class="navbar-brand">
     <a class="navbar-item" href="{{ site.url }}">
-      <img src="{{ site.url }}/images/bulma-logo.png" width="112" height="28">
+      <img src="{{ site.url }}/images/bulma-logo.png" width="112" height="28"/>
     </a>
 
     <a role="button" class="navbar-burger" aria-label="menu" aria-expanded="false" data-target="navbarBasicExample">
@@ -53,7 +53,7 @@ meta:
           <a class="navbar-item">
             Contact
           </a>
-          <hr class="navbar-divider">
+          <hr class="navbar-divider"/>
           <a class="navbar-item">
             Report an issue
           </a>
@@ -101,7 +101,7 @@ meta:
 <nav class="navbar" role="navigation" aria-label="main navigation">
   <div class="navbar-brand">
     <a class="navbar-item" href="{{ site.url }}">
-      <img src="{{ site.url }}/images/bulma-logo.png" alt="{{ site.data.meta.title }}" width="112" height="28">
+      <img src="{{ site.url }}/images/bulma-logo.png" alt="{{ site.data.meta.title }}" width="112" height="28"/>
     </a>
 
     <a role="button" class="navbar-burger" aria-label="menu" aria-expanded="false">
@@ -154,7 +154,7 @@ meta:
 
 {% capture navbar_item_brand_example %}
 <a class="navbar-item">
-  <img src="{{ site.url }}/images/bulma-logo.png" width="112" height="28" alt="Bulma">
+  <img src="{{ site.url }}/images/bulma-logo.png" width="112" height="28" alt="Bulma"/>
 </a>
 {% endcapture %}
 
@@ -254,7 +254,7 @@ meta:
       <a class="navbar-item">
         Components
       </a>
-      <hr class="navbar-divider">
+      <hr class="navbar-divider"/>
       <div class="navbar-item">
         Version {{ site.data.meta.version }}
       </div>
@@ -286,7 +286,7 @@ meta:
       <a class="navbar-item">
         Components
       </a>
-      <hr class="navbar-divider">
+      <hr class="navbar-divider"/>
       <div class="navbar-item">
         Version {{ site.data.meta.version }}
       </div>
@@ -320,7 +320,7 @@ meta:
           <a class="navbar-item">
             Components
           </a>
-          <hr class="navbar-divider">
+          <hr class="navbar-divider"/>
           <div class="navbar-item">
             Version {{ site.data.meta.version }}
           </div>
@@ -344,7 +344,7 @@ meta:
           <a class="navbar-item">
             Components
           </a>
-          <hr class="navbar-divider">
+          <hr class="navbar-divider"/>
           <div class="navbar-item">
             Version {{ site.data.meta.version }}
           </div>
@@ -409,7 +409,7 @@ meta:
           <a class="navbar-item">
             Components
           </a>
-          <hr class="navbar-divider">
+          <hr class="navbar-divider"/>
           <div class="navbar-item">
             Version {{ site.data.meta.version }}
           </div>
@@ -423,7 +423,7 @@ meta:
 {% capture navbar_dropdown_default_example %}
 <nav class="navbar" role="navigation" aria-label="dropdown navigation">
   <a class="navbar-item">
-    <img src="{{ site.url }}/images/bulma-logo.png" alt="{{ site.data.meta.title }}" width="112" height="28">
+    <img src="{{ site.url }}/images/bulma-logo.png" alt="{{ site.data.meta.title }}" width="112" height="28"/>
   </a>
 
   <div class="navbar-item has-dropdown is-active">
@@ -441,7 +441,7 @@ meta:
       <a class="navbar-item">
         Components
       </a>
-      <hr class="navbar-divider">
+      <hr class="navbar-divider"/>
       <div class="navbar-item">
         Version {{ site.data.meta.version }}
       </div>
@@ -464,7 +464,7 @@ meta:
 {% capture navbar_dropdown_boxed_example %}
 <nav class="navbar is-transparent" role="navigation" aria-label="dropdown navigation">
   <a class="navbar-item">
-    <img src="{{ site.url }}/images/bulma-logo.png" alt="{{ site.data.meta.title }}" width="112" height="28">
+    <img src="{{ site.url }}/images/bulma-logo.png" alt="{{ site.data.meta.title }}" width="112" height="28"/>
   </a>
 
   <div class="navbar-item has-dropdown is-active">
@@ -482,7 +482,7 @@ meta:
       <a class="navbar-item">
         Components
       </a>
-      <hr class="navbar-divider">
+      <hr class="navbar-divider"/>
       <div class="navbar-item">
         Version {{ site.data.meta.version }}
       </div>
@@ -505,7 +505,7 @@ meta:
 {% capture navbar_dropdown_item_active_example %}
 <nav class="navbar" role="navigation" aria-label="dropdown navigation">
   <a class="navbar-item">
-    <img src="{{ site.url }}/images/bulma-logo.png" alt="{{ site.data.meta.title }}" width="112" height="28">
+    <img src="{{ site.url }}/images/bulma-logo.png" alt="{{ site.data.meta.title }}" width="112" height="28"/>
   </a>
 
   <div class="navbar-item has-dropdown is-active">
@@ -523,7 +523,7 @@ meta:
       <a class="navbar-item">
         Components
       </a>
-      <hr class="navbar-divider">
+      <hr class="navbar-divider"/>
       <div class="navbar-item">
         Version {{ site.data.meta.version }}
       </div>
@@ -544,7 +544,7 @@ meta:
 {% endcapture %}
 
 {% capture navbar_divider_example %}
-<hr class="navbar-divider">
+<hr class="navbar-divider"/>
 {% endcapture %}
 
 {% capture navbar_js_html %}
@@ -767,7 +767,7 @@ $(document).ready(function() {
   </ul>
 </div>
 
-<hr>
+<hr/>
 
 <div id="navbarJsExample" class="message is-info">
   <h4 class="message-header">Javascript toggle</h4>
@@ -1092,7 +1092,7 @@ $(document).ready(function() {
     <a class="navbar-item">
       Components
     </a>
-    <hr class="navbar-divider">
+    <hr class="navbar-divider"/>
     <div class="navbar-item">
       Version {{ site.data.meta.version }}
     </div>


### PR DESCRIPTION
There is no closing tag or (/) in the navbar docs page in the `image` and `hr` tag.

<img width="626" alt="Screen Shot 2022-09-02 at 9 45 58 PM" src="https://user-images.githubusercontent.com/61580196/188193944-e0ffeb5b-43e5-41bc-91ff-1c713a5fdf5f.png">

Have added it on all the `image` and `hr` tag.