### PR TITLE
Fix GitHub link

### DIFF
--- a/docs/_includes/home/features.html
+++ b/docs/_includes/home/features.html
@@ -23,7 +23,7 @@
       subtitle="Download. Customize. Done."
       href=href
     %}
-    {% assign href = site.meta.github %}
+    {% assign href = site.data.meta.github %}
     {{ href }}
     {% include website/feature.html
       id="free"


### PR DESCRIPTION
This is an improvement to the homepage.

Proposed solution:
Fix the github button link

Tradeoffs:
None

Testing Done:
None

Changelog updated?
No