### PR TITLE
Update Lambdatest logo for support both Dark and Light mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Browse the [online documentation here.](https://bulma.io/documentation/start/ove
 | [Manifest](https://manifest.build)                                                   | Manifest is a lightweight Backend-as-a-Service with essential features: DB, Admin panel, API, JS SDK             |
 | [Reactive Bulma](https://github.com/NicolasOmar/reactive-bulma)                                                             | A component library based on React, Bulma, Typescript and Rollup         |
 
-<p>Browser testing via <a href="https://www.lambdatest.com/" target="_blank"><img src="https://www.lambdatest.com/resources/images/logo-white.svg" style="vertical-align: middle;margin-left:5px" width="147" height="26" /></a></p>
+<p>Browser testing via <a href="https://www.lambdatest.com/" target="_blank"><img src="https://www.lambdatest.com/resources/images/logos/logo.svg" style="vertical-align: middle;margin-left:5px" width="147" height="26" /></a></p>
 
 ## Copyright and license ![Github](https://img.shields.io/github/license/jgthms/bulma?logo=Github)
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,14 @@ Browse the [online documentation here.](https://bulma.io/documentation/start/ove
 | [Manifest](https://manifest.build)                                                   | Manifest is a lightweight Backend-as-a-Service with essential features: DB, Admin panel, API, JS SDK             |
 | [Reactive Bulma](https://github.com/NicolasOmar/reactive-bulma)                                                             | A component library based on React, Bulma, Typescript and Rollup         |
 
-<p>Browser testing via <a href="https://www.lambdatest.com/" target="_blank"><img src="https://www.lambdatest.com/resources/images/logos/logo.svg" style="vertical-align: middle;margin-left:5px" width="147" height="26" /></a></p>
+<p>Browser testing via 
+<a href=https://www.lambdatest.com/ target="_blank">
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset=https://www.lambdatest.com/resources/images/logo-white.svg>
+  <img src=https://www.lambdatest.com/resources/images/logos/logo.svg style="vertical-align: middle;margin-left:5px" width="147" height="26" />
+</picture>
+</a>
+</p>
 
 ## Copyright and license ![Github](https://img.shields.io/github/license/jgthms/bulma?logo=Github)
 


### PR DESCRIPTION
This is a **improvement**.
Currently, Lambdatest logo just display correct with Dark mode. With the White mode, it look link the blank.

### Proposed solution

Check Dark and Light mode for display Lambdatest logo correctly.

## Before:
<img width="621" alt="Before_After" src="https://github.com/user-attachments/assets/4326c16a-f198-43e2-97d8-ef15509bca28">
<img width="661" alt="Before_Black" src="https://github.com/user-attachments/assets/13ad5d25-c484-46ca-9ec3-860d44d9774d">

## After:
<img width="612" alt="After_White" src="https://github.com/user-attachments/assets/ef61e262-dd43-4bd4-8a2e-752c6b0122f1">
<img width="599" alt="After_Black" src="https://github.com/user-attachments/assets/884b145e-edc1-4e19-8539-010249c7edfc">


### Testing Done

Tested on both Dark and Light mode.

### Changelog updated?

No.
