### PR TITLE
Fixes #3676 change style of is_light button when is loading

### DIFF
--- a/sass/elements/button.sass
+++ b/sass/elements/button.sass
@@ -247,6 +247,9 @@ $button-responsive-sizes: ("mobile": ("small": ($size-small * 0.75), "normal": (
             background-color: bulmaDarken($color-light, 5%)
             border-color: transparent
             color: $color-dark
+          &.is-loading
+            &::after
+              border-color: transparent transparent $color $color !important              
   // Sizes
   &.is-small
     +button-small


### PR DESCRIPTION
This is a **bugfix** about Issue #3676.

### Proposed solution
This PR solves the button visibility problem when using `.is-light` and `is-loading` at the same time

### Testing Done
None.
