### PR TITLE
Update color.sass | Adding $custom-shades compiles to broken css

### DIFF
--- a/sass/helpers/color.sass
+++ b/sass/helpers/color.sass
@@ -31,9 +31,12 @@
         color: bulmaLighten($color-dark, 10%) !important
     .has-background-#{$name}-dark
       background-color: $color-dark !important
-
 @each $name, $shade in $shades
+  $value: $shade
+  @if type-of($custom-colors) == 'map'
+   $value: nth($shade, 1)
+  @debug $value
   .has-text-#{$name}
-    color: $shade !important
+    color: $value !important
   .has-background-#{$name}
-    background-color: $shade !important
+    background-color: $value !important


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->

<!-- Choose one of the following: -->
This is about **Bulma**.

<!-- Is it about Bulma or about the Docs? -->
<!-- Is it a bug/feature/question or do you need help? -->
<!-- If it's a bug, is it a browser bug? -->

### Overview of the problem

Adding a custom shade via $custom-shades results in a broken css class

<!-- UNCOMMENT THE APPROPRIATE LINES -->

This is about the Bulma **CSS framework**
 I'm using Bulma **version** [0.9.4]
This is a **Sass** issue: I'm using version [1.56.1]
I am sure this issue is **not a duplicate**

### Description







<!-- Description of the bug, enhancement, or question -->

### Steps to Reproduce

1. add `$custom-sahdes` to `bulma.scss`
   - ![image](https://user-images.githubusercontent.com/83591921/215797977-3959078f-d021-42d7-bb02-458799fc78c5.png)
2. see in `functions.sass`
   - ![image](https://user-images.githubusercontent.com/83591921/215798716-52ad6ab1-b6c9-4a72-8649-18a155500df8.png)
3. see in `color.sass`
   - ![image](https://user-images.githubusercontent.com/83591921/215798770-9e17a4e3-8e15-4beb-bd6e-803c632dea6e.png)
4. see inbrowser
   - ![image](https://user-images.githubusercontent.com/83591921/215798593-4472db74-d748-4e03-b006-dff14e9b459f.png)

### Expected behavior

This code in `color.sass`
```sass
@each $name, $shade in $shades
  .has-text-#{$name}
    color: $shade !important
  .has-background-#{$name}
    background-color: $shade !important
```

Should handle the created map values **atleast** with:
```sass
@each $name, $shade in $shades
  $value: $shade
  @if type-of($custom-colors) == 'map'
   $value: nth($shade, 1)
  @debug $value
  .has-text-#{$name}
    color: $value !important
  .has-background-#{$name}
    background-color: $value !important
```

### Actual behavior
it takes the map as value for `$shade`

