### PR TITLE
fix: typo in navbar doc

### DIFF
--- a/docs/documentation/components/navbar.html
+++ b/docs/documentation/components/navbar.html
@@ -761,7 +761,7 @@ $(document).ready(function() {
 
 <div class="content">
   <p>
-    On desktop {% include bp/desktop.html %}, the <code>navbar-menu</code> will <strong>fill up the space</strong> available in the navbar, leaving the navbar brand just the space it needs. It needs, however, two elements as direct children:
+    On desktop {% include bp/desktop.html %}, the <code>navbar-menu</code> will <strong>fill up the space</strong> available in the navbar, leaving the navbar brand just the space it needs. however, two elements as direct children:
   </p>
   <ul>
     <li>


### PR DESCRIPTION
This is a documentation fix.

### Proposed solution

fix typo on navbar components documentation

### Tradeoffs

No tradeoffs

### Testing Done

None.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
Didn't touch any of the Sass stuff
<!-- Please explain more than "Yes". -->

### Changelog updated?

No.

<!-- Thanks! -->
