### PR TITLE
fix: hide child elements inside .skeleton-block

### DIFF
--- a/sass/base/skeleton.scss
+++ b/sass/base/skeleton.scss
@@ -93,6 +93,13 @@ textarea.#{iv.$class-prefix}is-skeleton {
   @extend %skeleton-pulsation;
   color: transparent !important;
   min-height: cv.getVar("skeleton-block-min-height");
+
+  // Ensure child elements (links, buttons, etc.) also become invisible.
+  // `color: transparent` on the parent does not cascade to elements
+  // with their own color (e.g. <a> defaults to -webkit-link).
+  * {
+    color: inherit !important;
+  }
 }
 
 .#{iv.$class-prefix}skeleton-lines {


### PR DESCRIPTION
Fixes #3977

### Problem
Links and other elements with their own text color remain visible inside `.skeleton-block`. The parent's `color: transparent !important` does not cascade to children that have explicit color (e.g. `<a>` elements with browser default `-webkit-link`).

### Fix
Add `* { color: inherit !important; }` inside `.skeleton-block` to force all child elements to inherit the transparent color from the parent.