### PR TITLE
Fix proportions of icon only rounded buttons to be perfect circles

### DIFF
--- a/sass/elements/button.scss
+++ b/sass/elements/button.scss
@@ -534,14 +534,28 @@ $no-palette: ("white", "black", "light", "dark");
 
   &.#{iv.$class-prefix}is-rounded {
     border-radius: cv.getVar("radius-rounded");
-    padding-left: calc(
-      #{cv.getVar("button-padding-horizontal")} + #{$button-rounded-padding-horizontal-offset} -
-        #{cv.getVar("button-border-width")}
-    );
-    padding-right: calc(
-      #{cv.getVar("button-padding-horizontal")} + #{$button-rounded-padding-horizontal-offset} -
-        #{cv.getVar("button-border-width")}
-    );
+
+    &:not(:has(.icon:only-child)) {
+      padding-left: calc(
+        #{cv.getVar("button-padding-horizontal")} + #{$button-rounded-padding-horizontal-offset} -
+          #{cv.getVar("button-border-width")}
+      );
+      padding-right: calc(
+        #{cv.getVar("button-padding-horizontal")} + #{$button-rounded-padding-horizontal-offset} -
+          #{cv.getVar("button-border-width")}
+      );
+    }
+
+    @supports not selector(:has(a, b)) {
+      padding-left: calc(
+        #{cv.getVar("button-padding-horizontal")} + #{$button-rounded-padding-horizontal-offset} -
+          #{cv.getVar("button-border-width")}
+      );
+      padding-right: calc(
+        #{cv.getVar("button-padding-horizontal")} + #{$button-rounded-padding-horizontal-offset} -
+          #{cv.getVar("button-border-width")}
+      );
+    }
   }
 }
 


### PR DESCRIPTION
This is an **improvement / bugfix**.

Currently, creating a button with only a single icon inside it results in a perfect square icon button, but doing the same with the `is-rounded` modifier doesn't result in a perfect circle because extra padding is added for rounded buttons.

Submitting as improvement / bugfix because I think it depends on how you look at it — to me the icon-only buttons should be perfect circles, but this is really a small enhancement with a minor impact to make that specific scenario true. My gut feel says the icons appearing as circles would be the expected / preferred result when adding the `is-rounded` modifier.


### Proposed solution


Add an extra selector to move the extra padding case to happen only in the cases where a single icon isn't the sole child of the button.

This means that circular icon buttons can now  be created, but adding any other content to the button still results in the exact same proportions as before.

As maybe an optional thing I put the `:has()` selector behind behind an `@supports` rule to more gracefully handle older browsers that don't support it (falling back to the same logic as before). But it has recently gained good browser support too and I see some instances of it starting to turn up in Bulma already — so unsure wether the progressive enhancement is necessary!


### Tradeoffs

Adds a bit more duplicated css having the feature detection in there. But on the flipside browsers drop the whole rule set if `:has()` isn't supported so it feels good to have given the recency of browser support coverage.

Adds a bit more complexity to the button ruleset overall.

I don't see too many other drawbacks unless people are currently relying on the oval shaped icon buttons — seems unlikely but it could be a thing?


### Testing Done

Checked all existing buttons in the docs locally, and added the `is-rounded` modifier to as many variations as I could find or think of, making sure that anything more than a single icon as the only child still results in the same padding behaviour as before.

**Before:**

<img width="776" alt="image" src="https://github.com/jgthms/bulma/assets/616368/85103d35-37ac-4375-a6c8-92cf0d25cb17">


**After:**

<img width="768" alt="image" src="https://github.com/jgthms/bulma/assets/616368/bbfa1090-aeb7-4ac2-bcd3-4746dd1e4c7a">


### Changelog updated?

No.
