### PR TITLE
Improve text weight typography helpers docs display

### DIFF
--- a/docs/documentation/helpers/typography-helpers.html
+++ b/docs/documentation/helpers/typography-helpers.html
@@ -361,26 +361,26 @@ breadcrumb:
   </tr>
   </thead>
   <tbody>
-  <tr>
-    <td><code>has-text-weight-light</code></td>
-    <td>Transforms text weight to <strong>light</strong></td>
-  </tr>
-  <tr>
-    <td><code>has-text-weight-normal</code></td>
-    <td>Transforms text weight to <strong>normal</strong></td>
-  </tr>
-  <tr>
-    <td><code>has-text-weight-medium</code></td>
-    <td>Transforms text weight to <strong>medium</strong></td>
-  </tr>
-  <tr>
-    <td><code>has-text-weight-semibold</code></td>
-    <td>Transforms text weight to <strong>semi-bold</strong></td>
-  </tr>
-  <tr>
-    <td><code>has-text-weight-bold</code></td>
-    <td>Transforms text weight to <strong>bold</strong></td>
-  </tr>
+    <tr>
+      <td><code>has-text-weight-light</code></td>
+      <td>Transforms text weight to <span class="has-text-weight-light">light</span></td>
+    </tr>
+    <tr>
+      <td><code>has-text-weight-normal</code></td>
+      <td>Transforms text weight to <span class="has-text-weight-normal">normal</span></td>
+    </tr>
+    <tr>
+      <td><code>has-text-weight-medium</code></td>
+      <td>Transforms text weight to <span class="has-text-weight-medium">medium</span></td>
+    </tr>
+    <tr>
+      <td><code>has-text-weight-semibold</code></td>
+      <td>Transforms text weight to <span class="has-text-weight-semibold">semi-bold</span></td>
+    </tr>
+    <tr>
+      <td><code>has-text-weight-bold</code></td>
+      <td>Transforms text weight to <span class="has-text-weight-bold">bold</span></td>
+    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **documentation fix**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->
When using the helpers I wasn't sure which one I wanted because they were all just wrapped in `strong`.
Instead I think it would be nice for folks to be able to see the difference in text weight in the docs and see the helper applied in action.

### Proposed solution

<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->
Make the weight name match the weight helper it's aligned with.

![CleanShot 2023-03-16 at 11 53 17](https://user-images.githubusercontent.com/85516727/225724067-3d1ed5d6-d414-4a4a-94f9-2dcda6fa6974.png)

### Tradeoffs
Could possible affect readability.

### Changelog updated?

No.