### PR TITLE
Add weight-black to variables and helpers

### DIFF
--- a/sass/helpers/typography.sass
+++ b/sass/helpers/typography.sass
@@ -86,6 +86,8 @@ $alignments: ('centered': 'center', 'justified': 'justify', 'left': 'left', 'rig
   font-weight: $weight-semibold !important
 .has-text-weight-bold
   font-weight: $weight-bold !important
+.has-text-weight-black
+  font-weight: $weight-black !important
 
 .is-family-primary
   font-family: $family-primary !important

--- a/sass/utilities/initial-variables.sass
+++ b/sass/utilities/initial-variables.sass
@@ -43,6 +43,7 @@ $weight-normal: 400 !default
 $weight-medium: 500 !default
 $weight-semibold: 600 !default
 $weight-bold: 700 !default
+$weight-black: 800 !default
 
 // Spacing
 


### PR DESCRIPTION
This is an improvement.
I needed the BLACK font weight option for a website and noticed it was missing.

### Proposed solution
I have added the BLACK font weight option (800) as an initial variable and for its use as a typography helper.

### Tradeoffs
Nope.

### Testing Done
Tested on my website, it is a simple improvement.

### Changelog updated?
No.