### PR TITLE
Fix swapped paragraphs in grid-cells doc

### DIFF
--- a/docs/documentation/grid/grid-cells.html
+++ b/docs/documentation/grid/grid-cells.html
@@ -90,7 +90,7 @@ Each Bulma grid is comprised of several **cells**. You can adjust the width and 
 {% endcapture %}
 
 {% capture markdown %}
-Change which column a cell ends at, counting from the end.
+Change which column a cell starts at.
 {% endcapture %}
 
 {% include markdown.html content=markdown %}
@@ -130,7 +130,7 @@ Change which column a cell ends at, counting from the end.
 {% endcapture %}
 
 {% capture markdown %}
-Change which column a cell starts at.
+Change which column a cell ends at, counting from the end.
 {% endcapture %}
 
 {% include markdown.html content=markdown %}


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a documentation fix.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution

Paragraphs explaining `column-start` and `column-from-end` were swapped.
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->


### Tradeoffs

<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->

None.

### Testing Done

None.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

### Changelog updated?

No.

<!-- Thanks! -->
