### PR TITLE
Correct the syntax in hero is-bold colour variants

### DIFF
--- a/sass/layout/hero.scss
+++ b/sass/layout/hero.scss
@@ -122,9 +122,9 @@ $hero-colors: dv.$colors !default;
       // Modifiers
       &.#{iv.$class-prefix}is-bold {
         $gradient-top-left: hsl(
-          calc(#{cv.getVar("hero-h")} - $hero-gradient-h-offset),
-          calc(#{cv.getVar("hero-s")} + $hero-gradient-s-offset),
-          calc(#{cv.getVar("hero-background-l")} + $hero-gradient-l-offset)
+          calc(#{cv.getVar("hero-h")} - #{$hero-gradient-h-offset}),
+          calc(#{cv.getVar("hero-s")} + #{$hero-gradient-s-offset}),
+          calc(#{cv.getVar("hero-background-l")} + #{$hero-gradient-l-offset})
         );
         $gradient-middle: hsl(
           #{cv.getVar("hero-h")},
@@ -132,9 +132,9 @@ $hero-colors: dv.$colors !default;
           #{cv.getVar("hero-background-l")}
         );
         $gradient-bottom-right: hsl(
-          calc(#{cv.getVar("hero-h")} + $hero-gradient-h-offset),
-          calc(#{cv.getVar("hero-s")} - $hero-gradient-s-offset),
-          calc(#{cv.getVar("hero-background-l")} - $hero-gradient-l-offset)
+          calc(#{cv.getVar("hero-h")} + #{$hero-gradient-h-offset}),
+          calc(#{cv.getVar("hero-s")} - #{$hero-gradient-s-offset}),
+          calc(#{cv.getVar("hero-background-l")} - #{$hero-gradient-l-offset})
         );
 
         background-image: linear-gradient(


### PR DESCRIPTION
While the prior syntax does produce valid css, it's not quite valid scss and so produces warnings in various pre and post-processing pipelines which various upstream consumers of Bulma may use.

<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **bugfix**.

### Proposed solution

By using the correct scss syntax, we just prevent downstream warnings and errors, and make this file consistent with the rest of the bulma codebase., for example:

```
#30 114.5 WARNING in css/partner_portal-d7c813d1.css
#30 114.5 css/partner_portal-d7c813d1.css from Css Minimizer plugin
#30 114.5 postcss-calc:: Lexical error on line 1: Unrecognized text.
#30 114.5 
#30 114.5   Erroneous area:
#30 114.5 1: var(--bulma-hero-h) - $hero-gradient-h-offset
#30 114.5 ^........................^ webpack://./node_modules/bulma/sass/layout/hero.scss:146:12
```

### Testing Done

Generated css output has no difference before and after this change.

### Changelog updated?

No.
