### PR TITLE
Improve colour loading versions of outlined buttons

### DIFF
--- a/sass/elements/button.scss
+++ b/sass/elements/button.scss
@@ -383,6 +383,12 @@ $no-palette: ("white", "black", "light", "dark");
     @include cv.register-vars(
       (
         "button-border-width": max(1px, 0.0625em),
+        "loading-color":
+        hsl(
+          #{cv.getVar("button-h")},
+          #{cv.getVar("button-s")},
+          #{cv.getVar("button-l")}
+        ),
       )
     );
 


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a ** improvement | bugfix **.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

Right now the loading version of outlined buttons is broken for `is-link`, the other versions have been downgraded from from 0.x (in my opinion)

![afbeelding](https://github.com/user-attachments/assets/0c6e01ff-2803-46c7-a638-a8ffb1e1814e)

### Proposed solution

Overwrite the `loading-color` variable on buttons with the `is-outlined` modifier

![afbeelding](https://github.com/user-attachments/assets/0caa7c13-b16f-4ec6-8642-83c8bc8e0c95)

<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

### Tradeoffs

<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->

I'm new to the whole variable thing, but I hope overwriting a variable in a subclass is the way to go

### Testing Done

I tested all variants by making temporary changes to the documentation files, with and without `[disabled]`

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `main` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/main/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/main/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

### Changelog updated?

No.

<!-- Thanks! -->
