### PR TITLE
Uppercase text in breadcrumbs

### DIFF
--- a/sass/components/breadcrumb.sass
+++ b/sass/components/breadcrumb.sass
@@ -1,5 +1,6 @@
 @import "../utilities/mixins"
 
+$breadcrumb-text-transform: none !default 
 $breadcrumb-item-color: $link !default
 $breadcrumb-item-hover-color: $link-hover !default
 $breadcrumb-item-active-color: $text-strong !default
@@ -13,6 +14,7 @@ $breadcrumb-item-separator-color: $border-hover !default
   @extend %block
   @extend %unselectable
   font-size: $size-normal
+  text-transform: $breadcrumb-text-transform
   white-space: nowrap
   a
     align-items: center


### PR DESCRIPTION
Sometimes the breadcrumbs appear to be uppercase. It would be nice to make to developer choose this parameter.

<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **new feature | improvement | bugfix | documentation fix**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution

Just add a `text-transform: $breadcrumb-text-transform` inside the .breadcrumb class
Default value for `$breadcrumb-text-transform` is `none`


<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

### Tradeoffs

<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->

### Testing Done

None.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

### Changelog updated?

No.

<!-- Thanks! -->
