### PR TITLE
Removed the include tag at the end of message.html

### DIFF
--- a/docs/documentation/components/message.html
+++ b/docs/documentation/components/message.html
@@ -204,5 +204,4 @@ endfor %} {% include docs/elements/anchor.html name="Sizes" %}
 {% include docs/elements/snippet.html content=message_small %} {% include
 docs/elements/snippet.html content=message_normal %} {% include
 docs/elements/snippet.html content=message_medium %} {% include
-docs/elements/snippet.html content=message_large %} {% include
-docs/components/variables.html type='component' %}
+docs/elements/snippet.html content=message_large %}


### PR DESCRIPTION
This include tag is not necessary, since the layout for the docs already includes it, and results in duplication.

<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **bugfix**.

<!-- Bugfix? Reference that issue as well. -->

The following include tag is not necessary since the Documents layout already includes it, and causes duplication. 

Previously (lines 207-208):

```
docs/elements/snippet.html content=message_large %} {% include
docs/components/variables.html type='component' %}
```

Now:

```
docs/elements/snippet.html content=message_large %}
```


### Testing Done

None.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

Duplication successfully removed.

### Changelog updated?

No.

<!-- Thanks! -->
