### PR TITLE
Support install via Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,28 @@
+{
+  "name": "jgthms/bulma",
+  "description": "Modern CSS framework based on Flexbox",
+  "keywords": [
+    "css",
+    "sass",
+    "scss",
+    "flexbox",
+    "responsive",
+    "grid",
+    "framework"
+  ],
+  "homepage": "https://bulma.io",
+  "authors": [
+    {
+      "name": "Jeremy Thomas",
+      "email": "bbxdesign@gmail.com",
+      "homepage": "https://jgthms.com"
+    }
+  ],
+  "support": {
+    "issues": "https://github.com/jgthms/bulma/issues"
+  },
+  "license": "MIT",
+  "archive": {
+    "exclude": ["/docs", "/test"]
+  }
+}


### PR DESCRIPTION
Add support to install Bulma via [Composer](https://getcomposer.org).

This is an  **improvement**.

Some PHP frameworks, such as [Symfony](https://symfony.com) have their own way to compile sass files, via Dart Sass, i.e. [Symfony sass-bundle](https://symfony.com/bundles/SassBundle/current/index.html).
Since those packages don't rely on npm, it could be great if Bulma is installable via Composer.

### Proposed solution

Actually, it's a very easy task:

-  Add `composer.json` file to the Bulma repository root (this PR subject).
-  Register Bulma repository on [Packagist](https://packagist.org/).
### Tradeoffs

None.

### Testing Done

No need.

### Changelog updated?

No.
