### PR TITLE
Add .is-disabled state to Dropdown component

### DIFF
--- a/sass/components/dropdown.sass
+++ b/sass/components/dropdown.sass
@@ -63,7 +63,7 @@ $dropdown-divider-background-color: $border-light !default
   padding: 0.375rem 1rem
   position: relative
   &.is-disabled
-    color: $grey
+    color: $text-disabled
     cursor: default
     pointer-events: none
 

--- a/sass/components/dropdown.sass
+++ b/sass/components/dropdown.sass
@@ -38,6 +38,7 @@ $dropdown-divider-background-color: $border-light !default
       padding-top: initial
       top: auto
 
+
 .dropdown-menu
   display: none
   +ltr-position(0, false)
@@ -61,6 +62,10 @@ $dropdown-divider-background-color: $border-light !default
   line-height: 1.5
   padding: 0.375rem 1rem
   position: relative
+  &.is-disabled
+    color: $grey
+    cursor: default
+    pointer-events: none
 
 a.dropdown-item,
 button.dropdown-item


### PR DESCRIPTION


This is an **improvement**.
- Add a disabled state to the .dropdown-item of the dropdown component (As stated in issue #3682)

### Proposed solution
Add a `.is-disabled` class to the `.dropdown-item` element

```sass
.dropdown-item
  color: $dropdown-item-color
  display: block
  font-size: 0.875rem
  line-height: 1.5
  padding: 0.375rem 1rem
  position: relative
  &.is-disabled
    color: $grey
    cursor: default
    pointer-events: none
```

### Tradeoffs
None

### Testing Done
Yes, I created a test environment where I used a `Dropdown` component and added a `.is-disabled` class to a `.dropdown-item` element. The results can be seen in the screenshot and GIF below:

A dropdown with a disabled item:
![image](https://github.com/jgthms/bulma/assets/7586388/a1e0b936-4b7f-4e5e-be89-437f2999eb91)

A GIF Showing the disabled behavior on :hover
![gif](https://github.com/jgthms/bulma/assets/7586388/4b9ff01c-a549-4f9a-8466-a322a257ec4d)

### Changelog updated?
No.


