### PR TITLE
Fix select icon brightening on label hover

### DIFF
--- a/sass/form/tools.scss
+++ b/sass/form/tools.scss
@@ -270,7 +270,8 @@ $field-block-spacing: 0.75rem !default;
   &.#{iv.$class-prefix}has-icons-right {
     .#{iv.$class-prefix}input,
     .#{iv.$class-prefix}select {
-      &:hover {
+      &:hover,
+      &:has(select:hover) {
         & ~ .#{iv.$class-prefix}icon {
           color: cv.getVar("input-icon-hover-color");
         }


### PR DESCRIPTION
This is an **improvement**, maybe a **bug fix**.

Given the code below, when hovering over the corresponding label, the icon next to the select does not change to a brighter color. It works for input combinations, but not select.

```html
<div class="field">
	<label class="label" for="searchFilter">Filter</label>
	<div class="control has-icons-left">
  		<div class="select is-fullwidth">
    		<select id="searchFilter" name="searchFilter">
      			<option value="">(All)</option>
				<option value="1">Filter 1</option>
				<option value="2">Filter 2</option>
			</select>
		</div>
		<span class="icon is-small is-left">
			<i class="fa-solid fa-search"></i>
		</span>
	</div>
</div>
```

### Proposed solution

Add `&:has(select:hover)` to icon color code.

```sass
&:hover,
&:has(select:hover) {
  & ~ .#{iv.$class-prefix}icon {
    color: cv.getVar("input-icon-hover-color");
  }
}
```

Resulting in the following fix:

```css
.control.has-icons-left .select:has(select:hover) ~ .icon,
.control.has-icons-right .select:has(select:hover) ~ .icon {
  color: var(--bulma-input-icon-hover-color)
}
```

### Tradeoffs

The solution does create some junk, since the `input` and `select` classes are grouped together.

```css
// Bad selectors
.control.has-icons-left .input:has(select:hover) ~ .icon,
.control.has-icons-right .input:has(select:hover) ~ .icon {
  color: var(--bulma-input-icon-hover-color)
}
```

### Testing Done

[Added the fix (as CSS)](https://github.com/cityssm/sunrise-cms/commit/904f7c6ccf417bba9ef5a4119613513fd9a58f6c) to an app I'm currently working on. Looks good.

### Changelog updated?

No.
