### PR TITLE
Fix non-hiding navbar-link arrow

### DIFF
--- a/sass/components/navbar.sass
+++ b/sass/components/navbar.sass
@@ -244,7 +244,7 @@ a.navbar-item,
     .navbar-item
       align-items: center
       display: flex
-  .navbar-link
+  .navbar-link:not(.is-arrowless)
     &::after
       display: none
   .navbar-menu


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **bugfix**.

The `.is-arrowless` class was introduced with PR #1919 leading to regression for mobile viewports.
https://github.com/jgthms/bulma/blob/1af081285ef37990ce4b25ed9b1166ff3397ab08/sass/components/navbar.sass#L216-L222

Definition for a mobile viewport has not been changed. 
https://github.com/jgthms/bulma/blob/1af081285ef37990ce4b25ed9b1166ff3397ab08/sass/components/navbar.sass#L239
https://github.com/jgthms/bulma/blob/1af081285ef37990ce4b25ed9b1166ff3397ab08/sass/components/navbar.sass#L247-L249

The rule resulting from first block (`.navbar-link:not(.is-arrowless):after`) is more specific than second one (`.navbar-link:after`) which makes the second always superseded.

### Proposed solution
Add `:not(.is-arrowless)` specifier for mobile viewport
https://github.com/kubasaw/bulma/blob/9d6dd81d774779d71c26561b41ed20d1ef35a48d/sass/components/navbar.sass#L247-L249

<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

### Testing Done

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
1. [x] Pull the latest `master` branch
2. [x] Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide)
3. [x] Make sure your PR only affects `.sass` or documentation files
4. [x] [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes).

<!-- How have you confirmed this feature works? -->
Resulting `navbar-link` is as follows:

Before patching
![Zrzut ekranu z 2022-09-27 19-55-58](https://user-images.githubusercontent.com/13100091/192602251-9275c957-0f72-417d-9200-37b7e937c21d.png)
After patching
![Zrzut ekranu z 2022-09-27 19-56-16](https://user-images.githubusercontent.com/13100091/192602260-64b5ae5c-370c-4ac6-9c37-5d84b475d060.png)

### Changelog updated?
No.

<!-- Thanks! -->
