### PR TITLE
Correct Responsiveness page title

### DIFF
--- a/docs/documentation/start/responsiveness.html
+++ b/docs/documentation/start/responsiveness.html
@@ -1,5 +1,5 @@
 ---
-title: How to install Bulma
+title: Responsiveness
 layout: docs
 theme: start
 doc-tab: start


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **documentation fix**.

### Proposed solution

The page title for 'Responsiveness' was `How to install Bulma`, which is likely a copy-paste mistake from the Installation page.

Reading the incorrect title on the page is misleading, obviously.

### Tradeoffs

N/A

### Testing Done

None.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

### Changelog updated?

No.

<!-- Thanks! -->
