### PR TITLE
Fix docs: update text weight helper count and clean up CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - #3937: Add .has-text-weight-extrabold as a typography class.
 - #3906 fixes #3895: Make variables root configurable
-- 
+
 ### Bug Fixes
 
 - #3963: Improve colour loading versions of outlined buttons
@@ -14,7 +14,7 @@
 
 ### Documentation Fixes
 
-- #3916 Fixed .skeleton-toggler issues 
+- #3916 Fixed .skeleton-toggler issues
 
 ## 1.0.3
 

--- a/docs/documentation/helpers/typography-helpers.html
+++ b/docs/documentation/helpers/typography-helpers.html
@@ -290,7 +290,7 @@ breadcrumb:
 <div class="content">
   <p>
     You can transform the text weight with the use of one of
-    <strong>5 text weight helpers</strong>:
+    <strong>6 text weight helpers</strong>:
   </p>
 </div>
 


### PR DESCRIPTION
### What this PR does

- Updates the text helper count from 5 to 6 in the documentation to include `has-text-weight-extrabold`
- Removes an empty bullet point in `CHANGELOG.md`
- Removes an unnecessary trailing space in `CHANGELOG.md`


Let me know if any of these changes need to be split into separate PRs.
