### PR TITLE
Fix form field-label alignment for rtl

### DIFF
--- a/sass/form/tools.sass
+++ b/sass/form/tools.sass
@@ -130,7 +130,10 @@ $label-colors: $form-colors !default
     flex-grow: 1
     flex-shrink: 0
     +ltr-property("margin", 1.5rem)
-    text-align: right
+    +ltr
+      text-align: right
+    +rtl
+      text-align: left
     &.is-small
       font-size: $size-small
       padding-top: 0.375em


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a bugfix for a small rtl issue with field-label. It should align the other way.

Before:

<img width="626" alt="image" src="https://user-images.githubusercontent.com/1277636/218338698-ccfae24c-a62c-49a0-9d49-3077c8b56e4e.png">

After:

<img width="639" alt="image" src="https://user-images.githubusercontent.com/1277636/218338651-a40cbc18-56a7-445a-b5e7-4ebc92c083be.png">


<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Testing Done

Visual inspection locally.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

### Changelog updated?

No.

<!-- Thanks! -->
