### PR TITLE
Add a Dependabot config to keep GitHub action versions updated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
_This is an **infrastructure** improvement._

The GitHub action versions are no longer current and are issuing deprecation warnings ([recent example](https://github.com/jgthms/bulma/actions/runs/5905032435) for `actions/checkout@v2`, which is now at v4).

Rather than submitting a PR to update the versions once, this PR introduces a Dependabot configuration that will keep the action versions updated in perpetuity.

If this merges, you can expect Dependabot to immediately submit PR(s) to update out-of-date action versions.

Thanks for your work on Bulma!