### PR TITLE
Feature/flex is-gap with sizes derived from initial $sizes values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Bulma Changelog
 
+## 0.9.5
+
+### New features
+
+- `is-gap`: can add gap betwen item in an `is-flex` container with `is-gap-(size)`, with sizes 1-7
+
 ## 0.9.4
 
 ### New features
@@ -126,7 +132,7 @@ The Bulma package now also comes with a `bulma-rtl.css` and `bulma-rtl.min.css` 
 
 ### Spacing helpers
 
-Bulma now has **spacing helpers**: https://bulma.io/documentation/helpers/spacing-helpers/
+Bulma now has **spacing helpers**: <https://bulma.io/documentation/helpers/spacing-helpers/>
 
 <p>Bulma provides <strong>margin</strong> <code>m*</code> and <strong>padding</strong> <code>p*</code> helpers in all <strong>directions</strong>:</p>
 
@@ -1513,7 +1519,7 @@ Variable name changes (mostly appending `-color`):
 
 ## 0.0.19
 
-### NEW!!!
+### NEW
 
 - `.tile`
 

--- a/docs/documentation/helpers/flexbox-helpers.html
+++ b/docs/documentation/helpers/flexbox-helpers.html
@@ -128,7 +128,7 @@ and flex shrink" %}
 <div class="content">
   <p>
     Gap sizes are calculated from the <code>initial-variables</code>
-    <code>$sizeX</code>-values.
+    <code>$size-x</code>-values.
   </p>
 </div>
 

--- a/docs/documentation/helpers/flexbox-helpers.html
+++ b/docs/documentation/helpers/flexbox-helpers.html
@@ -4,65 +4,66 @@ layout: documentation
 doc-tab: helpers
 doc-subtab: helpers-flexbox
 breadcrumb:
-- home
-- documentation
-- helpers
-- helpers-flexbox
+  - home
+  - documentation
+  - helpers
+  - helpers-flexbox
 flex-direction-values:
-- row
-- row-reverse
-- column
-- column-reverse
+  - row
+  - row-reverse
+  - column
+  - column-reverse
 flex-wrap-values:
-- nowrap
-- wrap
-- wrap-reverse
+  - nowrap
+  - wrap
+  - wrap-reverse
 justify-content-values:
-- flex-start
-- flex-end
-- center
-- space-between
-- space-around
-- space-evenly
-- start
-- end
-- left
-- right
+  - flex-start
+  - flex-end
+  - center
+  - space-between
+  - space-around
+  - space-evenly
+  - start
+  - end
+  - left
+  - right
 align-content-values:
-- flex-start
-- flex-end
-- center
-- space-between
-- space-around
-- space-evenly
-- stretch
-- start
-- end
-- baseline
+  - flex-start
+  - flex-end
+  - center
+  - space-between
+  - space-around
+  - space-evenly
+  - stretch
+  - start
+  - end
+  - baseline
 align-items-values:
-- stretch
-- flex-start
-- flex-end
-- center
-- baseline
-- start
-- end
-- self-start
-- self-end
+  - stretch
+  - flex-start
+  - flex-end
+  - center
+  - baseline
+  - start
+  - end
+  - self-start
+  - self-end
 align-self-values:
-- auto
-- flex-start
-- flex-end
-- center
-- baseline
-- stretch
+  - auto
+  - flex-start
+  - flex-end
+  - center
+  - baseline
+  - stretch
 ---
 
 {% include elements/new-tag.html version="0.9.1" %}
 
 <div class="content">
   <p>
-    Combined with <code>is-flex</code>, all of the <strong>Flexbox CSS properties</strong> are available as Bulma helpers:
+    Combined with <code>is-flex</code>, all of the
+    <strong>Flexbox CSS properties</strong> are available as Bulma helpers:
   </p>
   <ul>
     <li><code>flex-direction</code></li>
@@ -73,34 +74,25 @@ align-self-values:
     <li><code>align-self</code></li>
     <li><code>flex-grow</code></li>
     <li><code>flex-shrink</code></li>
+    <li><code>gap</code></li>
   </ul>
 </div>
 
