### PR TITLE
Add Composer support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,25 @@
+{
+  "name": "jgthms/bulma",
+  "description": "Modern CSS framework based on Flexbox",
+  "keywords": [
+    "css",
+    "sass",
+    "scss",
+    "flexbox",
+    "grid",
+    "responsive",
+    "framework"
+  ],
+  "homepage": "https://bulma.io",
+  "authors": [
+    {
+      "name": "Jeremy Thomas",
+      "email": "bbxdesign@gmail.com",
+      "homepage": "https://jgthms.com"
+    }
+  ],
+  "support": {
+    "issues": "https://github.com/jgthms/bulma/issues"
+  },
+  "license": "MIT"
+}


### PR DESCRIPTION
This is a **improvement**.

Support installing Bulma via [Composer](getcomposer.org), in PHP projects.

Some modern PHP frameworks, such as Symfony and Laravel, give the possibility to customize and compile sass files without adding node-npm stack to the project.
In that situation, installing Bulma via Composer could be very handy.

### Proposed solution

Supporting Composer is trivial:
  1. add `composer.json` file to Bulma root (this PR)
  2. add Bulma repository to [Packagist](packagist.org) (I can do it and add @jgthms as administrator)


### Changelog updated?

No.
