### PR TITLE
docs: Add Alex Smith to backers list

### DIFF
--- a/BACKERS.md
+++ b/BACKERS.md
@@ -5,6 +5,7 @@
 
 ## Generous backers ($10+)
 
+* Alex Smith
 * Jason Seminara
 * Jordan Nemrow
 * Ian Ebden


### PR DESCRIPTION
This is a **documentation improvement**.

### Proposed solution

This PR adds Alex Smith to the BACKERS.md file as a Generous backer ($10+ tier). Alex is currently contributing $10/month through GitHub Sponsors and is a huge fan of Jeremy's work on Bulma.

Alex is also the author of the new bestax-bulma React package (https://bestax.io), which provides a complete TypeScript implementation of Bulma components for React.

Additionally, I wanted to ask: How can sponsors get added to the backers.json file that displays on https://bulma.io/backers/? It would be great to understand the process for keeping the website's backers page in sync with GitHub Sponsors.

### Tradeoffs

No drawbacks - this is simply updating the backers documentation to reflect current GitHub Sponsors.

### Testing Done

Verified the markdown formatting is correct and consistent with existing entries in BACKERS.md.

### Changelog updated?

No. Documentation-only change.

Keep up the great work @jgthms!