### PR TITLE
Fixes #3655

### DIFF
--- a/sass/components/navbar.sass
+++ b/sass/components/navbar.sass
@@ -3,7 +3,7 @@
 $navbar-background-color: $scheme-main !default
 $navbar-box-shadow-size: 0 2px 0 0 !default
 $navbar-box-shadow-color: $background !default
-$navbar-height: 3.25rem !default
+$navbar-height: 3.5rem !default
 $navbar-padding-vertical: 1rem !default
 $navbar-padding-horizontal: 2rem !default
 $navbar-z: 30 !default


### PR DESCRIPTION
This is a bugfix.

Issue#3655 -> Update sass/components/navbar.sass:6
The variable $navbar-height is set to 3.25rem (52px) by default. However the navbar height changes to 3.5rem (56px) as soon as a button is added!

### Proposed solution
Change default navbar height from 3.25rem to 3.5rem.

There is an alternate solution as well. We can reduce the default button size so that the navbar doesn't get disturbed
### Testing Done
Unit testing has been done by linking my test project locally with bulma

I have:
1. Cloned the bulma repo.
2. Created a new react project named PGReact.
3. Linked bulma locally with PGReact.
4. Wrote this piece of code in App.js
`<body class="has-navbar-fixed-top">
      <nav class="navbar is-fixed-top has-background-light">

        <a class="navbar-item">Link</a>

        <div class="navbar-item">
          <a class="button">Button</a>
        </div>

      </nav>
    </body>`
5. Commented the code written between <nav> and </nav>
6. The height of navbar didn't get disturbed

### Changelog updated?

No.

<!-- Thanks! -->
