### PR TITLE
feat: Add new helpers-only version

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,11 +38,12 @@
   "scripts": {
     "build-bulma": "sass --style=expanded --source-map bulma.scss css/bulma.css",
     "minify-bulma": "postcss css/bulma.css --no-map --use cssnano --output css/bulma.min.css",
+    "version-helpers": "sass --style=expanded --source-map versions/bulma-helpers.scss css/versions/bulma-helpers.css",
     "version-no-dark-mode": "sass --style=expanded --source-map versions/bulma-no-dark-mode.scss css/versions/bulma-no-dark-mode.css",
     "version-no-helpers": "sass --style=expanded --source-map versions/bulma-no-helpers.scss css/versions/bulma-no-helpers.css",
     "version-no-helpers-prefixed": "sass --style=expanded --source-map versions/bulma-no-helpers-prefixed.scss css/versions/bulma-no-helpers-prefixed.css",
     "version-prefixed": "sass --style=expanded --source-map versions/bulma-prefixed.scss css/versions/bulma-prefixed.min.css",
-    "build-versions": "npm run version-no-dark-mode && npm run version-no-helpers && npm run version-no-helpers-prefixed && npm run version-prefixed",
+    "build-versions": "npm run version-helpers && npm run version-no-dark-mode && npm run version-no-helpers && npm run version-no-helpers-prefixed && npm run version-prefixed",
     "minify-versions": "postcss css/versions/*.css --dir css/versions --ext min.css --no-map --use cssnano",
     "build-all": "npm run build-bulma && npm run build-versions",
     "minify-all": "npm run minify-bulma && npm run minify-versions",

--- a/versions/bulma-helpers.scss
+++ b/versions/bulma-helpers.scss
@@ -1,0 +1,12 @@
+@charset "utf-8";
+
+/*! bulma.io v1.0.2 | MIT License | github.com/jgthms/bulma */
+@forward "../sass/helpers";
+
+@use "../sass/themes/light";
+@use "../sass/themes/setup";
+
+:root {
+  @include light.light-theme;
+  @include setup.setup-theme;
+}


### PR DESCRIPTION
**Purpose:**
Introduce a new version of Bulma that includes only the helper classes, allowing users to utilize these handy classes without importing the entire Bulma framework.

**Changes:**
- Added a new script `version-helpers` in `package.json` to build the helpers-only version.
- Created a new file `versions/bulma-helpers.scss` that imports only the necessary helper classes and themes.

**Benefits:**
- **Flexibility:** Users can now integrate Bulma's helper classes into their projects without the overhead of the full framework.
- **Efficiency:** Ideal for small projects or those that require only specific utility classes, reducing the overall CSS footprint.
- **Modularity:** Enhances Bulma's modularity, making it more adaptable to various project needs.