### PR TITLE
fix: themes were missing from no-helpers versions

### DIFF
--- a/versions/bulma-no-helpers-prefixed.scss
+++ b/versions/bulma-no-helpers-prefixed.scss
@@ -4,6 +4,7 @@
 @use "../sass/utilities" with (
   $class-prefix: "bulma-"
 );
+@forward "../sass/themes";
 @forward "../sass/base";
 @forward "../sass/elements";
 @forward "../sass/form";

--- a/versions/bulma-no-helpers.scss
+++ b/versions/bulma-no-helpers.scss
@@ -2,6 +2,7 @@
 
 /*! bulma.io v1.0.2 | MIT License | github.com/jgthms/bulma */
 @forward "../sass/utilities";
+@forward "../sass/themes";
 @forward "../sass/base";
 @forward "../sass/elements";
 @forward "../sass/form";


### PR DESCRIPTION
This pull request addresses issue [#3894](https://github.com/jgthms/bulma/issues/3894) where the `no-helpers` versions of Bulma were missing theme forwarding, resulting in unstyled pages when custom colors were set via `:root {}` variables.

**Changes**:
- Added `@forward "../sass/themes";` to `versions/bulma-no-helpers-prefixed.scss`.
- Added `@forward "../sass/themes";` to `versions/bulma-no-helpers.scss`.