### PR TITLE
Can customize $gap-base in sass/helpers/gap.scss

### DIFF
--- a/sass/helpers/gap.scss
+++ b/sass/helpers/gap.scss
@@ -7,7 +7,7 @@
 }
 
 $gaps: "gap", "column-gap", "row-gap";
-$gap-base: 0.5rem;
+$gap-base: 0.5rem !default;
 
 @each $gap in $gaps {
   @for $i from 0 through 8 {


### PR DESCRIPTION
This is an improvement.

It would be awesome to customize the gap behavior by overwriting the $gap-base css variable.

This is a very none-intrusive change that will open up for more customization on an essential element on a website: spacing.

### Testing Done

None.

<!-- How have you confirmed this feature works? -->

Used branch version of bulma in local project where $gap-base was overwritten in a sass @use statement.

### Changelog updated?

No.