### PR TITLE
Fix inconsistent z-index of dropdown

### DIFF
--- a/css/bulma.css
+++ b/css/bulma.css
@@ -6669,7 +6669,7 @@ button.tag:active,
   --bulma-dropdown-content-padding-top: 0.5rem;
   --bulma-dropdown-content-radius: var(--bulma-radius);
   --bulma-dropdown-content-shadow: var(--bulma-shadow);
-  --bulma-dropdown-content-z: 20;
+  --bulma-dropdown-content-z: 35;
   --bulma-dropdown-item-h: var(--bulma-scheme-h);
   --bulma-dropdown-item-s: var(--bulma-scheme-s);
   --bulma-dropdown-item-l: var(--bulma-scheme-main-l);


### PR DESCRIPTION
The menu of an open dropdown (z-index currently 20) must be rendered below a navbar (z-index 30) but should be rendered above. Both must be rendered below a modal (z-index 4).

Using a z-index of 35 for a drowdown menu fixes the issue.

<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **bugfix**.

Currently a open dropdown menu is rendered above navbar items:

![grafik](https://github.com/user-attachments/assets/940e6684-7c22-4368-8382-cf5e7b6b9165)


### Proposed solution

<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

### Tradeoffs

None known.

### Testing Done

None.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `main` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/main/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/main/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

### Changelog updated?

No.

<!-- Thanks! -->
