### PR TITLE
fix(package.json): `.min` suffixes were duplicated for `version-prefixed`

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "version-no-dark-mode": "sass --style=expanded --source-map versions/bulma-no-dark-mode.scss css/versions/bulma-no-dark-mode.css",
     "version-no-helpers": "sass --style=expanded --source-map versions/bulma-no-helpers.scss css/versions/bulma-no-helpers.css",
     "version-no-helpers-prefixed": "sass --style=expanded --source-map versions/bulma-no-helpers-prefixed.scss css/versions/bulma-no-helpers-prefixed.css",
-    "version-prefixed": "sass --style=expanded --source-map versions/bulma-prefixed.scss css/versions/bulma-prefixed.min.css",
+    "version-prefixed": "sass --style=expanded --source-map versions/bulma-prefixed.scss css/versions/bulma-prefixed.css",
     "build-versions": "npm run version-no-dark-mode && npm run version-no-helpers && npm run version-no-helpers-prefixed && npm run version-prefixed",
     "minify-versions": "postcss css/versions/*.css --dir css/versions --ext min.css --no-map --use cssnano",
     "build-all": "npm run build-bulma && npm run build-versions",


### PR DESCRIPTION
This patch corrects the `version-prefixed` script in `package.json` by removing the duplicated `.min` suffix. The script now correctly outputs `bulma-prefixed.css` instead of `bulma-prefixed.min.css`, which was then minified to `bulma-prefixed.min.min.css`.