### PR TITLE
Remove positioning from sidebar menu

### DIFF
--- a/docs/_data/links.json
+++ b/docs/_data/links.json
@@ -860,7 +860,6 @@
     "helpers": [
       "helpers-color",
       "helpers-palette",
-      "helpers-positioning",
       "helpers-spacing",
       "helpers-typography",
       "helpers-visibility",


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **documentation fix**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution

<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

The `helpers-positioning` and `helpers-spacing` helpers both point to the same page. `helpers-sizing` also points to this page, but is not part of the helpers that are shown in the sidebar menu.

![Screenshot 2024-03-30 at 14 24 31](https://github.com/jgthms/bulma/assets/178448/e64403f9-845c-48ea-ad75-ee9bb9b9bb23)

I'm removing `helpers-positioning` as the page is called "Spacing helpers" when entering it.

<!-- ### Tradeoffs -->

<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->

### Testing Done

None.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

### Changelog updated?

No.

<!-- Thanks! -->
