### PR TITLE
Remove the navigation role from navbar examples

### DIFF
--- a/docs/documentation/components/navbar.html
+++ b/docs/documentation/components/navbar.html
@@ -19,7 +19,7 @@ modals:
 ---
 
 {% capture navbar_basic_example %}
-<nav class="navbar" role="navigation" aria-label="main navigation">
+<nav class="navbar" aria-label="main navigation">
   <div class="navbar-brand">
     <a class="navbar-item" href="{{ site.url }}">
       {% include svg/bulma-logo.html %}
@@ -87,7 +87,7 @@ modals:
 {% endcapture %}
 
 {% capture navbar_brand_example %}
-<nav class="navbar" role="navigation" aria-label="main navigation">
+<nav class="navbar" aria-label="main navigation">
   <div class="navbar-brand">
     <!-- navbar items, navbar burger... -->
   </div>
@@ -113,7 +113,7 @@ modals:
 {% endcapture %}
 
 {% capture navbar_brand_items_example %}
-<nav class="navbar" role="navigation" aria-label="main navigation">
+<nav class="navbar" aria-label="main navigation">
   <div class="navbar-brand">
     <a class="navbar-item" href="{{ site.url }}">
       {% include svg/bulma-logo.html %}
@@ -130,7 +130,7 @@ modals:
 {% endcapture %}
 
 {% capture navbar_menu_example %}
-<nav class="navbar" role="navigation" aria-label="main navigation">
+<nav class="navbar" aria-label="main navigation">
   <div class="navbar-brand">
     <!-- navbar items, navbar burger... -->
   </div>
@@ -222,7 +222,7 @@ modals:
 {% endcapture %}
 
 {% capture navbar_dropdown_example %}
-<nav class="navbar" role="navigation" aria-label="dropdown navigation">
+<nav class="navbar" aria-label="dropdown navigation">
   <div class="navbar-item has-dropdown">
     <a class="navbar-link">
       Docs
@@ -254,7 +254,7 @@ modals:
 {% endcapture %}
 
 {% capture navbar_dropdown_hover_example %}
-<nav class="navbar" role="navigation" aria-label="dropdown navigation">
+<nav class="navbar" aria-label="dropdown navigation">
   <div class="navbar-item has-dropdown is-hoverable">
     <a class="navbar-link">
       Docs
@@ -286,7 +286,7 @@ modals:
 {% endcapture %}
 
 {% capture navbar_dropdown_active_example %}
-<nav class="navbar" role="navigation" aria-label="dropdown navigation">
+<nav class="navbar" aria-label="dropdown navigation">
   <div class="navbar-item has-dropdown is-active">
     <a class="navbar-link">
       Docs
@@ -318,7 +318,7 @@ modals:
 {% endcapture %}
 
 {% capture navbar_dropdown_right_example %}
-<nav class="navbar" role="navigation" aria-label="dropdown navigation">
+<nav class="navbar" aria-label="dropdown navigation">
   <div class="navbar-menu">
     <div class="navbar-start">
       <div class="navbar-item has-dropdown is-active">
@@ -407,7 +407,7 @@ modals:
   </div>
 </section>
 
-<nav class="navbar" role="navigation" aria-label="dropdown navigation">
+<nav class="navbar" aria-label="dropdown navigation">
   <div class="navbar-menu">
     <div class="navbar-start">
       <div class="navbar-item has-dropdown has-dropdown-up is-active">
@@ -437,7 +437,7 @@ modals:
 {% endcapture %}
 
 {% capture navbar_dropdown_default_example %}
-<nav class="navbar" role="navigation" aria-label="dropdown navigation">
+<nav class="navbar" aria-label="dropdown navigation">
   <a class="navbar-item">
     {% include svg/bulma-logo.html %}
   </a>
@@ -478,7 +478,7 @@ modals:
 {% endcapture %}
 
 {% capture navbar_dropdown_boxed_example %}
-<nav class="navbar is-transparent" role="navigation" aria-label="dropdown navigation">
+<nav class="navbar is-transparent" aria-label="dropdown navigation">
   <a class="navbar-item">
     {% include svg/bulma-logo.html %}
   </a>
@@ -519,7 +519,7 @@ modals:
 {% endcapture %}
 
 {% capture navbar_dropdown_item_active_example %}
-<nav class="navbar" role="navigation" aria-label="dropdown navigation">
+<nav class="navbar" aria-label="dropdown navigation">
   <a class="navbar-item">
     {% include svg/bulma-logo.html %}
   </a>


### PR DESCRIPTION
This is a **documentation fix**.

### Proposed solution

See the [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/navigation_role#description):

> Using the &lt;nav&gt; element will automatically communicate a section has a role of navigation. Developers should always prefer using the correct semantic HTML element over using ARIA

### Tradeoffs

None.

### Testing Done

None.

### Changelog updated?

No.