-{% include elements/anchor.html name="Flex direction" %}
-
-{% include elements/flexbox-helper-table.html property="flex-direction" values=page.flex-direction-values %}
-
-{% include elements/anchor.html name="Flex wrap" %}
-
-{% include elements/flexbox-helper-table.html property="flex-wrap" values=page.flex-wrap-values %}
-
-{% include elements/anchor.html name="Justify content" %}
-
-{% include elements/flexbox-helper-table.html property="justify-content" values=page.justify-content-values %}
-
-{% include elements/anchor.html name="Align content" %}
-
-{% include elements/flexbox-helper-table.html property="align-content" values=page.align-content-values %}
-
-{% include elements/anchor.html name="Align items" %}
-
-{% include elements/flexbox-helper-table.html property="align-items" values=page.align-items-values %}
-
-{% include elements/anchor.html name="Align self" %}
-
-{% include elements/flexbox-helper-table.html property="align-self" values=page.align-self-values %}
-
-{% include elements/anchor.html name="Flex grow and flex shrink" %}
+{% include elements/anchor.html name="Flex direction" %} {% include
+elements/flexbox-helper-table.html property="flex-direction"
+values=page.flex-direction-values %} {% include elements/anchor.html name="Flex
+wrap" %} {% include elements/flexbox-helper-table.html property="flex-wrap"
+values=page.flex-wrap-values %} {% include elements/anchor.html name="Justify
+content" %} {% include elements/flexbox-helper-table.html
+property="justify-content" values=page.justify-content-values %} {% include
+elements/anchor.html name="Align content" %} {% include
+elements/flexbox-helper-table.html property="align-content"
+values=page.align-content-values %} {% include elements/anchor.html name="Align
+items" %} {% include elements/flexbox-helper-table.html property="align-items"
+values=page.align-items-values %} {% include elements/anchor.html name="Align
+self" %} {% include elements/flexbox-helper-table.html property="align-self"
+values=page.align-self-values %} {% include elements/anchor.html name="Flex grow
+and flex shrink" %}
 
 <table class="table is-bordered">
   <thead>
@@ -114,20 +106,73 @@ align-self-values:
       <th colspan="2">Grow</th>
     </tr>
     {% for i in (0..5) %}
-      <tr>
-        <td><code>is-flex-grow-{{ i }}</code></td>
-        <td><code>flex-grow: {{ i }}</code></td>
-      </tr>
+    <tr>
+      <td><code>is-flex-grow-{{ i }}</code></td>
+      <td><code>flex-grow: {{ i }}</code></td>
+    </tr>
     {% endfor %}
     <tr>
       <th colspan="2">Shrink</th>
     </tr>
     {% for i in (0..5) %}
-      <tr>
-        <td><code>is-flex-shrink-{{ i }}</code></td>
-        <td><code>flex-shrink: {{ i }}</code></td>
-      </tr>
+    <tr>
+      <td><code>is-flex-shrink-{{ i }}</code></td>
+      <td><code>flex-shrink: {{ i }}</code></td>
+    </tr>
     {% endfor %}
   </tbody>
 </table>
 
+{% include elements/anchor.html name="Gap" %}
+
+<div class="content">
+  <p>
+    Gap sizes are calculated from the <code>initial-variables</code>
+    <code>$sizeX</code>-values.
+  </p>
+</div>
+
+<table class="table is-bordered">
+  <thead>
+    <th>Suffix</th>
+    <th>Value</th>
+    <th>Default Value</th>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>is-gap-1</code></td>
+      <td><code>$size1 / 3</code></td>
+      <td><code>1rem</code></td>
+    </tr>
+    <tr>
+      <td><code>is-gap-2</code></td>
+      <td><code>$size2 / 3</code></td>
+      <td><code>.833rem</code></td>
+    </tr>
+    <tr>
+      <td><code>is-gap-3</code></td>
+      <td><code>$size3 / 3</code></td>
+      <td><code>.667rem</code></td>
+    </tr>
+    <tr>
+      <td><code>is-gap-4</code></td>
+      <td><code>$size4 / 3</code></td>
+      <td><code>.5rem</code></td>
+    </tr>
+    <tr>
+      <td><code>is-gap-5</code></td>
+      <td><code>$size5 / 3</code></td>
+      <td><code>.416rem</code></td>
+    </tr>
+    <tr>
+      <td><code>is-gap-6</code></td>
+      <td><code>$size6 / 3</code></td>
+      <td><code>.333rem</code></td>
+    </tr>
+    <tr>
+      <td><code>is-gap-7</code></td>
+      <td><code>$size7 / 3</code></td>
+      <td><code>.25rem</code></td>
+    </tr>
+  </tbody>
+</table>

--- a/sass/helpers/flexbox.sass
+++ b/sass/helpers/flexbox.sass
@@ -30,13 +30,13 @@ $align-self-values: auto, flex-start, flex-end, center, baseline, stretch
   .is-align-self-#{$value}
     align-self: $value !important
 
-@each $size in $sizes
-  $i: index($sizes, $size)
-  .is-gap-#{$i}
-    gap: calc($size / 3) !important
-
 $flex-operators: grow, shrink
 @each $operator in $flex-operators
   @for $i from 0 through 5
     .is-flex-#{$operator}-#{$i}
       flex-#{$operator}: $i !important
+
+@each $size in $sizes
+  $i: index($sizes, $size)
+  .is-gap-#{$i}
+    gap: calc($size / 3) !important

--- a/sass/helpers/flexbox.sass
+++ b/sass/helpers/flexbox.sass
@@ -1,3 +1,5 @@
+@import "../utilities/derived-variables"
+
 $flex-direction-values: row, row-reverse, column, column-reverse
 @each $value in $flex-direction-values
   .is-flex-direction-#{$value}
@@ -27,6 +29,11 @@ $align-self-values: auto, flex-start, flex-end, center, baseline, stretch
 @each $value in $align-self-values
   .is-align-self-#{$value}
     align-self: $value !important
+
+@each $size in $sizes
+  $i: index($sizes, $size)
+  .is-gap-#{$i}
+    gap: calc($size / 3) !important
 
 $flex-operators: grow, shrink
 @each $operator in $flex-operators


### PR DESCRIPTION
This is a new feature.

### Proposed solution

Bulmas `is-flex` helpers greatly simplifies implementation of flexbox layouts, but a common request is to have gaps between the flexed items. These new `is-gap` classes greatly simplifies this.  
The sizes range from `is-gap-1` to `is-gap-7` and are derived from the initial `$size-X` values. The initial sizes are scaled down 1/3 to range between `.25rem` and `1rem` with Bulmas default sizes.

### Tradeoffs

This does create a slightly larger css bundle - although not a lot.  
It would also be an option to add different gaps for different screen sizes, but this would create an even larger bundle size without adding a lot of value.

### Testing Done

Local testing done with all sizes and settings. Works as expected.

### Changelog updated?

Yes - I have made a new section for 0.9.5
