### PR TITLE
Fix "at the following" typo

### DIFF
--- a/docs/documentation/components/modal.html
+++ b/docs/documentation/components/modal.html
@@ -222,7 +222,7 @@ document.addEventListener('DOMContentLoaded', () => {
   <h4>1. Add the HTML for the modal</h4>
 
   <p>
-    At the end of your page, before the closing <code>&lt;/body&gt;</code> tag, at the following HTML snippet:
+    At the end of your page, before the closing <code>&lt;/body&gt;</code> tag, add the following HTML snippet:
   </p>
 </div>
 


### PR DESCRIPTION
Should be: "add the following"

<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **documentation fix**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution

There is minor typo regarding modals. Replace "at" with "add" regarding the example HTML to be included for modals.

### Tradeoffs

Just a simple typo fix here.

### Testing Done

None. Fixes docs only.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

### Changelog updated?

No.

<!-- Thanks! -->
