### PR TITLE
Fixes #3637 created a style for inverted loading buttons

### DIFF
--- a/sass/elements/button.sass
+++ b/sass/elements/button.sass
@@ -178,6 +178,9 @@ $button-responsive-sizes: ("mobile": ("small": ($size-small * 0.75), "normal": (
           border-color: transparent
           box-shadow: none
           color: $color
+        &.is-loading
+          &::after
+            border-color: transparent transparent $color $color !important
       &.is-loading
         &::after
           border-color: transparent transparent $color-invert $color-invert !important


### PR DESCRIPTION
This is a **bugfix** about Issue #3637.

### Proposed solution

This PR solves the button disappearing problem when using `.is-inverted` and `is-loading` at the same time

### Testing Done

None.

<!-- Thanks! -->
