### PR TITLE
Remove vendor prefixes from sass

### DIFF
--- a/sass/base/skeleton.scss
+++ b/sass/base/skeleton.scss
@@ -65,7 +65,7 @@ input.#{iv.$class-prefix}is-skeleton,
 textarea.#{iv.$class-prefix}is-skeleton {
   resize: none;
 
-  @include mx.placeholder {
+  &::placeholder {
     color: transparent !important;
   }
 }

--- a/sass/form/shared.scss
+++ b/sass/form/shared.scss
@@ -121,7 +121,7 @@ $input-radius: cv.getVar("radius") !default;
     #{cv.getVar("input-color-l")}
   );
 
-  @include mx.placeholder {
+  &::placeholder {
     color: cv.getVar("input-placeholder-color");
   }
 
@@ -167,7 +167,7 @@ $input-radius: cv.getVar("radius") !default;
     box-shadow: none;
     color: cv.getVar("input-disabled-color");
 
-    @include mx.placeholder {
+    &::placeholder {
       color: cv.getVar("input-disabled-placeholder-color");
     }
   }

--- a/sass/utilities/mixins.scss
+++ b/sass/utilities/mixins.scss
@@ -237,16 +237,10 @@
 
 @mixin selection($current-selector: false) {
   @if $current-selector {
-    &::-moz-selection {
-      @content;
-    }
     &::selection {
       @content;
     }
   } @else {
-    ::-moz-selection {
-      @content;
-    }
     ::selection {
       @content;
     }
@@ -432,9 +426,6 @@
 
 @mixin unselectable {
   -webkit-touch-callout: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
 }
 

--- a/sass/utilities/mixins.scss
+++ b/sass/utilities/mixins.scss
@@ -224,16 +224,6 @@
   -webkit-overflow-scrolling: touch;
 }
 
-@mixin placeholder {
-  $placeholders: ":-moz" ":-webkit-input" "-moz" "-ms-input";
-
-  @each $placeholder in $placeholders {
-    &:#{$placeholder}-placeholder {
-      @content;
-    }
-  }
-}
-
 @mixin reset {
   appearance: none;
   background: none;


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **new feature | improvement | bugfix | documentation fix**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution

When debugging some other issues with placeholders in my application, I noticed some vendor prefixes popping up on attributes where I did not expect them. Then I figured that they are actually hardcoded within the scope of this repository, rather than applied by tooling (e.g. `autoprefixer`).

*Edit:* for the `::placeholder` mixin, it was actually rendering all the variants *except* for the correct modern `::placeholder` pseudo-element, so this actually might ensure proper behavior across environments that previously did not work.

This PR removes the hardcoded vendor-prefixed variants of some properties. The preferred way (I think) should be using tooling to handle this. Although the `README` mentions that `autoprefixer` is used within this repository, it seems it has since been replaced with `cssnano`, which may not include it by default.

Probably this requires rebuilding `css` too, however the `npm run build` alias mentioned in `CONTRIBUTING.md` no longer exists, so I'm not sure which parts are intended to run on MR submissions.

Note: I encountered this issue on version `v0.9.4`, but I'm not sure if bugfixes are still welcome for the old version?

### Tradeoffs

Theoretically this could cause a change of behavior on legacy browsers. Given the wide availability of the non-prefixed alternatives and the fact that tooling like `autoprefixer` is commonly used, I suspect this will have little to no impact in that regard.

### Testing Done

None.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

### Changelog updated?

No.

<!-- Thanks! -->
