### PR TITLE
Fixes #3994 : focus on search input when clicking on js-search element

### DIFF
--- a/docs/assets/javascript/main.js
+++ b/docs/assets/javascript/main.js
@@ -458,4 +458,13 @@ document.addEventListener("DOMContentLoaded", () => {
     event.preventDefault();
     closeMasterclass();
   });
+
+  document.querySelectorAll('[data-target="js-search"]').forEach((el) => {
+    el.addEventListener("click", () => {
+      const searchInput = document.querySelector("#js-search input");
+      if (searchInput) {
+        searchInput.focus();
+      }
+    });
+  });
 });


### PR DESCRIPTION
This is a **documentation fix**.

### Proposed solution

Focusing on search input when it is displayed would enable to type directly one's search terms.

### Tradeoffs

It adds a specific bit of js into `main.js`, which might be improved or better located ?