### PR TITLE
docs: fix until-fullhd mixin name in responsive mixins example

### DIFF
--- a/docs/documentation/sass/responsive-mixins.html
+++ b/docs/documentation/sass/responsive-mixins.html
@@ -248,7 +248,7 @@ $breakpoint: 1280px;
 {% capture inc-until-fullhd %}
 @use "bulma/sass/utilities/mixins";
 
-@include mixins.until {
+@include mixins.until-fullhd {
   // Styles applied
   // below $fullhd
 }


### PR DESCRIPTION
This is a **documentation fix**.

### Proposed solution

In the named mixin shortcuts table on the responsive mixins docs page, the `until-fullhd` example used `@include mixins.until` instead of `@include mixins.until-fullhd`. That matches the real mixin in `sass/utilities/mixins.scss`.

Fixes #3554.

### Tradeoffs

None. Docs-only change.

### Testing Done

Checked the example against `@mixin until-fullhd` in `sass/utilities/mixins.scss` and confirmed the other named mixin examples already use the correct names.

### Changelog updated?

No.