### PR TITLE
Fix navbar-item hover styles for button elements

### DIFF
--- a/sass/components/navbar.scss
+++ b/sass/components/navbar.scss
@@ -293,8 +293,8 @@ body {
     }
   }
 }
-
 a.#{iv.$class-prefix}navbar-item,
+button.#{iv.$class-prefix}navbar-item,
 .#{iv.$class-prefix}navbar-link {
   background-color: hsla(
     #{cv.getVar("navbar-h")},


### PR DESCRIPTION
This is a **bugfix**.

### Proposed solution

Fixed hover, focus, and active background styles for `<button class="navbar-item">`.  
The issue was that the existing selector targeted only:
### Issue
Closes #3936

- `a.navbar-item`
- `.navbar-link`

…so buttons were missing the hover/focus/active behavior.  

The fix is **simple and safe**: add `button.navbar-item` to the selector.

```scss
a.#{iv.$class-prefix}navbar-item,
button.#{iv.$class-prefix}navbar-item,
.#{iv.$class-prefix}navbar-link {
  ...
}




