### PR TITLE
Fix broken logo links in `/brand/`

### DIFF
--- a/docs/_includes/docs/components/logos-item.html
+++ b/docs/_includes/docs/components/logos-item.html
@@ -11,10 +11,10 @@
   <div class="bd-logos-download">
     <div class="has-text-centered">
       <div class="buttons are-centered">
-        <a class="button is-primary is-light is-small" href="{{ site.url }}/assets/{{ include.asset }}.png">
+        <a class="button is-primary is-light is-small" href="{{ site.url }}/assets/brand/{{ include.asset }}.png">
           PNG
         </a>
-        <a class="button is-primary is-light is-small" href="{{ site.url }}/assets/{{ include.asset }}.svg">
+        <a class="button is-primary is-light is-small" href="{{ site.url }}/assets/brand/{{ include.asset }}.svg">
           SVG
         </a>
       </div>


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **documentation fix**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

Links to the PNG/SVG image assets on https://bulma.io/brand/ are all broken.

### Proposed solution

<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

Images with path `/assets/` should now be `/assets/brand/`.

### Tradeoffs

<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->

None.

### Testing Done

I've tested that the new links in the docs work.

### Changelog updated?

No.

