### PR TITLE
removed deprecated code in example

### DIFF
--- a/docs/documentation/components/modal.html
+++ b/docs/documentation/components/modal.html
@@ -120,9 +120,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Add a keyboard event to close all modals
   document.addEventListener('keydown', (event) => {
-    const e = event || window.event;
-
-    if (e.keyCode === 27) { // Escape key
+    if (event.code === 'Escape') {
       closeAllModals();
     }
   });


### PR DESCRIPTION
removed `window.event`.
replaced `keyCode` with `code`.

This is a documentation fix.

### Proposed solution

`window.event` and `event.keyCode` are deprecated.

 - windows.event

> Web developers are strongly encouraged to instead rely on the [Event](http://dom.spec.whatwg.org/#event) object passed to event listeners, as that will result in more portable code. This attribute is not available in workers or worklets, and is inaccurate for events dispatched in [shadow trees](http://dom.spec.whatwg.org/#concept-shadow-tree).

Removed `window.event` as we already accept an event, as suggested above.

- event.keyCode:

> You should avoid using this if possible; it's been deprecated for some time. Instead, you should use KeyboardEvent.code, if it's implemented.

Replaced `event.keyCode` with `event.code` as suggested above.

### Tradeoffs

According to the [documentation](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code#browser_compatibility), code is supported by all major browsers, so there should be no tradeoffs.

### Testing Done

Run the same code after changing the event listener, pressed escape, observed that the modal closed.

### Changelog updated?

No.
