### PR TITLE
[Docs] Mention required order on form controls' modifiers

### DIFF
--- a/docs/documentation/form/general.html
+++ b/docs/documentation/form/general.html
@@ -915,7 +915,8 @@ variables_keys:
     <li><code>icon is-left</code> if <code>has-icons-left</code> is used</li>
     <li><code>icon is-right</code> if <code>has-icons-right</code> is used</li>
   </ul>
-  <p>The size of the <strong>input</strong> will define the size of the icon container.</p>
+  <p>Make sure the input is the control's first child, otherwise the icon may disappear when selected. The size of the
+    <strong>input</strong> will define the size of the icon container.</p>
 </div>
 
 {% include docs/elements/snippet.html content=icons_example clipped=true %}


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **documentation fix**.  Given the following html
```
    <div class="field has-addons">
        <div class="control has-icons-left">
            <span class="icon is-small is-left">
                <i class="fa fa-filter" aria-hidden="true"></i> 
            </span>
            <input class="input" type="text" placeholder="Find a repository">
        </div>
        <div class="control">
            <button class="button is-info">
            Search
          </button>
        </div>
      </div>
```
if the input is not the control's first child the icon disappears when the input is selected.

### Changelog updated?

No.


