### PR TITLE
Fix bulma color brightness

### DIFF
--- a/sass/utilities/functions.scss
+++ b/sass/utilities/functions.scss
@@ -184,10 +184,10 @@
 
 @function bulmaColorBrightness($n) {
   $color-brightness: round(
-    (red($n) * 299) + (green($n) * 587) + (blue($n) * 114) / 1000
+   ((red($n) * 299) + (green($n) * 587) + (blue($n) * 114)) / 1000
   );
   $light-color: round(
-    (red(#ffffff) * 299) + (green(#ffffff) * 587) + (blue(#ffffff) * 114) / 1000
+    ((red(#ffffff) * 299) + (green(#ffffff) * 587) + (blue(#ffffff) * 114)) / 1000
   );
 
   @if abs($color-brightness) < math.div($light-color, 2) {

--- a/sass/utilities/functions.scss
+++ b/sass/utilities/functions.scss
@@ -184,10 +184,10 @@
 
 @function bulmaColorBrightness($n) {
   $color-brightness: round(
-   ((red($n) * 299) + (green($n) * 587) + (blue($n) * 114)) / 1000
+   math.div((red($n) * 299) + (green($n) * 587) + (blue($n) * 114), 1000)
   );
   $light-color: round(
-    ((red(#ffffff) * 299) + (green(#ffffff) * 587) + (blue(#ffffff) * 114)) / 1000
+    math.div((red(#ffffff) * 299) + (green(#ffffff) * 587) + (blue(#ffffff) * 114), 1000)
   );
 
   @if abs($color-brightness) < math.div($light-color, 2) {


### PR DESCRIPTION
This is a **bugfix**.

### Proposed solution

Previously, the bulmaColorBrightness function was understating the value of the blue channel when estimating brightness for a specific colour, due to a missing set of brackets. This just corrects the brackets so that all channels of the colour are weighted, instead of just red and green.

Additionally, I've switched from the slash division operation which is deprecated in Sass, to the math.div operator.

### Tradeoffs

Some folks may be relying on the slightly odd behaviour, though with blue being the least significant channel for brightness this will be an edge case and will likely be a producing confusing rules with the current implementation.

### Testing Done

Ran the docs site and visually compared a variety of buttons, panels, box, and theme pages to ensure no difference. Using the default theming values, validated that there are no differences before and after this change in the output css.

### Changelog updated?

No, but happy too if that's a good idea.
