### PR TITLE
Fix "style" field

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "description": "Modern CSS framework based on Flexbox",
   "main": "bulma.sass",
   "unpkg": "css/bulma.css",
-  "style": "bulma/css/bulma.min.css",
+  "style": "css/bulma.min.css",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/jgthms/bulma.git"


### PR DESCRIPTION
This is a **bugfix**.

### Proposed solution

The field currently points to a non-existent file, confusing tools that read it. Changed to the correct path. Fixes jsdelivr/jsdelivr#18468.

### Tradeoffs

N/A

### Testing Done

None.

### Changelog updated?

No.