### PR TITLE
fix(menu): use text-align: start so items follow RTL

### DIFF
--- a/sass/components/menu.scss
+++ b/sass/components/menu.scss
@@ -100,7 +100,7 @@ $menu-label-spacing: 1em !default;
     );
     display: block;
     padding: cv.getVar("menu-list-link-padding");
-    text-align: left;
+    text-align: start;
     width: 100%;
 
     &:hover {


### PR DESCRIPTION
Fixes #4029.

The menu is already mostly migrated to logical properties — the nested list uses `border-inline-start` / `padding-inline-start`. The one physical holdout is item alignment in `sass/components/menu.scss`:

```scss
.menu-list .menu-item,
a,
button { text-align: left; }
```

This forces left alignment regardless of writing direction. Switching to `text-align: start`:

- resolves to `left` in LTR, so it's **identical** there (non-breaking);
- resolves to `right` under `dir="rtl"`, so items align with the writing direction automatically — matching the rest of the component.

Verified on a `.menu` in both directions: items hug the left in LTR and the right in RTL, with nothing else changed.

---

While here, I noticed `.field-label` (`sass/form/tools.scss`) and table `th` (`sass/elements/table.scss`) have the same physical `text-align` — happy to fix those too if you'd like, here or in a follow-up.
