### PR TITLE
Add vars for tag.is-delete :hover/:focus/:active background

### DIFF
--- a/sass/elements/tag.sass
+++ b/sass/elements/tag.sass
@@ -4,6 +4,8 @@ $tag-background-color: $background !default
 $tag-color: $text !default
 $tag-radius: $radius !default
 $tag-delete-margin: 1px !default
+$tag-delete-background-color-focus: darken($tag-background-color, 5%) !default
+$tag-delete-background-color-active: darken($tag-background-color, 10%) !default
 
 $tag-colors: $colors !default
 
@@ -129,9 +131,9 @@ $tag-colors: $colors !default
       width: 1px
     &:hover,
     &:focus
-      background-color: darken($tag-background-color, 5%)
+      background-color: $tag-delete-background-color-focus
     &:active
-      background-color: darken($tag-background-color, 10%)
+      background-color: $tag-delete-background-color-active
   &.is-rounded
     border-radius: $radius-rounded
 


### PR DESCRIPTION
This is an **improvement** that will allow people to bind `$background` to CSS variables.

### Proposed solution

Not a direct solution to but will help:
- #3694

### Tradeoffs

No tradeoffs.

### Testing Done

- [x] 1. Pull the latest `master` branch
- [x] 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide)
- [x] 3. Make sure your PR only affects `.sass` or documentation files
- [x] 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes).

**Additional check**: No diffs in output `css/bulma.css` files before and after this change.

### Changelog updated?

No.