### PR TITLE
Added style to "<input type="color" />" component

### DIFF
--- a/sass/form/shared.scss
+++ b/sass/form/shared.scss
@@ -169,6 +169,25 @@ $input-radius: cv.getVar("radius") !default;
       color: cv.getVar("input-disabled-placeholder-color");
     }
   }
+
+  &[type="color"] {
+    width: cv.getVar("input-height");
+    min-width: cv.getVar("input-height");
+    max-width: cv.getVar("input-height");
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+
+    &::-webkit-color-swatch-wrapper {
+      margin: 0;
+      padding: 0;
+    }
+    &::-webkit-color-swatch {
+      margin: 0;
+      padding: 0;
+      border: none;
+    }
+  }
 }
 
 %input {


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **improvement**.
I added some specific style for the `<input class="input" type="color">`

### Proposed solution

This PR solve the issue #3789

## Before
![Before](https://github.com/user-attachments/assets/c8ee89eb-5612-4bfc-89c4-a6796a2d2323)

## After
![After](https://github.com/user-attachments/assets/9e175f92-b5a0-4e64-b478-bb7e28d4b0c4)



### Testing Done

Tested on both Dark and Light mode and tested on different browsers (Firefox, Chrome, Brave and Safari).

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

### Changelog updated?

No.

<!-- Thanks! -->
