### PR TITLE
Moved message bg color to body

### DIFF
--- a/sass/components/message.sass
+++ b/sass/components/message.sass
@@ -23,7 +23,6 @@ $message-colors: $colors !default
 
 .message
   @extend %block
-  background-color: $message-background-color
   border-radius: $message-radius
   font-size: $size-normal
   strong
@@ -88,6 +87,7 @@ $message-colors: $colors !default
     border-top-right-radius: 0
 
 .message-body
+  background-color: $message-background-color
   border-color: $message-body-border-color
   border-radius: $message-body-radius
   border-style: solid


### PR DESCRIPTION
This is a **improvement**.

With bgcolor at whole message it shows weird fragments around top corners radius. It is mostly visible when you use dark message as content of modal (with dark background).

### Testing Done

- Small visual change tested with my eyes.

Before

![image](https://user-images.githubusercontent.com/5502917/210797211-b9e4fb80-7490-44db-bcf0-79e056d851be.png)

After

![image](https://user-images.githubusercontent.com/5502917/210797253-6d59346c-6ece-420f-ab9e-8e088b67f23b.png)

- Tested compiling sass into css.

### Changelog updated?

No.
