### PR TITLE
fix: restore default is-outlined button visibility

### DIFF
--- a/sass/elements/button.scss
+++ b/sass/elements/button.scss
@@ -8,7 +8,7 @@
 
 $button-h: #{cv.getVar("scheme-h")};
 $button-s: #{cv.getVar("scheme-s")};
-$button-l: #{cv.getVar("scheme-main-l")};
+$button-l: #{cv.getVar("text-strong-l")};
 $button-background-l: #{cv.getVar("scheme-main-l")};
 $button-background-l-delta: 0%;
 $button-hover-background-l-delta: #{cv.getVar("hover-background-l-delta")};


### PR DESCRIPTION
Fixes #3996

### Problem
Button with class `is-outlined` but without color modifier (like `is-primary`) renders invisible — white text on transparent background. Regression from v0.9.4.

### Root Cause
`$button-l` defaults to `scheme-main-l` (100% = white in light theme). The default filled button does NOT use `button-l` — it uses `button-background-l` for bg, `button-color-l` for text, `button-border-l` for border. But `is-outlined` incorrectly uses `button-l` for BOTH text and border.

### Fix
Change `$button-l` default from `scheme-main-l` to `text-strong-l` (1 character in variable name). Safe because:
- Default filled button doesn't use `button-l`
- Color modifiers override ALL variables
- Loading spinner color also becomes visible