### PR TITLE
Docs: reduce code example width so components are displayed correctly

### DIFF
--- a/docs/documentation/components/navbar.html
+++ b/docs/documentation/components/navbar.html
@@ -423,7 +423,9 @@ meta:
 {% capture navbar_dropdown_default_example %}
 <nav class="navbar" role="navigation" aria-label="dropdown navigation">
   <a class="navbar-item">
-    <img src="{{ site.url }}/images/bulma-logo.png" alt="{{ site.data.meta.title }}" width="112" height="28">
+    <img src="{{ site.url }}/images/bulma-logo.png"
+      alt="{{ site.data.meta.title }}"
+      width="112" height="28">
   </a>
 
   <div class="navbar-item has-dropdown is-active">
@@ -464,7 +466,9 @@ meta:
 {% capture navbar_dropdown_boxed_example %}
 <nav class="navbar is-transparent" role="navigation" aria-label="dropdown navigation">
   <a class="navbar-item">
-    <img src="{{ site.url }}/images/bulma-logo.png" alt="{{ site.data.meta.title }}" width="112" height="28">
+    <img src="{{ site.url }}/images/bulma-logo.png"
+      alt="{{ site.data.meta.title }}"
+      width="112" height="28">
   </a>
 
   <div class="navbar-item has-dropdown is-active">
@@ -505,7 +509,9 @@ meta:
 {% capture navbar_dropdown_item_active_example %}
 <nav class="navbar" role="navigation" aria-label="dropdown navigation">
   <a class="navbar-item">
-    <img src="{{ site.url }}/images/bulma-logo.png" alt="{{ site.data.meta.title }}" width="112" height="28">
+    <img src="{{ site.url }}/images/bulma-logo.png"
+      alt="{{ site.data.meta.title }}"
+      width="112" height="28">
   </a>
 
   <div class="navbar-item has-dropdown is-active">


### PR DESCRIPTION
This is a **documentation fix**.

In some examples for the [navbar](https://bulma.io/documentation/components/navbar/), the component (left) doesn't look good because the code (right) takes too much space.

![image](https://user-images.githubusercontent.com/20623084/192606458-b5b81ef2-2adb-4b71-b0fc-9ba192264e6d.png)

### Proposed solution

The easiest solution seems to be formatting the markup in the example so lines are shorter 

### Testing Done

Running the docs locally and seeing the result

### Changelog updated?

No.