### PR TITLE
Migrate Deprecated Sass Unquote to `String.unquote` for Dart Compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Bulma Changelog
 
+# 1.0.5
+
+### Bug Fixes
+
+- Fix #4006: (fixes #4009) Use String.unquote for Dart compatibility
+
 ## 1.0.4
 
 ### New Features

--- a/sass/utilities/css-variables.scss
+++ b/sass/utilities/css-variables.scss
@@ -31,7 +31,7 @@
 
 @function getRgbaVar($name, $alpha, $prefix: "", $suffix: "") {
   $varName: buildVarName($name, $prefix, $suffix);
-  @return unquote("rgba(var(#{$varName}), #{$alpha})");
+  @return string.unquote("rgba(var(#{$varName}), #{$alpha})");
 }
 
 @mixin register-var($name, $value, $prefix: "", $suffix: "") {


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
@jgthms this is a **bugfix**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution

Replaces the deprecated global built-in `unquote()` function with `string.unquote()` to align with Dart Sass 3.0 requirements. This change affects the `getRgbaVar()` function in `utilities/css-variables.scss`, which supports Bulma’s CSS variable parsing.

### Tradeoffs

- Minimal impact to CSS output, but this assumes use of a modern Dart Sass environment.
- Older Sass versions may not support namespaced functions, so contributors on legacy tooling should be aware.
- Avoids future build warnings while preserving clarity for maintainers.

### Testing Done

None.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `main` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/main/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/main/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
Function usage has been validated in Dart Sass and complies with modern syntax guidelines.

### Changelog updated?

Yes!


Related: https://github.com/buefy/buefy/issues/4093
<!-- Thanks! -->
