### PR TITLE
Fix(readme): correct link to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Internet Explorer (10+) is only partially supported.
 
 The documentation resides in the [docs](docs) directory, and is built with the Ruby-based [Jekyll](https://jekyllrb.com/) tool.
 
-Browse the [online documentation here.](https://bulma.io/documentation/overview/start/)
+Browse the [online documentation here.](https://bulma.io/documentation/start/overview/)
 
 ## Related projects
 


### PR DESCRIPTION
This is a **documentation fix**.

There was a broken link in the docs so I fixed it