### PR TITLE
Scope .icon to direct child of .has-icons-left|right

### DIFF
--- a/sass/form/tools.sass
+++ b/sass/form/tools.sass
@@ -180,7 +180,7 @@ $label-colors: $form-colors !default
         font-size: $size-medium
       &.is-large ~ .icon
         font-size: $size-large
-    .icon
+    >.icon
       color: $input-icon-color
       height: $input-height
       pointer-events: none


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->

<!-- Choose one of the following: -->
This is about **Bulma**. I consider it a bug.

### Overview of the problem

This is about the Bulma **CSS framework**
I'm using Bulma **version** 0.9.4

`.control.has-icons-left|right .icon` is overreaching, `.icon` should not match all descendants.

The bulma docs indicate the form field icon should be implemented with a `span.icon` as a direct child of the `.control`, but the css matches any descendant.  This can be a problem if you are using a different icon system that also requires its element to have the class icon. 

### Proposal

Forms `.control.has-icons-left .icon` should be `.control.has-icons-left > .icon`

Fix in saas sass/form/tools.saas (line 183) 
```
- 183 | .icon
+ 183 | >.icon
```

### Tradeoffs

So long as people have implemented according to docs, this minor change should have no negative side-effects, but could fix many issues.

### Testing Done

Specifically my use case was implementing an icon from my framework which generated html as:
```html
<p class="control is-expanded has-icons-left">
  <input class="input" type="text" placeholder="Name"> 
  <span class="icon is-small is-left"><i class="icon material-icons" style="">person </i></span>
</p>
```

I have changed my own tools.sass and tested my entire app, saw no negative impact, but it did fix all the forms which was displaying like this:

![image](https://github.com/jgthms/bulma/assets/139705774/230d8fdc-cb72-45c5-85c2-3ca45c17d76b)

And after fix:
![image](https://github.com/jgthms/bulma/assets/139705774/4799efc4-d00b-4e27-95ab-123b64edcd6e)


### Changelog updated?

No.


