### PR TITLE
Added is-fullheight-with-spaced-navbar modifier for navbars that use is-spaced.

### DIFF
--- a/docs/documentation/layout/hero.html
+++ b/docs/documentation/layout/hero.html
@@ -183,6 +183,9 @@ meta:
   <p>
     If you are using a <a href="{{ site.url }}/documentation/components/navbar/#fixed-navbar">fixed navbar</a>, you can use the <code>is-fullheight-with-navbar</code> modifier on the hero for it to occupy the viewport height minus the navbar height.
   </p>
+  <p>
+    If the navbar contains the <code>is-spaced</code> modifier, you should use <code>is-fullheight-with-spaced-navbar</code> instead as this will account for the extra vertical spacing.
+  </p>
 </div>
 
 

--- a/sass/components/navbar.sass
+++ b/sass/components/navbar.sass
@@ -442,5 +442,10 @@ a.navbar-item,
 // Combination
 
 .hero
-  &.is-fullheight-with-navbar
+  &.is-fullheight-with-navbar,
+  &.is-fullheight-with-spaced-navbar
     min-height: calc(100vh - #{$navbar-height})
+.hero
+  &.is-fullheight-with-spaced-navbar
+    +desktop
+      min-height: calc(100vh - #{$navbar-height} - #{$navbar-padding-vertical*2})

--- a/sass/layout/hero.sass
+++ b/sass/layout/hero.sass
@@ -94,6 +94,7 @@ $hero-colors: $colors !default
   &.is-halfheight,
   &.is-fullheight,
   &.is-fullheight-with-navbar
+  &.is-fullheight-with-spaced-navbar
     .hero-body
       align-items: center
       display: flex


### PR DESCRIPTION
<!-- Choose one of the following: -->
This is an **improvement**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution

Currently the hero layout with `is-fullheight-with-navbar` fails to account for `is-spaced` navbars resulting in an extra space at the bottom of the page. This PR adds a new modifier `is-fullheight-with-spaced-navbar` so that the spacing is accounted for on desktop and higher.

This problem has already been addressed in issue #2845 which in turn ended up going stale.

<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

### Tradeoffs

Users must now decide between `is-fullheight-with-navbar` and `is-fullheight-with-spaced-navbar` but we already differentiate between fixed-bars and regular bars so I don't see this as an unnecessary complication.

### Testing Done

#### Minimal example:

```
<nav class="navbar is-light is-spaced" role="navigation">
  <div class="navbar-brand">
  </div>
</nav>
<section class="hero is-info is-fullheight-with-spaced-navbar">
  <div class="hero-body">
  </div>
</section>
```

Note how the page does not scroll when `with-spaced-navbar` is used.

### Changelog updated?

No.
