### PR TITLE
chore: Update outdated GitHub Actions version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
- This is a **new feature**.
- Proposed solution: Updates `actions/checkout` from `v4` to `v6` in `.github/workflows/main.yml`.
- Tradeoffs: A major version update may require adjustments in workflows, but the benefits include newer features and improvements.
- Testing Done: None.
- Changelog updated?: No.